### PR TITLE
As/pycharm configuration and json indentation settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,22 @@ Launch the build manually one time to navigate through any system permission dia
   - rerun failed tests: `pytest -lf` 
   - rerun the test suite as above - run: `pytest`
   - or just the failed test; i.e.: `pytest test_amazon.py`
+
+- ### IDE Pycharm Configuration
+- #### Configuration to run tests from the IDE interactive interface
+- Open Run/Debug Configurations**:
+    - Click on the **Current File** in the toolbar and select **Edit Configurations**, or
+    - Click on the **More actions** button (three dots) and select **Edit** from the configuration section
+- Open Edit Configuration Templates**:
+    - In the **Templates** section, select **Python tests** and then **pytest**
+    - Set the **Working directory** to the path of your current project root directory
+    - Ensure you have the correct Python interpreter selected
+    - Leave all other settings as default
+    - Click Apply
+
+- #### Tabs and Indents config
+- json:
+    - Tab size: 4
+    - Indent: 4
+    - Continuation indent: 8
+    - Keep indents on empty lines unchecked


### PR DESCRIPTION
# Description
Added PyCharm configuration for running tests and JSON indentation settings

The merge  from #21 was intended to address issues with Windows paths, but it ended up breaking my setup (I am on Windows). The steps added here for Pycharm configuration seams to work with the initial code, for both me and Virgil. 

The Json settings are something I've run into when trying to reformat an entry, the changes were applied to the entire file.  Setting those default values solved the formatting issue. 

## Bugzilla bug ID

**ID:** 
**Link:**

## Type of change

Please delete options that are not relevant.

- [ x] Other Changes (Readme)

# How does this resolve / make progress on that bug?

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns