### PR TITLE
Bc/fix certain broken shadow doms

### DIFF
--- a/ci_pyproject.toml
+++ b/ci_pyproject.toml
@@ -1,7 +1,7 @@
 [tool.pytest.ini_options]
 generate_report_on_test = true
 log_cli = true
-log_cli_level = "info"
+log_cli_level = "warn"
 markers = [
     "pynput: test uses pynput package",
     "incident: incident smoke tests"

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 
 from pypom import Page
@@ -7,7 +8,6 @@ from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
 
 from modules.util import PomUtils
-import logging
 
 # Convert "strategy" from the components json to Selenium By vals
 STRATEGY_MAP = {

--- a/modules/page_object_about_prefs.py
+++ b/modules/page_object_about_prefs.py
@@ -1,8 +1,8 @@
 from pypom import Region
-from selenium.webdriver.common.by import By
 from selenium.webdriver import Firefox
-from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
 
 from modules.page_base import BasePage
 from modules.util import PomUtils

--- a/modules/page_object_about_prefs.py
+++ b/modules/page_object_about_prefs.py
@@ -1,6 +1,8 @@
 from pypom import Region
 from selenium.webdriver.common.by import By
+from selenium.webdriver import Firefox
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.keys import Keys
 
 from modules.page_base import BasePage
 from modules.util import PomUtils

--- a/modules/page_object_about_prefs.py
+++ b/modules/page_object_about_prefs.py
@@ -1,7 +1,5 @@
 from pypom import Region
-from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 
 from modules.page_base import BasePage

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Iterable
-from typing import Union
 from random import shuffle
+from typing import Union
 
 from selenium.common.exceptions import (
     InvalidArgumentException,
@@ -10,8 +10,8 @@ from selenium.common.exceptions import (
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.remote.shadowroot import ShadowRoot
+from selenium.webdriver.remote.webelement import WebElement
 
 
 class Utilities:
@@ -127,7 +127,9 @@ class PomUtils:
     def __init__(self, driver: Firefox):
         self.driver = driver
 
-    def get_shadow_content(self, element: WebElement) -> list[Union[WebElement, ShadowRoot]]:
+    def get_shadow_content(
+        self, element: WebElement
+    ) -> list[Union[WebElement, ShadowRoot]]:
         """
         Given a WebElement, return the shadow DOM root or roots attached to it. Returns a list.
         """
@@ -156,7 +158,9 @@ class PomUtils:
             return shadow_from_script()
         return []
 
-    def css_selector_matches_element(self, element: Union[WebElement, ShadowRoot], selector: list) -> bool:
+    def css_selector_matches_element(
+        self, element: Union[WebElement, ShadowRoot], selector: list
+    ) -> bool:
         if type(element) == ShadowRoot:
             return False
         sel = f'"{selector[1]}"'

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 from random import shuffle
+import logging
 
 from selenium.common.exceptions import (
     InvalidArgumentException,
@@ -128,30 +129,61 @@ class PomUtils:
         """
         Given a WebElement, return the shadow DOM root or roots attached to it. Returns a list.
         """
-        try:
-            shadow_root = element.shadow_root
-            return [shadow_root]
-        except InvalidArgumentException:
+        logging.info(f"Getting shadow nodes from root {element}")
+        def shadow_from_script():
             shadow_children = self.driver.execute_script(
                 "return arguments[0].shadowRoot.children", element
             )
             if len(shadow_children) and any(shadow_children):
-                return [s for s in shadow_children if s is not None]
+                logging.info("Returning script-returned shadow elements")
+                shadow_elements = [s for s in shadow_children if s is not None]
+                logging.info(shadow_elements)
+                return shadow_elements
+
+        try:
+            logging.info("Getting shadow content...")
+            shadow_root = element.shadow_root
+            shadow_content = [shadow_root]
+            if not shadow_content:
+                logging.info("Selenium shadow nav returned no elements in Shadow DOM")
+                return shadow_from_script()
+            return shadow_content
+        except InvalidArgumentException:
+            logging.info("Selenium shadow nav failed.")
+            return shadow_from_script()
         return []
 
+    def css_selector_matches_element(self, element: WebElement, selector: list) -> bool:
+        sel = f'"{selector[1]}"'
+        return self.driver.execute_script(f"return arguments[0].matches({sel})", element)
+
     def find_shadow_element(
-        self, shadow_parent: WebElement, selector: tuple
+        self, shadow_parent: WebElement, selector: list
     ) -> WebElement:
         """
         Given a WebElement with a shadow root attached, find a selector in the
         shadow DOM of that root.
         """
+        original_timeout = self.driver.timeouts.implicit_wait
         matches = []
+        logging.info(f"Requesting shadow nodes from root {shadow_parent}")
         shadow_nodes = self.get_shadow_content(shadow_parent)
+        logging.info("Found shadow nodes")
+        logging.info(shadow_nodes)
+        logging.info(f"looking for {selector}")
+        self.driver.implicitly_wait(0)
         for node in shadow_nodes:
+            logging.info(node)
+            logging.info(node.get_attribute("outerHTML"))
+            if self.css_selector_matches_element(node, selector):
+                # If we collect shadow children via JS, and one matches the selector, we're good.
+                self.driver.implicitly_wait(original_timeout)
+                return node
             elements = node.find_elements(*selector)
             if elements:
+                logging.info("Found a match")
                 matches.extend(elements)
+        self.driver.implicitly_wait(original_timeout)
         if len(matches) == 1:
             return matches[0]
         elif len(matches):

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,6 +1,6 @@
+import logging
 from collections.abc import Iterable
 from random import shuffle
-import logging
 
 from selenium.common.exceptions import (
     InvalidArgumentException,
@@ -130,6 +130,7 @@ class PomUtils:
         Given a WebElement, return the shadow DOM root or roots attached to it. Returns a list.
         """
         logging.info(f"Getting shadow nodes from root {element}")
+
         def shadow_from_script():
             shadow_children = self.driver.execute_script(
                 "return arguments[0].shadowRoot.children", element
@@ -155,7 +156,9 @@ class PomUtils:
 
     def css_selector_matches_element(self, element: WebElement, selector: list) -> bool:
         sel = f'"{selector[1]}"'
-        return self.driver.execute_script(f"return arguments[0].matches({sel})", element)
+        return self.driver.execute_script(
+            f"return arguments[0].matches({sel})", element
+        )
 
     def find_shadow_element(
         self, shadow_parent: WebElement, selector: list

--- a/modules/util.py
+++ b/modules/util.py
@@ -161,7 +161,7 @@ class PomUtils:
     def css_selector_matches_element(
         self, element: Union[WebElement, ShadowRoot], selector: list
     ) -> bool:
-        if type(element) == ShadowRoot:
+        if element is ShadowRoot:
             return False
         sel = f'"{selector[1]}"'
         return self.driver.execute_script(

--- a/modules/util.py
+++ b/modules/util.py
@@ -161,7 +161,7 @@ class PomUtils:
     def css_selector_matches_element(
         self, element: Union[WebElement, ShadowRoot], selector: list
     ) -> bool:
-        if element is ShadowRoot:
+        if type(element) == ShadowRoot:
             return False
         sel = f'"{selector[1]}"'
         return self.driver.execute_script(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 generate_report_on_test = false
 addopts = "-vs --html=report.html"
 log_cli = true
-log_cli_level = "info"
+log_cli_level = "warn"
 markers = [
     "pynput: test uses pynput package",
     "incident: incident smoke tests"


### PR DESCRIPTION
We locate elements of a Shadow DOM by attempting to use the Selenium `shadow_root` attribute. If that doesn't work, we use JS to get `.shadowRoot.children`. When we do the latter, and the element being searched is a direct child of the shadow root, selection failed because `WebElement.find_elements` only looks for the children of an element; it won't match the WebElement on which it is executed. We get around that with some more JS. This required additional typing for clarity.

Logging is added.