### PR TITLE
Bc/add keyring unlock

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 from typing import List, Tuple
+from subprocess import (check_call, CalledProcessError)
 
 import pytest
 from selenium import webdriver
@@ -183,6 +184,18 @@ def driver(
     finally:
         driver.quit()
 
+@pytest.fixture()
+def unlock_keyring(sys_platform: str):
+    # TODO: add linux and windows unlocks if relevant
+    # TODO: add secrets mgmt and insertion
+    if sys_platform != "Darwin":
+        return None
+    try:
+        check_call(["security", "unlock-keychain"])
+    except CalledProcessError:
+        logging.warning("Failed to unlock keyring: security has errors.")
+    except OSError:
+        logging.warning("Failed to unlock keyring: security executable not found.")
 
 @pytest.fixture()
 def screenshot(driver: webdriver.Firefox, opt_ci: bool):

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,8 @@
 import logging
 import os
 import platform
+from subprocess import CalledProcessError, check_call
 from typing import List, Tuple
-from subprocess import (check_call, CalledProcessError)
 
 import pytest
 from selenium import webdriver
@@ -184,6 +184,7 @@ def driver(
     finally:
         driver.quit()
 
+
 @pytest.fixture()
 def unlock_keyring(sys_platform: str):
     # TODO: add linux and windows unlocks if relevant
@@ -196,6 +197,7 @@ def unlock_keyring(sys_platform: str):
         logging.warning("Failed to unlock keyring: security has errors.")
     except OSError:
         logging.warning("Failed to unlock keyring: security executable not found.")
+
 
 @pytest.fixture()
 def screenshot(driver: webdriver.Firefox, opt_ci: bool):

--- a/tests/form_autofill/conftest.py
+++ b/tests/form_autofill/conftest.py
@@ -9,4 +9,7 @@ def suite_id():
 @pytest.fixture()
 def set_prefs():
     """Set prefs"""
-    return []
+    return [
+        ("extensions.formautofill.creditCards.reauth.optout", False),
+        ("extensions.formautofill.reauth.enabled", False)
+    ]

--- a/tests/form_autofill/conftest.py
+++ b/tests/form_autofill/conftest.py
@@ -11,5 +11,5 @@ def set_prefs():
     """Set prefs"""
     return [
         ("extensions.formautofill.creditCards.reauth.optout", False),
-        ("extensions.formautofill.reauth.enabled", False)
+        ("extensions.formautofill.reauth.enabled", False),
     ]

--- a/tests/form_autofill/test_autofill_credit_card.py
+++ b/tests/form_autofill/test_autofill_credit_card.py
@@ -26,7 +26,7 @@ def test_autofill_credit_card(driver: Firefox):
 
 def test_enable_disable_form_autofill_cc(driver: Firefox):
     """
-    C122388, tests that after saving cc information and toggling the autofill credit 
+    C122388, tests that after saving cc information and toggling the autofill credit
     cards box the dropdown does not appear.
     """
     nav = Navigation(driver)


### PR DESCRIPTION
# Description

Adds a fixture called `unlock_keyring` which can be requested in tests that need an unlocked keyring. If a keyring password exists on the OS under test, the user will be prompted in the command line. This should not cause a problem for CI, as we will not set a keyring password there.

Usage is just to add `unlock_keyring` to the signature of any test function that needs it.

- [x] Quality of life / deflake

# Comments / Concerns

Created the possible future need for secrets management. Not implemented for Linux or Windows.
