### PR TITLE
Add t-linux-wayland workers

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -25,3 +25,8 @@ workers:
       implementation: docker-worker
       os: linux
       worker-type: '{alias}-gcp'
+    t-linux-wayland:
+      provisioner: '{trust-domain}-t'
+      implementation: docker-worker
+      os: linux
+      worker-type: '{alias}'


### PR DESCRIPTION
These workers use a new image that runs Wayland, and should have a GUI available to run Firefox with.