### PR TITLE
Write test to reopen tab through ctx menu

### DIFF
--- a/modules/data/tab_context_menu.components.json
+++ b/modules/data/tab_context_menu.components.json
@@ -10,5 +10,11 @@
         "selectorData": "context_unpinTab",
         "strategy": "id",
         "groups": []
+    },
+
+    "context-menu-reopen-tab": {
+        "selectorData": "context_undoCloseTab",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/tabs/test_pin_tab.py
+++ b/tests/tabs/test_pin_tab.py
@@ -4,6 +4,7 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import TabBar, TabContextMenu
 
+
 def test_pin_tab(driver: Firefox):
     """
     C134722, ensures that tabs can be pinned

--- a/tests/tabs/test_reopen_tab_through_context_menu.py
+++ b/tests/tabs/test_reopen_tab_through_context_menu.py
@@ -1,0 +1,36 @@
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TabBar, TabContextMenu
+
+
+def test_reopen_tab_through_context_menu(driver: Firefox):
+    """C134648: Reopen tab through context menu"""
+    tabs = TabBar(driver).open()
+    tab_context_menu = TabContextMenu(driver)
+
+    tabs_to_open = 4
+
+    driver.get("about:about")
+    for _ in range(1, tabs_to_open):
+        tabs.new_tab_by_button()
+    driver.switch_to.window(driver.window_handles[-1])
+    driver.get("about:robots")
+    remaining_tab = tabs.get_tab(1)
+    closing_tab = tabs.get_tab(tabs_to_open)
+
+    with driver.context(driver.CONTEXT_CHROME):
+        assert tabs.get_tab_title(closing_tab).startswith("Gort")
+
+    driver.close()
+    driver.switch_to.window(driver.window_handles[0])
+
+    with driver.context(driver.CONTEXT_CHROME):
+        tabs.actions.context_click(remaining_tab).perform()
+        reopen_item = tab_context_menu.get_context_item("context-menu-reopen-tab")
+        reopen_item.click()
+
+        # tab numbers are not reused, so the reopened tab is 1 higher
+        reopened_tab = tabs.get_tab(tabs_to_open + 1)
+        assert tabs.get_tab_title(reopened_tab).startswith("Gort")
+
+        tabs.hide_popup("tabContextMenu")


### PR DESCRIPTION
# Description
This adds a test that closes a tab, then reopens it through the tab context menu.

## Bugzilla bug ID

**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1895899

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

Completes test
