### PR TITLE
hy/form autofill cvv not displayed

### DIFF
--- a/tests/form_autofill/test_autofill_cc_cvv.py
+++ b/tests/form_autofill/test_autofill_cc_cvv.py
@@ -1,0 +1,51 @@
+import json
+import logging
+
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.browser_object_navigation import Navigation
+from modules.page_object_about_prefs import AboutPrefs
+from modules.page_object_autofill_credit_card import CreditCardFill
+from modules.util import Utilities, BrowserActions
+
+
+def test_autofill_cc_cvv(driver: Firefox):
+    """
+    C122399, Test form autofill CC CVV number
+    """
+    # instantiate objects
+    Navigation(driver).open()
+    credit_card_autofill = CreditCardFill(driver).open()
+    autofill_popup = AutofillPopup(driver)
+    util = Utilities()
+    about_prefs_obj = AboutPrefs(driver, category="privacy")
+    browser_action_obj = BrowserActions(driver)
+
+    # create fake data, fill it in and press submit and save on the doorhanger
+    credit_card_sample_data = util.fake_credit_card_data()
+    credit_card_autofill.fill_credit_card_info(credit_card_sample_data)
+    cvv = credit_card_sample_data.cvv
+    autofill_popup.press_doorhanger_save()
+
+    # navigate to prefs
+    about_prefs_obj.open()
+    iframe = about_prefs_obj.press_button_get_popup_dialog_iframe("Saved payment methods")
+    browser_action_obj.switch_to_iframe_context(iframe)
+
+    # Select the saved cc
+    saved_profile = about_prefs_obj.get_element("cc-saved-options")
+    info_string = saved_profile.get_attribute("data-l10n-args")
+    cc_info_json_original = json.loads(info_string)
+    logging.info(f"Extracted Original data: {cc_info_json_original}")
+    saved_profile.click()
+
+    # Click on edit
+    about_prefs_obj.get_element("panel-popup-button", labels=["autofill-manage-edit-button"]).click()
+
+    # Verify that CVV number is not saved under CC profile
+    element = about_prefs_obj.get_element("cc-saved-options", multiple=True)
+    cvv_not_displayed = not any(cvv in element.text for element in element)
+    assert (
+        cvv_not_displayed
+    ), "CVV is displayed."


### PR DESCRIPTION
# Description

This test verifies that a saved cvv number isn't displayed in a cc profile

## Bugzilla bug ID

**ID: 1895890**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1895890**

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

The test is completed.

# Screenshots / Explanations

N/A

# Comments / Concerns

Not sure if the verification for the cvv number under CC profile is done right.
