### PR TITLE
As/server not found error page

### DIFF
--- a/modules/data/error_page.components.json
+++ b/modules/data/error_page.components.json
@@ -1,0 +1,32 @@
+{
+    "error-title": {
+        "selectorData": ".title-text[data-l10n-id='dnsNotFound-title']",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "error-short-description": {
+        "selectorData": "errorShortDesc",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "error-suggestion-link": {
+        "selectorData": "#errorShortDesc a[data-l10n-name='website']",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "error-long-description-items": {
+        "selectorData": "#errorLongDesc li",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "try-again-button": {
+        "selectorData": "#netErrorButtonContainer #neterrorTryAgainButton",
+        "strategy": "css",
+        "groups": []
+    }
+
+}

--- a/modules/page_object_error_page.py
+++ b/modules/page_object_error_page.py
@@ -1,0 +1,24 @@
+from selenium.webdriver.remote.webelement import WebElement
+
+from modules.page_base import BasePage
+
+
+class ErrorPage(BasePage):
+    """
+    Page Object Model for the 'Server Not Found' error page.
+    """
+
+    def get_error_title(self) -> str:
+        return self.get_element("error-title").get_attribute("innerText")
+
+    def get_error_short_description(self) -> str:
+        return self.get_element("error-short-description").get_attribute("innerText")
+
+    def get_error_long_description_items(self) -> list[WebElement]:
+        return self.get_elements("error-long-description-items")
+
+    def get_try_again_button(self) -> WebElement:
+        return self.get_element("try-again-button")
+
+    def get_error_suggestion_link(self) -> WebElement:
+        return self.get_element("error-suggestion-link")

--- a/tests/address_bar_and_search/test_server_not_found_error.py
+++ b/tests/address_bar_and_search/test_server_not_found_error.py
@@ -1,0 +1,79 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
+
+from modules.browser_object import Navigation
+from modules.browser_object_tabbar import TabBar
+from modules.page_object_error_page import ErrorPage
+
+
+@pytest.fixture()
+def add_prefs():
+    return [
+        ("browser.search.region", "US"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "url, site_name, suggestion_url",
+    [
+        ("http://cnn", "cnn", "https://www.cnn.com/"),
+        ("http://example", "example", "https://www.example.com/"),
+    ],
+)
+def test_server_not_found_error(driver: Firefox, url, site_name, suggestion_url):
+    """
+    C1901393: - This tests that when a user navigates to a non-existent site, a "Server Not Found" error is
+    displayed. The error page contains the correct elements, and the suggested link redirects to the appropriate page.
+
+    """
+
+    # Create objects
+    nav = Navigation(driver).open()
+    tabs = TabBar(driver)
+    error_page = ErrorPage(driver)
+
+    nav.search(url)
+
+    # Verify the tab title
+
+    WebDriverWait(driver, 30).until(
+        lambda d: tabs.get_tab_title(tabs.get_tab(1)) == "Server Not Found"
+    )
+
+    # Verify elements on the error page
+
+    error_title = error_page.get_error_title()
+    assert (
+        error_title == "Hmm. We’re having trouble finding that site."
+    ), f"Expected error title text not found. Actual: {error_title}"
+
+    error_short_description = error_page.get_error_short_description()
+    assert (
+        error_short_description
+        == f"We can’t connect to the server at {site_name}. Did you mean to go to www.{site_name}.com?"
+    ), (
+        f"Expected error short description text not found."
+        f"Actual: {error_short_description}"
+    )
+
+    error_long_description_items = error_page.get_error_long_description_items()
+    expected_texts = [
+        "Try again later",
+        "Check your network connection",
+        "Check that Firefox has permission to access the web (you might be connected but behind a firewall)",
+    ]
+
+    for i, item in enumerate(error_long_description_items):
+        assert (
+            item.text == expected_texts[i]
+        ), f"Expected error long description item text not found. Actual: {item.text}"
+
+    try_again_button = error_page.get_try_again_button()
+    assert try_again_button.is_displayed(), "The 'Try Again' button is not displayed"
+
+    # Verify that the suggested link redirects to the correct page
+
+    error_page.get_error_suggestion_link().click()
+    nav.expect_in_content(EC.url_contains(suggestion_url))

--- a/tests/address_bar_and_search/test_server_not_found_error.py
+++ b/tests/address_bar_and_search/test_server_not_found_error.py
@@ -15,18 +15,10 @@ def add_prefs():
     ]
 
 
-@pytest.mark.parametrize(
-    "url, site_name, suggestion_url",
-    [
-        ("http://cnn", "cnn", "https://www.cnn.com/"),
-        ("http://example", "example", "https://www.example.com/"),
-    ],
-)
-def test_server_not_found_error(driver: Firefox, url, site_name, suggestion_url):
+def test_server_not_found_error(driver: Firefox):
     """
     C1901393: - This tests that when a user navigates to a non-existent site, a "Server Not Found" error is
     displayed. The error page contains the correct elements, and the suggested link redirects to the appropriate page.
-
     """
 
     # Create objects
@@ -34,16 +26,14 @@ def test_server_not_found_error(driver: Firefox, url, site_name, suggestion_url)
     tabs = TabBar(driver)
     error_page = ErrorPage(driver)
 
-    nav.search(url)
+    nav.search("http://cnn")
 
     # Verify the tab title
-
     WebDriverWait(driver, 30).until(
         lambda d: tabs.get_tab_title(tabs.get_tab(1)) == "Server Not Found"
     )
 
     # Verify elements on the error page
-
     error_title = error_page.get_error_title()
     assert (
         error_title == "Hmm. We’re having trouble finding that site."
@@ -52,7 +42,7 @@ def test_server_not_found_error(driver: Firefox, url, site_name, suggestion_url)
     error_short_description = error_page.get_error_short_description()
     assert (
         error_short_description
-        == f"We can’t connect to the server at {site_name}. Did you mean to go to www.{site_name}.com?"
+        == "We can’t connect to the server at cnn. Did you mean to go to www.cnn.com?"
     ), (
         f"Expected error short description text not found."
         f"Actual: {error_short_description}"
@@ -74,6 +64,5 @@ def test_server_not_found_error(driver: Firefox, url, site_name, suggestion_url)
     assert try_again_button.is_displayed(), "The 'Try Again' button is not displayed"
 
     # Verify that the suggested link redirects to the correct page
-
     error_page.get_error_suggestion_link().click()
-    nav.expect_in_content(EC.url_contains(suggestion_url))
+    nav.expect_in_content(EC.url_contains("https://www.cnn.com/"))


### PR DESCRIPTION
# Description

This test verifies that when a user navigates to a non-existent site, a 'Server Not Found' error title is displayed in the browser tab. The error page contains the correct elements, and the suggested link redirects to the appropriate page.

## Bugzilla bug ID

**ID: 1902783**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1902783**

## Type of change

Please delete options that are not relevant.

- [x] New Test
- [x] New POM

# How does this resolve / make progress on that bug?
Completed

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
