### PR TITLE
As/addon suggestion based on search input

### DIFF
--- a/ci_pyproject.toml
+++ b/ci_pyproject.toml
@@ -7,6 +7,7 @@ markers = [
     "pynput: test uses pynput package",
     "incident: incident smoke tests",
     "unstable: temporary mark for unstable tests",
+    "slow: test is clocked at more than 30s on modern machines",
     "ci: basic tests to run in ci",
     "locale_de: tests run in DE locale versions",
     "locale_fr: tests run in FR locale versions",

--- a/dev_pyproject.toml
+++ b/dev_pyproject.toml
@@ -8,6 +8,7 @@ markers = [
     "pynput: test uses pynput package",
     "incident: incident smoke tests",
     "unstable: temporary mark for unstable tests",
+    "slow: test is clocked at more than 30s on modern machines",
     "ci: basic tests to run in ci",
     "locale_de: tests run in DE locale versions",
     "locale_fr: tests run in FR locale versions",

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -124,6 +124,12 @@
         "selectorData": "downloads-button",
         "strategy": "id",
         "groups": []
+    },
+
+     "addon-suggestion": {
+        "selectorData": "div.urlbarView-row[type='rust_amo'] span.urlbarView-title.urlbarView-overflowable",
+        "strategy": "css",
+        "groups": []
     }
 
 }

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -138,7 +138,7 @@
         "selectorData": "div.urlbarView-row[type='rust_amo'] span.urlbarView-title.urlbarView-overflowable",
         "strategy": "css",
         "groups": []
