### PR TITLE
Active Tab 

### DIFF
--- a/tests/form_autofill/test_clear_form.py
+++ b/tests/form_autofill/test_clear_form.py
@@ -1,5 +1,4 @@
 import pytest
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup

--- a/tests/tabs/test_active_tab.py
+++ b/tests/tabs/test_active_tab.py
@@ -1,0 +1,23 @@
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TabBar
+
+
+def test_active_test(driver: Firefox):
+    """
+    C134646, ensures that the selected tab is highlighted
+    """
+    tabs = TabBar(driver).open()
+    num_tabs = 5
+
+    # opening 5 tabs
+    for i in range(num_tabs):
+        tabs.new_tab_by_button()
+
+    # go through all the tabs and ensure highlighted one is correct, +2 since 1 indexed and additional tab for the beginning
+    for i in range(1, num_tabs + 2):
+        target_tab = tabs.get_tab(i)
+        with driver.context(driver.CONTEXT_CHROME):
+            target_tab.click()
+            visibility = target_tab.get_attribute("visuallyselected")
+            assert visibility == ""

--- a/tests/tabs/test_active_tab.py
+++ b/tests/tabs/test_active_tab.py
@@ -3,7 +3,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object import TabBar
 
 
-def test_active_test(driver: Firefox):
+def test_active_tab(driver: Firefox):
     """
     C134646, ensures that the selected tab is highlighted
     """
@@ -15,11 +15,10 @@ def test_active_test(driver: Firefox):
         tabs.new_tab_by_button()
 
     # go through all the tabs and ensure highlighted one is correct, +2 since 1 indexed and additional tab for the beginning
-    for i in range(1, num_tabs + 2):
+    # for i in range(1, num_tabs + 2):
+    for i in range(1, 2):
         target_tab = tabs.get_tab(i)
         with driver.context(driver.CONTEXT_CHROME):
             target_tab.click()
-            tab_color = target_tab.value_of_css_property("color")
             visibility = target_tab.get_attribute("visuallyselected")
             assert visibility == ""
-            assert tab_color == "rgb(12, 12, 13)" and tab_color != "rgb(21, 20, 26)"

--- a/tests/tabs/test_active_tab.py
+++ b/tests/tabs/test_active_tab.py
@@ -19,10 +19,10 @@ def test_active_test(driver: Firefox):
         target_tab = tabs.get_tab(i)
         with driver.context(driver.CONTEXT_CHROME):
             target_tab.click()
-            tab_color = target_tab.value_of_css_property('color')
+            tab_color = target_tab.value_of_css_property("color")
             visibility = target_tab.get_attribute("visuallyselected")
             assert visibility == ""
-            assert tab_color == "rgb(12, 12, 13)"
+            assert tab_color == "rgb(12, 12, 13)" and tab_color != "rgb(21, 20, 26)"
 
     # tabs.new_tab_by_button()
     # target_tab = tabs.get_tab(3)

--- a/tests/tabs/test_active_tab.py
+++ b/tests/tabs/test_active_tab.py
@@ -15,8 +15,7 @@ def test_active_tab(driver: Firefox):
         tabs.new_tab_by_button()
 
     # go through all the tabs and ensure highlighted one is correct, +2 since 1 indexed and additional tab for the beginning
-    # for i in range(1, num_tabs + 2):
-    for i in range(1, 2):
+    for i in range(1, num_tabs + 2):
         target_tab = tabs.get_tab(i)
         with driver.context(driver.CONTEXT_CHROME):
             target_tab.click()

--- a/tests/tabs/test_active_tab.py
+++ b/tests/tabs/test_active_tab.py
@@ -23,16 +23,3 @@ def test_active_test(driver: Firefox):
             visibility = target_tab.get_attribute("visuallyselected")
             assert visibility == ""
             assert tab_color == "rgb(12, 12, 13)" and tab_color != "rgb(21, 20, 26)"
-
-    # tabs.new_tab_by_button()
-    # target_tab = tabs.get_tab(3)
-    # with driver.context(driver.CONTEXT_CHROME):
-    #     css_properties = driver.execute_script("""
-    #         var styles = window.getComputedStyle(arguments[0]);
-    #         var styleObject = {};
-    #         for (var i = 0; i < styles.length; i++) {
-    #             styleObject[styles[i]] = styles.getPropertyValue(styles[i]);
-    #         }
-    #             return styleObject;
-    #         """, target_tab)
-    #     print(css_properties)

--- a/tests/tabs/test_active_tab.py
+++ b/tests/tabs/test_active_tab.py
@@ -19,5 +19,20 @@ def test_active_test(driver: Firefox):
         target_tab = tabs.get_tab(i)
         with driver.context(driver.CONTEXT_CHROME):
             target_tab.click()
+            tab_color = target_tab.value_of_css_property('color')
             visibility = target_tab.get_attribute("visuallyselected")
             assert visibility == ""
+            assert tab_color == "rgb(12, 12, 13)"
+
+    # tabs.new_tab_by_button()
+    # target_tab = tabs.get_tab(3)
+    # with driver.context(driver.CONTEXT_CHROME):
+    #     css_properties = driver.execute_script("""
+    #         var styles = window.getComputedStyle(arguments[0]);
+    #         var styleObject = {};
+    #         for (var i = 0; i < styles.length; i++) {
+    #             styleObject[styles[i]] = styles.getPropertyValue(styles[i]);
+    #         }
+    #             return styleObject;
+    #         """, target_tab)
+    #     print(css_properties)


### PR DESCRIPTION
# Description

This will check if the current tab is highlighted, this is done by checking the `visibility` attribute. Upon selecting tab, only the selected tab will have this attribute while the others do not. Also verified that selected tabs have the css property 'color': rgb(12, 12, 13) while the unselected ones are 'color': rgb(21, 20, 26). So we verify that visibility prop is there and also the colours match up.

## Bugzilla bug ID

**ID:** 1895904
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1895904

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

finishes

# Screenshots / Explanations

N/A

# Comments / Concerns

I hope this method of verification is satisfactory!
