### PR TITLE
Edit CC Profile from about:prefs

### DIFF
--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -86,7 +86,9 @@
     "cc-saved-options": {
         "selectorData": "option[data-l10n-id='credit-card-label-number-name-expiration-2']",
         "strategy": "css",
-        "groups": []
+        "groups": [
+            "doNotCache"
+        ]
     },
 
     "panel-popup-button": {

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -121,5 +121,11 @@
         "selectorData": "addresses",
         "strategy": "id",
         "groups": []
+    },
+
+    "panel-popup-stack": {
+        "selectorData": "dialogStack",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/modules/data/credit_card_popup.components.json
+++ b/modules/data/credit_card_popup.components.json
@@ -6,12 +6,6 @@
         "groups": []
     },
 
-    "autofill-profile-option": {
-        "selectorData": "autocomplete-richlistitem",
-        "strategy": "class",
-        "groups": []
-      },
-
     "autofill-panel": {
         "selectorData": "PopupAutoComplete",
         "strategy": "id",

--- a/modules/page_object_about_prefs.py
+++ b/modules/page_object_about_prefs.py
@@ -1,5 +1,4 @@
 import re
-from time import sleep
 from typing import List
 
 from pypom import Region

--- a/modules/page_object_about_prefs.py
+++ b/modules/page_object_about_prefs.py
@@ -1,4 +1,5 @@
 import re
+from time import sleep
 from typing import List
 
 from pypom import Region
@@ -20,6 +21,7 @@ class AboutPrefs(BasePage):
 
     # number of tabs to reach the country tab
     TABS_TO_COUNTRY = 6
+    TABS_TO_SAVE_CC = 5
 
     class Dropdown(Region):
         def __init__(self, page, **kwargs):
@@ -211,3 +213,23 @@ class AboutPrefs(BasePage):
         self.get_element("prefs-button", labels=["Saved payment methods"]).click()
         iframe = self.get_element("browser-popup")
         return iframe
+
+    def update_cc_field_panel(self, num_tabs: int, new_info: str) -> BasePage:
+        """
+        Updates a field in the credit card popup panel in about:prefs by pressing the number of tabs and sending the new information
+        ...
+
+        Attributes
+        ----------
+        autofill_info: AutofillAddressBase
+            The object containing all of the sample date
+        """
+        for _ in range(num_tabs):
+            self.actions.send_keys(Keys.TAB).perform()
+
+        self.actions.send_keys(new_info).perform()
+
+        for _ in range(self.TABS_TO_SAVE_CC - num_tabs):
+            self.actions.send_keys(Keys.TAB).perform()
+
+        self.actions.send_keys(Keys.ENTER).perform()

--- a/tests/form_autofill/test_clear_form.py
+++ b/tests/form_autofill/test_clear_form.py
@@ -1,5 +1,4 @@
 import pytest
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -1,11 +1,10 @@
 import json
 import logging
-from time import sleep
 
 import pytest
 from selenium.webdriver import Firefox
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 
 from modules.browser_object import Navigation
 from modules.browser_object_autofill_popup import AutofillPopup
@@ -14,6 +13,7 @@ from modules.page_object_autofill_credit_card import CreditCardFill
 from modules.util import BrowserActions, Utilities
 
 tabs = [i for i in range(4)]
+
 
 @pytest.mark.parametrize("num_tabs", tabs)
 def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
@@ -59,10 +59,7 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
     # ensure the same year or month is not generated
     credit_card_sample_data_new = util.fake_credit_card_data()
     while (
-        len(
-            credit_card_sample_data_new.card_number
-        )
-        < 14
+        len(credit_card_sample_data_new.card_number) < 14
         or credit_card_sample_data_new.card_number[-4:] in info_string
         or credit_card_sample_data_new.expiration_month in info_string
     ):
@@ -92,15 +89,15 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
     browser_action_obj.switch_to_content_context()
     dialog_stack = about_prefs_obj.get_element("panel-popup-stack")
     while True:
-        dialog_stack_elements = dialog_stack.find_elements(
-            By.ID, "dialogTemplate"
-        )
+        dialog_stack_elements = dialog_stack.find_elements(By.ID, "dialogTemplate")
         if len(dialog_stack_elements) < 3:
             break
     browser_action_obj.switch_to_iframe_context(iframe)
 
     logging.info(f"New data: {credit_card_sample_data_new.expiration_month}")
-    logging.info(f"Attribute data: {about_prefs_obj.get_element('cc-saved-options').get_attribute("data-l10n-args")}")
+    logging.info(
+        f"Attribute data: {about_prefs_obj.get_element('cc-saved-options').get_attribute("data-l10n-args")}"
+    )
 
     # fetch the edited profile, ensure that the attribute containing the data is new
     about_prefs_obj.expect_not(

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -60,31 +60,12 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
 
     # ensure the same year or month is not generated
     credit_card_sample_data_new = util.fake_credit_card_data()
-    while (
-        credit_card_sample_data_new.card_number[-4:] in info_string
-        or str(int(credit_card_sample_data_new.expiration_month)) in info_string
-        or credit_card_sample_data_new.expiration_year in info_string
-    ):
+    while len(credit_card_sample_data_new.card_number or credit_card_sample_data_new.card_number[-4:] in info_string) < 14:
         credit_card_sample_data_new = util.fake_credit_card_data()
-
-    # create the dict
-    tab_num_to_data = {
-        0: credit_card_sample_data_new.card_number,
-        1: credit_card_sample_data_new.expiration_month,
-        2: f"20{credit_card_sample_data_new.expiration_year}",
-        3: credit_card_sample_data_new.name,
-    }
-
-    tab_num_to_original_data = {
-        0: credit_card_sample_data_original.card_number[-4:],
-        1: f"{str(int(credit_card_sample_data_original.expiration_month))}",
-        2: f"20{credit_card_sample_data_original.expiration_year}",
-        3: credit_card_sample_data_original.name,
-    }
 
     # modify some values
     panel_edit_button.click()
-    about_prefs_obj.update_cc_field_panel(num_tabs, tab_num_to_data[num_tabs])
+    about_prefs_obj.update_cc_field_panel(0, credit_card_sample_data_new.card_number)
 
     logging.info(f"New data: {credit_card_sample_data_new.expiration_month}")
     # fetch the edited profile, ensure that the attribute containing the data is new
@@ -92,13 +73,10 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
         EC.text_to_be_present_in_element_attribute(
             about_prefs_obj.get_selector("cc-saved-options"),
             "data-l10n-args",
-            tab_num_to_original_data[num_tabs],
+            credit_card_sample_data_original.card_number[-4:],
         )
     )
-    try:
-        edited_profile = about_prefs_obj.get_element("cc-saved-options")
-    except TimeoutException:
-        util.write_html_content("cur", driver, False)
+    edited_profile = about_prefs_obj.get_element("cc-saved-options")
     cc_info_json = json.loads(edited_profile.get_attribute("data-l10n-args"))
     logging.info(f"Extracted Edited data: {cc_info_json}")
 
@@ -106,19 +84,6 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
     logging.info(f"Original Data: {credit_card_sample_data_original.card_number}")
     logging.info(f"New Data: {credit_card_sample_data_new.card_number}")
 
-    if num_tabs == 0:
-        credit_card_sample_data_original.card_number = (
-            credit_card_sample_data_new.card_number
-        )
-    elif num_tabs == 1:
-        credit_card_sample_data_original.expiration_month = (
-            credit_card_sample_data_new.expiration_month
-        )
-    elif num_tabs == 2:
-        credit_card_sample_data_original.expiration_year = (
-            credit_card_sample_data_new.expiration_year
-        )
-    else:
-        credit_card_sample_data_original.name = credit_card_sample_data_new.name
+    credit_card_sample_data_original.card_number = credit_card_sample_data_new.card_number
 
     about_prefs_obj.verify_cc_json(cc_info_json, credit_card_sample_data_original)

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -1,0 +1,124 @@
+import json
+import logging
+from time import sleep
+
+import pytest
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver import Firefox
+from selenium.webdriver.support import expected_conditions as EC
+
+from modules.browser_object import CreditCardPopup, Navigation
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object import AboutPrefs
+from modules.page_object_autofill_credit_card import CreditCardFill
+from modules.util import BrowserActions, Utilities
+
+# tabs = [i for i in range(4)]
+tabs = [1]
+
+
+@pytest.mark.parametrize("num_tabs", tabs)
+def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
+    """
+    C122390, ensures that editing a credit card profile in the about:prefs
+    has the correct behaviour
+    """
+    # instantiate objects
+    nav = Navigation(driver)
+    about_prefs_obj = AboutPrefs(driver, category="privacy")
+    util = Utilities()
+    browser_action_obj = BrowserActions(driver)
+    credit_card_fill_obj = CreditCardFill(driver).open()
+    autofill_popup_obj = AutofillPopup(driver)
+
+    # fill in cc information
+    nav.open()
+    credit_card_fill_obj.open()
+    credit_card_sample_data_original = util.fake_credit_card_data()
+    credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data_original)
+    autofill_popup_obj.press_doorhanger_save()
+
+    # navigate to about:prefs and select the saved payment methods
+    about_prefs_obj.open()
+    iframe = about_prefs_obj.press_button_get_popup_dialog_iframe(
+        "Saved payment methods"
+    )
+    browser_action_obj.switch_to_iframe_context(iframe)
+
+    # fetch the saved cc profile and select edit
+    saved_profile = about_prefs_obj.get_element("cc-saved-options")
+    info_string = saved_profile.get_attribute("data-l10n-args")
+    cc_info_json_original = json.loads(info_string)
+    logging.info(f"Extracted Original data: {cc_info_json_original}")
+    saved_profile.click()
+
+    # assert that the edit button is clickable
+    panel_edit_button = about_prefs_obj.get_element(
+        "panel-popup-button", labels=["autofill-manage-edit-button"]
+    )
+    about_prefs_obj.expect(EC.element_to_be_clickable(panel_edit_button))
+
+    # ensure the same year or month is not generated
+    credit_card_sample_data_new = util.fake_credit_card_data()
+    while (
+        credit_card_sample_data_new.card_number[-4:] in info_string
+        or str(int(credit_card_sample_data_new.expiration_month)) in info_string
+        or credit_card_sample_data_new.expiration_year in info_string
+    ):
+        credit_card_sample_data_new = util.fake_credit_card_data()
+
+    # create the dict
+    tab_num_to_data = {
+        0: credit_card_sample_data_new.card_number,
+        1: credit_card_sample_data_new.expiration_month,
+        2: f"20{credit_card_sample_data_new.expiration_year}",
+        3: credit_card_sample_data_new.name,
+    }
+
+    tab_num_to_original_data = {
+        0: credit_card_sample_data_original.card_number[-4:],
+        1: f"{str(int(credit_card_sample_data_original.expiration_month))}",
+        2: f"20{credit_card_sample_data_original.expiration_year}",
+        3: credit_card_sample_data_original.name,
+    }
+
+    # modify some values
+    panel_edit_button.click()
+    about_prefs_obj.update_cc_field_panel(num_tabs, tab_num_to_data[num_tabs])
+
+    logging.info(f"New data: {credit_card_sample_data_new.expiration_month}")
+    # fetch the edited profile, ensure that the attribute containing the data is new
+    about_prefs_obj.expect_not(
+        EC.text_to_be_present_in_element_attribute(
+            about_prefs_obj.get_selector("cc-saved-options"),
+            "data-l10n-args",
+            tab_num_to_original_data[num_tabs],
+        )
+    )
+    try:
+        edited_profile = about_prefs_obj.get_element("cc-saved-options")
+    except TimeoutException:
+        util.write_html_content("cur", driver, False)
+    cc_info_json = json.loads(edited_profile.get_attribute("data-l10n-args"))
+    logging.info(f"Extracted Edited data: {cc_info_json}")
+
+    # changing the cc number
+    logging.info(f"Original Data: {credit_card_sample_data_original.card_number}")
+    logging.info(f"New Data: {credit_card_sample_data_new.card_number}")
+
+    if num_tabs == 0:
+        credit_card_sample_data_original.card_number = (
+            credit_card_sample_data_new.card_number
+        )
+    elif num_tabs == 1:
+        credit_card_sample_data_original.expiration_month = (
+            credit_card_sample_data_new.expiration_month
+        )
+    elif num_tabs == 2:
+        credit_card_sample_data_original.expiration_year = (
+            credit_card_sample_data_new.expiration_year
+        )
+    else:
+        credit_card_sample_data_original.name = credit_card_sample_data_new.name
+
+    about_prefs_obj.verify_cc_json(cc_info_json, credit_card_sample_data_original)

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -16,6 +16,7 @@ tabs = [i for i in range(4)]
 
 
 @pytest.mark.parametrize("num_tabs", tabs)
