### PR TITLE
Accounting for light and dark alpenglow theme

### DIFF
--- a/modules/page_object_about_addons.py
+++ b/modules/page_object_about_addons.py
@@ -17,7 +17,9 @@ class AboutAddons(BasePage):
         """
         self.get_element("sidebar-options", labels=[option]).click()
 
-    def activate_theme(self, nav: Navigation, theme_name: str, intended_color: str):
+    def activate_theme(
+        self, nav: Navigation, theme_name: str, intended_color: str, perform_assert=True
+    ):
         """
         Clicks the theme card and presses enable. Then verifies that the theme is the correct colour.
 
@@ -44,4 +46,7 @@ class AboutAddons(BasePage):
             background_colour = navigation_component.value_of_css_property(
                 "background-color"
             )
-            assert background_colour == intended_color
+            if perform_assert:
+                assert background_colour == intended_color
+            else:
+                return background_colour

--- a/modules/page_object_about_addons.py
+++ b/modules/page_object_about_addons.py
@@ -21,7 +21,7 @@ class AboutAddons(BasePage):
         self, nav: Navigation, theme_name: str, intended_color: str, perform_assert=True
     ):
         """
-        Clicks the theme card and presses enable. Then verifies that the theme is the correct colour.
+        Clicks the theme card and presses enable. Then verifies that the theme is the correct color.
 
         Attributes
         ----------
@@ -30,7 +30,7 @@ class AboutAddons(BasePage):
         theme_name: str
             The name of the theme to press
         intended_color: str
-            The RGB string that is the intended colour of the element
+            The RGB string that is the intended color of the element
         """
         self.get_element("theme-card", labels=[theme_name]).click()
         self.get_element("enable-theme").click()
@@ -43,10 +43,10 @@ class AboutAddons(BasePage):
 
         with self.driver.context(self.driver.CONTEXT_CHROME):
             navigation_component = nav.get_element("navigation-background-component")
-            background_colour = navigation_component.value_of_css_property(
+            background_color = navigation_component.value_of_css_property(
                 "background-color"
             )
             if perform_assert:
-                assert background_colour == intended_color
+                assert background_color == intended_color
             else:
-                return background_colour
+                return background_color

--- a/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
+++ b/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
@@ -8,7 +8,8 @@ themes = {
     "firefox-compact-dark_mozilla_org-heading": "rgb(43, 42, 51)",
     "firefox-compact-light_mozilla_org-heading": "rgb(249, 249, 251)",
 }
-# breaking: "firefox-alpenglow_mozilla_org-heading": "rgba(255, 255, 255, 0.76)",
+
+alpengow_map = {"light": "rgba(255, 255, 255, 0.76)", "dark": "rgba(40, 29, 78, 0.96)"}
 
 
 @pytest.mark.ci
@@ -33,3 +34,18 @@ def test_open_addons(driver: Firefox, theme_name: str):
     abt_addons = AboutAddons(driver).open()
     abt_addons.choose_sidebar_option("theme")
     abt_addons.activate_theme(nav, theme_name, themes[theme_name])
+
+
+def test_alpenglow_theme(driver: Firefox):
+    """
+    C118173, specifically for alpenglow theme because colour can be two values for dark or light mode
+    """
+
+    nav = Navigation(driver).open()
+    abt_addons = AboutAddons(driver).open()
+    abt_addons.choose_sidebar_option("theme")
+    current_bg = abt_addons.activate_theme(
+        nav, "firefox-alpenglow_mozilla_org-heading", "", perform_assert=False
+    )
+
+    assert current_bg == alpengow_map["light"] or current_bg == alpengow_map["dark"]

--- a/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
+++ b/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
@@ -9,7 +9,7 @@ themes = {
     "firefox-compact-light_mozilla_org-heading": "rgb(249, 249, 251)",
 }
 
-alpengow_map = {"light": "rgba(255, 255, 255, 0.76)", "dark": "rgba(40, 29, 78, 0.96)"}
+alpenglow_map = {"light": "rgba(255, 255, 255, 0.76)", "dark": "rgba(40, 29, 78, 0.96)"}
 
 
 @pytest.mark.ci
@@ -38,7 +38,7 @@ def test_open_addons(driver: Firefox, theme_name: str):
 
 def test_alpenglow_theme(driver: Firefox):
     """
-    C118173, specifically for alpenglow theme because colour can be two values for dark or light mode
+    C118173, specifically for alpenglow theme because color can be two values for dark or light mode
     """
 
     nav = Navigation(driver).open()
@@ -48,4 +48,4 @@ def test_alpenglow_theme(driver: Firefox):
         nav, "firefox-alpenglow_mozilla_org-heading", "", perform_assert=False
     )
 
-    assert current_bg == alpengow_map["light"] or current_bg == alpengow_map["dark"]
+    assert current_bg == alpenglow_map["light"] or current_bg == alpenglow_map["dark"]


### PR DESCRIPTION
# Description

Fixing the alpenglow theme issue

## Type of change
- [x] Other Changes: Bug fix

# How does this resolve / make progress on that bug?

Minor bug fix 

# Screenshots / Explanations

N/A

# Comments / Concerns

`assert current_bg == alpengow_map["light"] or current_bg == alpengow_map["dark"]` is questionable in terms of correctness but I can't think of another way to verify unless we are able to get the system theme during runtime. im open to suggestions on this one 🤷‍♀️
