### PR TITLE
Bc/disable flaky

### DIFF
--- a/ci_pyproject.toml
+++ b/ci_pyproject.toml
@@ -5,12 +5,13 @@ log_cli_level = "warn"
 markers = [
     "audio: test is reliant on audio",
     "pynput: test uses pynput package",
-    "incident: incident smoke tests"
+    "incident: incident smoke tests",
+    "unstable: temporary mark for unstable tests"
 ]
 testpaths = [
     "tests"
 ]
-addopts = "-vs -m 'not incident' --ci --html=/builds/worker/artifacts/report.html"
+addopts = "-vs -m 'not incident' -m 'not unstable' --ci --html=/builds/worker/artifacts/report.html"
 
 [tool.ruff]
 target-version = "py310"

--- a/tests/credential/test_about_logins_search.py
+++ b/tests/credential/test_about_logins_search.py
@@ -1,3 +1,4 @@
+import pytest
 from typing import List, Tuple
 
 from selenium.webdriver import Firefox
@@ -5,7 +6,7 @@ from selenium.webdriver import Firefox
 from modules.page_object import AboutLogins
 from modules.util import BrowserActions
 
-
+@pytest.mark.unstable
 def test_about_logins_search_functionality(
     driver_and_saved_usernames: Tuple[Firefox, List[str]],
 ):

--- a/tests/credential/test_about_logins_search.py
+++ b/tests/credential/test_about_logins_search.py
@@ -1,10 +1,11 @@
-import pytest
 from typing import List, Tuple
 
+import pytest
 from selenium.webdriver import Firefox
 
 from modules.page_object import AboutLogins
 from modules.util import BrowserActions
+
 
 @pytest.mark.unstable
 def test_about_logins_search_functionality(


### PR DESCRIPTION
# Description

Attempts to deflake the credentials test have been not so great. Let's disable it and mark deflaking it as tech debt. It will still run in local, just not in CI.

## Type of change

Please delete options that are not relevant.

- [ ] New Test
- [ ] New POM
- [x] Disable Test

# How does this resolve / make progress on that bug?

We use a new mark: `pytest.mark.unstable` to skip it in CI.

# Comments / Concerns

If this doesn't stop the conftest from running, then we'll still have error-based failures. I intend to rerun CI for all failing tests after merge.