-    }
+    },
 
     "search-suggestion-list": {
         "selectorData": "div.urlbarView-row[type='search_engine'] span.urlbarView-title",

--- a/modules/page_object.py
+++ b/modules/page_object.py
@@ -5,6 +5,7 @@ from modules.page_object_about_logins import *
 from modules.page_object_about_newtab import *
 from modules.page_object_about_prefs import *
 from modules.page_object_about_profiles import *
+from modules.page_object_about_telemetry import *
 from modules.page_object_addons_mozilla_org import *
 from modules.page_object_autofill_credit_card import *
 from modules.page_object_autofill_test_basic import *
@@ -12,4 +13,3 @@ from modules.page_object_example_page import *
 from modules.page_object_generic_pdf import *
 from modules.page_object_google_search import *
 from modules.page_object_wiki_firefox_logo import *
-from modules.page_object_about_telemetry import *

--- a/modules/util.py
+++ b/modules/util.py
@@ -6,12 +6,11 @@ import platform
 import re
 from os import remove
 from random import shuffle
-from typing import Union
-from jsonpath_ng import parse
 from typing import Literal, Union
 
 from faker import Faker
 from faker.providers import internet, misc
+from jsonpath_ng import parse
 from PIL import Image
 from pynput.keyboard import Controller, Key
 from selenium.common.exceptions import (
@@ -316,7 +315,10 @@ class Utilities:
         """Parse json and validate json search string with its value"""
         expr = parse(jsonpath_expr)
         match = expr.find(json_data)
-        return match[0].value == expected_value, f"Expected {expected_value}, but got {match[0].value}"
+        return (
+            match[0].value == expected_value,
+            f"Expected {expected_value}, but got {match[0].value}",
+        )
 
 
 class BrowserActions:
@@ -382,7 +384,7 @@ class BrowserActions:
                 url_bar.send_keys(term)
 
     def filter_elements_by_attr(
-            self, elements: list[WebElement], attr: str, value: str
+        self, elements: list[WebElement], attr: str, value: str
     ) -> list[WebElement]:
         """
         Given a list of WebElements, return the ones where attribute `attr` has value `value`.
@@ -390,7 +392,7 @@ class BrowserActions:
         return [el for el in elements if el.get_attribute(attr) == value]
 
     def pick_element_from_list_by_text(
-            self, elements: list[WebElement], substr: str
+        self, elements: list[WebElement], substr: str
     ) -> WebElement:
         """
         Given a list of WebElements, return the one where innerText matches `substr`.
@@ -481,7 +483,7 @@ class PomUtils:
         self.driver = driver
 
     def get_shadow_content(
-            self, element: WebElement
+        self, element: WebElement
     ) -> list[Union[WebElement, ShadowRoot]]:
         """
         Given a WebElement, return the shadow DOM root or roots attached to it. Returns a list.
@@ -515,7 +517,7 @@ class PomUtils:
         return []
 
     def css_selector_matches_element(
-            self, element: Union[WebElement, ShadowRoot], selector: list
+        self, element: Union[WebElement, ShadowRoot], selector: list
     ) -> bool:
         if type(element) == ShadowRoot:
             return False
@@ -525,7 +527,7 @@ class PomUtils:
         )
 
     def find_shadow_chrome_element(
-            self, nodes: list[WebElement], selector: list
+        self, nodes: list[WebElement], selector: list
     ) -> Union[WebElement, None]:
         logging.info("Selecting element in Chrome Context Shadow DOM...")
         if selector[0] not in self.allowed_selectors_shadow_chrome_element:
@@ -551,11 +553,11 @@ class PomUtils:
         return None
 
     def find_shadow_element(
-            self,
-            shadow_parent: Union[WebElement, ShadowRoot],
-            selector: list,
-            multiple=False,
-            context="content",
+        self,
+        shadow_parent: Union[WebElement, ShadowRoot],
+        selector: list,
+        multiple=False,
+        context="content",
     ) -> WebElement:
         """
         Given a WebElement with a shadow root attached, find a selector in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ markers = [
     "pynput: test uses pynput package",
     "incident: incident smoke tests",
     "unstable: temporary mark for unstable tests",
+    "slow: test is clocked at more than 30s on modern machines",
     "ci: basic tests to run in ci",
     "locale_de: tests run in DE locale versions",
     "locale_fr: tests run in FR locale versions",

--- a/tests/address_bar_and_search/test_addon_suggestion.py
+++ b/tests/address_bar_and_search/test_addon_suggestion.py
@@ -1,0 +1,40 @@
+import time
+
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.support import expected_conditions as EC
+
+from modules.browser_object import Navigation
+
+# Map input text to addon names
+input_to_addon_name = {
+    "clips": "video-downloadhelper",
+    "grammar": "languagetool",
+    "Temp mail": "private-relay",
+    "pics search": "search_by_image",
+    "darker theme": "darkreader",
+    "privacy": "privacy-badger17",
+    "read aloud": "read-aloud",
+}
+
+
+@pytest.mark.parametrize("input_text, addon_name", input_to_addon_name.items())
+def test_addon_suggestion_based_on_search_input(
+    driver: Firefox, input_text: str, addon_name: str
+):
+    """
+    C2234714: Test that add-on suggestions match the URL bar input.
+    """
+
+    nav = Navigation(driver).open()
+    time.sleep(10)
+    nav.set_awesome_bar()
+    time.sleep(10)
+    nav.awesome_bar.click()
+    nav.awesome_bar.send_keys(input_text)
+    nav.element_visible("addon-suggestion")
+    nav.get_element("addon-suggestion").click()
+
+    # Construct the expected URL
+    expected_url = f"https://addons.mozilla.org/en-US/firefox/addon/{addon_name}/"
+    nav.expect_in_content(EC.url_contains(expected_url))

--- a/tests/address_bar_and_search/test_addon_suggestion.py
+++ b/tests/address_bar_and_search/test_addon_suggestion.py
@@ -14,6 +14,7 @@ def add_prefs():
     ]
 
 
+@pytest.mark.slow
 def test_addon_suggestion_based_on_search_input(driver: Firefox):
     """
     C2234714: Test that add-on suggestions match the URL bar input.

--- a/tests/address_bar_and_search/test_addon_suggestion.py
+++ b/tests/address_bar_and_search/test_addon_suggestion.py
@@ -6,35 +6,48 @@ from selenium.webdriver.support import expected_conditions as EC
 
 from modules.browser_object import Navigation
 
-# Map input text to addon names
-input_to_addon_name = {
-    "clips": "video-downloadhelper",
-    "grammar": "languagetool",
-    "Temp mail": "private-relay",
-    "pics search": "search_by_image",
-    "darker theme": "darkreader",
-    "privacy": "privacy-badger17",
-    "read aloud": "read-aloud",
-}
+
+@pytest.fixture()
+def add_prefs():
+    return [
+        ("browser.search.region", "US"),
+    ]
 
 
-@pytest.mark.parametrize("input_text, addon_name", input_to_addon_name.items())
-def test_addon_suggestion_based_on_search_input(
-    driver: Firefox, input_text: str, addon_name: str
-):
+def test_addon_suggestion_based_on_search_input(driver: Firefox):
     """
     C2234714: Test that add-on suggestions match the URL bar input.
+
+    To avoid lengthy waits caused by network traffic during browser startup,
+    this test loops through the list of addons in a single browser session
+    instead of using parameterization. This reduces the overall test duration
+    by waiting for the network traffic only once.
     """
 
-    nav = Navigation(driver).open()
-    time.sleep(10)
-    nav.set_awesome_bar()
-    time.sleep(10)
-    nav.awesome_bar.click()
-    nav.awesome_bar.send_keys(input_text)
-    nav.element_visible("addon-suggestion")
-    nav.get_element("addon-suggestion").click()
+    # Map input text to addon names
+    input_to_addon_name = {
+        "clips": "video-downloadhelper",
+        "grammar": "languagetool",
+        "Temp mail": "private-relay",
+        "pics search": "search_by_image",
+        "darker theme": "darkreader",
+        "privacy": "privacy-badger17",
+        "read aloud": "read-aloud",
+    }
 
-    # Construct the expected URL
-    expected_url = f"https://addons.mozilla.org/en-US/firefox/addon/{addon_name}/"
-    nav.expect_in_content(EC.url_contains(expected_url))
+    nav = Navigation(driver).open()
+    time.sleep(20)
+    nav.set_awesome_bar()
+    time.sleep(20)
+    nav.awesome_bar.click()
+
+    for input_text, addon_name in input_to_addon_name.items():
+        nav.awesome_bar.send_keys(input_text)
+        nav.element_visible("addon-suggestion")
+        nav.get_element("addon-suggestion").click()
+
+        # Construct the expected URL
+        expected_url = f"https://addons.mozilla.org/en-US/firefox/addon/{addon_name}/"
+        nav.expect_in_content(EC.url_contains(expected_url))
+
+        nav.awesome_bar.clear()

--- a/tests/address_bar_and_search/test_google_search_counts_us.py
+++ b/tests/address_bar_and_search/test_google_search_counts_us.py
@@ -1,11 +1,12 @@
 import time
+
 import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation
 from modules.page_object import AboutTelemetry
-
 from modules.util import Utilities
+
 
 # unstable: for some reason cannot pass in Taskcluster Linux VM
 @pytest.mark.unstable
@@ -27,5 +28,11 @@ def test_google_search_counts_us(driver: Firefox):
 
     # Verify pings are recorded
     json_data = u.decode_url(driver)
-    assert u.assert_json_value(json_data, '$..SEARCH_COUNTS.["google-b-1-d.urlbar"].sum', 1)
-    assert u.assert_json_value(json_data, '$..["browser.search.content.urlbar"].["google:tagged:firefox-b-1-d"]', 1)
+    assert u.assert_json_value(
+        json_data, '$..SEARCH_COUNTS.["google-b-1-d.urlbar"].sum', 1
+    )
+    assert u.assert_json_value(
+        json_data,
+        '$..["browser.search.content.urlbar"].["google:tagged:firefox-b-1-d"]',
+        1,
+    )

--- a/tests/address_bar_and_search/test_search_code_google_non_us.py
+++ b/tests/address_bar_and_search/test_search_code_google_non_us.py
@@ -55,7 +55,7 @@ def test_search_code_google_us(driver: Firefox):
     nav.set_content_context()
     driver.get("http://example.com")
     h1_tag = driver.find_element(By.TAG_NAME, "h1")
-    nav.triple_click_element(h1_tag)
+    nav.triple_click(h1_tag)
     nav.context_click_element(h1_tag)
     nav.set_chrome_context()
     context_menu.get_context_item("context-menu-search-selected-text").click()

--- a/tests/address_bar_and_search/test_suggestion_engine_selection.py
+++ b/tests/address_bar_and_search/test_suggestion_engine_selection.py
@@ -16,6 +16,10 @@ def add_prefs():
 
 @pytest.mark.parametrize("site", sites)
 def test_search_suggestion_for_engine_selection(driver: Firefox, site: str):
+    """
+    C1365228 - Test to verify that when entering "@", a list of search engines is suggested, and upon selecting an
+    engine, the search is performed using the selected engine.
+    """
     nav = Navigation(driver).open()
     nav.type_in_awesome_bar("@")
     nav.element_has_text("results-dropdown", f"Search with {site}")


### PR DESCRIPTION
# Description

This test ensures that a matching add-on suggestion appears based on the search input and that clicking on the suggested add-on redirects to the corresponding add-on page.

## Bugzilla bug ID

**ID: 1902787**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1902787**

## Type of change

Please delete options that are not relevant.

- [x ] New Test

# How does this resolve / make progress on that bug?
In progress

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns
I have a passing test, but I need to work on optimizing the timing. None of the waiting condition approach I've tried so far did the trick.


Please add a short blurb about any comments or concerns that this change might cause.
