### PR TITLE
As/add open search engine from address bar

### DIFF
--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -94,3 +94,8 @@ class Navigation(BasePage):
             else:
                 self.type_in_awesome_bar(term + Keys.ENTER)
         return self
+
+    def click_in_awesome_bar(self) -> BasePage:
+        self.set_awesome_bar()
+        self.awesome_bar.click()
+        return self

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -1,5 +1,4 @@
 {
-
     "context": "chrome",
     "awesome-bar": {
         "selectorData": "urlbar-input",
@@ -78,12 +77,6 @@
         "groups": []
     },
 
-    "search-one-off-engine-button": {
-        "selectorData": "[id*=urlbar-engine-one-off-item-engine][tooltiptext^={site}]",
-        "strategy": "css",
-        "groups": []
-    },
-
     "search-one-off-browser-button": {
         "selectorData": "urlbar-engine-one-off-item-{source}",
         "strategy": "id",
@@ -99,6 +92,18 @@
     "navigation-background-component": {
         "selectorData": "nav-bar",
         "strategy": "id",
+        "groups": []
+    },
+
+    "add-extra-search-engine": {
+        "selectorData": "[id*=urlbar-engine-one-off-item-engine--1][tooltiptext*='{0}']",
+        "strategy": "css",
+        "groups": []
+},
+
+    "search-one-off-engine-button": {
+        "selectorData": "[id*=urlbar-engine-one-off-item-engine][tooltiptext^='{0}']",
+        "strategy": "css",
         "groups": []
     }
 

--- a/tests/address_bar_and_search/test_add_engine_address_bar.py
+++ b/tests/address_bar_and_search/test_add_engine_address_bar.py
@@ -1,0 +1,22 @@
+from selenium.webdriver import Firefox
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
+
+from modules.browser_object import Navigation
+
+
+def test_add_search_engine_from_address_bar(driver: Firefox):
+    """
+    C1365478: Test that an open search engine can be added from the address bar.
+    """
+
+    site = "YouTube"
+    nav = Navigation(driver).open()
+    nav.search("youtube.com")
+    WebDriverWait(driver, 10).until(EC.url_contains("https://www.youtube.com"))
+    nav.click_in_awesome_bar()
+    nav.element_clickable("add-extra-search-engine", labels=[site])
+    nav.get_element("add-extra-search-engine", labels=[site]).click()
+    nav.get_element("search-one-off-engine-button", labels=[site]).click()
+    nav.search("soccer")
+    nav.expect_in_content(EC.url_contains("youtube"))

--- a/tests/address_bar_and_search/test_add_engine_address_bar.py
+++ b/tests/address_bar_and_search/test_add_engine_address_bar.py
@@ -1,22 +1,30 @@
+import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 from modules.browser_object import Navigation
 
+sites = [("YouTube", "com"), ("Ecosia", "org")]
 
-def test_add_search_engine_from_address_bar(driver: Firefox):
+
+@pytest.mark.parametrize("site, domain", sites)
+def test_add_search_engine_from_address_bar(driver: Firefox, site: str, domain: str):
     """
     C1365478: Test that an open search engine can be added from the address bar.
     """
-
-    site = "YouTube"
+    open_site_engine = site.lower()
     nav = Navigation(driver).open()
-    nav.search("youtube.com")
-    WebDriverWait(driver, 10).until(EC.url_contains("https://www.youtube.com"))
+
+    # Construct the full URL
+    full_url = f"https://www.{open_site_engine}.{domain}"
+    nav.search(full_url)
+
+    # Wait until the expected URL is loaded
+    WebDriverWait(driver, 10).until(EC.url_contains(full_url))
     nav.click_in_awesome_bar()
     nav.element_clickable("add-extra-search-engine", labels=[site])
     nav.get_element("add-extra-search-engine", labels=[site]).click()
     nav.get_element("search-one-off-engine-button", labels=[site]).click()
-    nav.search("soccer")
-    nav.expect_in_content(EC.url_contains("youtube"))
+    nav.search("cobra")
+    nav.expect_in_content(EC.url_contains(open_site_engine))


### PR DESCRIPTION
# Description

This verifies that an open search engines (youtube and ecosia in this case) can be added from the address bar.

## Bugzilla bug ID

**ID: 1902772**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1902772**

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?
- Completed

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