+@pytest.mark.unstable
 def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
     """
     C122390, ensures that editing a credit card profile in the about:prefs
@@ -62,6 +63,7 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
         len(credit_card_sample_data_new.card_number) < 14
         or credit_card_sample_data_new.card_number[-4:] in info_string
         or credit_card_sample_data_new.expiration_month in info_string
+        or credit_card_sample_data_new.expiration_year in info_string
     ):
         credit_card_sample_data_new = util.fake_credit_card_data()
 

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -94,11 +94,6 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
             break
     browser_action_obj.switch_to_iframe_context(iframe)
 
-    logging.info(f"New data: {credit_card_sample_data_new}")
-    logging.info(
-        f"Attribute data: {about_prefs_obj.get_element('cc-saved-options').get_attribute("data-l10n-args")}"
-    )
-
     # fetch the edited profile, ensure that the attribute containing the data is new
     about_prefs_obj.expect_not(
         EC.text_to_be_present_in_element_attribute(

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -94,7 +94,7 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int):
             break
     browser_action_obj.switch_to_iframe_context(iframe)
 
-    logging.info(f"New data: {credit_card_sample_data_new.expiration_month}")
+    logging.info(f"New data: {credit_card_sample_data_new}")
     logging.info(
         f"Attribute data: {about_prefs_obj.get_element('cc-saved-options').get_attribute("data-l10n-args")}"
     )


### PR DESCRIPTION
# Description

This will save a profile and then modify it in about:prefs and check if the modification was successful. This will modify the card number, the exp date and the year. 

## Bugzilla bug ID

**ID:** 1895885
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1895885

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

Finishes it

# Screenshots / Explanations

https://tropical-roadrunner-d78.notion.site/Blockers-8111925c19dd44f8b0460bd6a10b2265?pvs=4 

relevant blockers related to this 

# Comments / Concerns

This test has a ~2% fail rate. This is due to the flaky nature of changing the date, specifically the month. After trying mulitple workarounds, there are still cases where it will just not retrieve the updated information. This is slightly concerning because in a dry run of ~50 iterations, the month attr fails around once. 

Ideally it would be nice to find the root of the issue but as of now, no luck : (

Related Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1901622
