### PR TITLE
Intervention Card Firefox

### DIFF
--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -26,15 +26,6 @@ class AutofillPopup(BasePage):
             element = self.get_element("autofill-panel")
             self.expect_not(EC.element_to_be_clickable(element))
 
-    def hover_over_element(self, element: str):
-        """
-        Hover over the specified element.
-        Parameters: element (str): The element to hover over.
-        """
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            self.actions.move_to_element(element).perform()
-            return self
-
     def get_nth_element(self, index: str) -> WebElement:
         """
         Get the nth element from the autocomplete list.

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -44,7 +44,9 @@
     "refresh-intervention-card": {
         "selectorData": "div[tip-type=\"intervention_refresh\"]",
         "strategy": "css",
-        "groups": []
+        "groups": [
+            "doNotCache"
+        ]
     },
 
     "fx-refresh-text": {
@@ -68,6 +70,12 @@
     "fx-refresh-menu-get-help-item": {
         "selectorData": "menuitem[data-l10n-id=\"urlbar-result-menu-tip-get-help\"]",
         "strategy": "css",
+        "groups": []
+    },
+
+    "fx-refresh-menu-get-help-item-get-help": {
+        "selectorData": "urlbarView-result-menuitem",
+        "strategy": "class",
         "groups": []
     },
 
@@ -122,6 +130,12 @@
 
     "downloads-button": {
         "selectorData": "downloads-button",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "search-results-container": {
+        "selectorData": "urlbar-results",
         "strategy": "id",
         "groups": []
     }

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -5,7 +5,7 @@ import platform
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 from pypom import Page
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
@@ -436,6 +436,32 @@ class BasePage(Page):
                 self.driver.execute_script(script, node)
         else:
             self.driver.execute_script(script, node)
+
+    def hover_over_element(self, element: WebElement, chrome=False):
+        """
+        Hover over the specified element.
+        Parameters: element (str): The element to hover over.
+
+        Default tries to hover something in the chrome context
+        """
+        if chrome:
+            with self.driver.context(self.driver.CONTEXT_CHROME):
+                self.actions.move_to_element(element).perform()
+        else:
+            self.actions.move_to_element(element).perform()
+        return self
+
+    def get_all_children(self, element: WebElement, chrome=False) -> List[WebElement]:
+        """
+        Gets all the children of a webelement
+        """
+        children = None
+        if chrome:
+            with self.driver.context(self.driver.CONTEXT_CHROME):
+                children = element.find_elements(By.XPATH, "./*")
+        else:
+            children = element.find_elements(By.XPATH, "./*")
+        return children
 
     @property
     def loaded(self):

--- a/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
+++ b/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
@@ -3,12 +3,8 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation
 
-LIGHT_MODE_BEFORE_RBG_VALUE = "rgba(207, 207, 216, 0.33)"
-DARK_MODE_BEFORE_RGB_VALUE = "rgba(0, 0, 0, 0.33)"
-
-LIGHT_MODE_AFTER_RGB_VALUE = "color(srgb 0 0 0 / 0.6)"
-DARK_MODE_AFTER_RGB_VALUE = "color(srgb 0.984314 0.984314 0.996078 / 0.6)"
-
+ALLOWED_RGB_BEFORE_VALUES = set(["rgba(207, 207, 216, 0.33)", "color(srgb 0 0 0 / 0.13)", "rgba(0, 0, 0, 0.33)"])
+ALLOWED_RGB_AFTER_VALUES = set(["color(srgb 0 0 0 / 0.6)", "color(srgb 0.984314 0.984314 0.996078 / 0.6)"])
 
 # Set search region
 @pytest.fixture()
@@ -40,35 +36,22 @@ def test_intervention_card_refresh(driver: Firefox):
 
     # ensure the color before hover
     button_background = refresh_button.value_of_css_property("background-color")
-    assert (
-        button_background == LIGHT_MODE_BEFORE_RBG_VALUE
-        or button_background == DARK_MODE_BEFORE_RGB_VALUE
-    )
+    assert button_background in ALLOWED_RGB_BEFORE_VALUES
     nav.hover_over_element(refresh_button, chrome=True)
 
     # ensure there is a hover state
     new_button_background = refresh_button.value_of_css_property("background-color")
-    assert (
-        new_button_background == LIGHT_MODE_AFTER_RGB_VALUE
-        or new_button_background == DARK_MODE_AFTER_RGB_VALUE
-    )
-
+    assert new_button_background in ALLOWED_RGB_AFTER_VALUES
     # repeated from before but with the 3 dots menu button
     help_menu_background = help_menu_button.value_of_css_property("background-color")
-    assert (
-        help_menu_background == LIGHT_MODE_BEFORE_RBG_VALUE
-        or help_menu_background == DARK_MODE_BEFORE_RGB_VALUE
-    )
+    assert help_menu_background in ALLOWED_RGB_BEFORE_VALUES
     assert help_menu_button.get_attribute("open") is None
     nav.hover_over_element(help_menu_button, chrome=True)
 
     new_help_menu_background = help_menu_button.value_of_css_property(
         "background-color"
     )
-    assert (
-        new_help_menu_background == LIGHT_MODE_AFTER_RGB_VALUE
-        or new_help_menu_background == DARK_MODE_AFTER_RGB_VALUE
-    )
+    assert new_help_menu_background in ALLOWED_RGB_AFTER_VALUES
 
     # ensure the popup appears
     help_menu_button.click()

--- a/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
+++ b/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
@@ -1,0 +1,81 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation
+
+LIGHT_MODE_BEFORE_RBG_VALUE = "rgba(207, 207, 216, 0.33)"
+DARK_MODE_BEFORE_RGB_VALUE = "rgba(0, 0, 0, 0.33)"
+
+LIGHT_MODE_AFTER_RGB_VALUE = "color(srgb 0 0 0 / 0.6)"
+DARK_MODE_AFTER_RGB_VALUE = "color(srgb 0.984314 0.984314 0.996078 / 0.6)"
+
+
+# Set search region
+@pytest.fixture()
+def add_prefs():
+    return [
+        ("browser.search.region", "US"),
+    ]
+
+
+def test_intervention_card_refresh(driver: Firefox):
+    """
+    C1365204.1: regular firefox, check the intervention card
+    """
+    # instantiate objects and type in search bar
+    nav = Navigation(driver).open()
+    nav.set_awesome_bar()
+    nav.type_in_awesome_bar("refresh firefox")
+
+    # get relevant items
+    refresh_text = nav.get_element("fx-refresh-text")
+    refresh_button = nav.get_element("fx-refresh-button")
+    help_menu_button = nav.get_element("fx-refresh-menu")
+
+    # ensure the text is correct
+    assert (
+        refresh_text.get_attribute("innerHTML")
+        == "Restore default settings and remove old add-ons for optimal performance."
+    )
+
+    # ensure the color before hover
+    button_background = refresh_button.value_of_css_property("background-color")
+    assert (
+        button_background == LIGHT_MODE_BEFORE_RBG_VALUE
+        or button_background == DARK_MODE_BEFORE_RGB_VALUE
+    )
+    nav.hover_over_element(refresh_button, chrome=True)
+
+    # ensure there is a hover state
+    new_button_background = refresh_button.value_of_css_property("background-color")
+    assert (
+        new_button_background == LIGHT_MODE_AFTER_RGB_VALUE
+        or new_button_background == DARK_MODE_AFTER_RGB_VALUE
+    )
+
+    # repeated from before but with the 3 dots menu button
+    help_menu_background = help_menu_button.value_of_css_property("background-color")
+    assert (
+        help_menu_background == LIGHT_MODE_BEFORE_RBG_VALUE
+        or help_menu_background == DARK_MODE_BEFORE_RGB_VALUE
+    )
+    assert help_menu_button.get_attribute("open") is None
+    nav.hover_over_element(help_menu_button, chrome=True)
+
+    new_help_menu_background = help_menu_button.value_of_css_property(
+        "background-color"
+    )
+    assert (
+        new_help_menu_background == LIGHT_MODE_AFTER_RGB_VALUE
+        or new_help_menu_background == DARK_MODE_AFTER_RGB_VALUE
+    )
+
+    # ensure the popup appears
+    help_menu_button.click()
+    assert help_menu_button.get_attribute("open") == "true"
+    assert nav.get_element("fx-refresh-menu-get-help-item-get-help") is not None
+
+    # get the number of options (search results)
+    search_results_container = nav.get_element("search-results-container")
+    search_results = nav.get_all_children(search_results_container, chrome=True)
+    assert len(search_results) == 2

--- a/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
+++ b/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
@@ -3,8 +3,13 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation
 
-ALLOWED_RGB_BEFORE_VALUES = set(["rgba(207, 207, 216, 0.33)", "color(srgb 0 0 0 / 0.13)", "rgba(0, 0, 0, 0.33)"])
-ALLOWED_RGB_AFTER_VALUES = set(["color(srgb 0 0 0 / 0.6)", "color(srgb 0.984314 0.984314 0.996078 / 0.6)"])
+ALLOWED_RGB_BEFORE_VALUES = set(
+    ["rgba(207, 207, 216, 0.33)", "color(srgb 0 0 0 / 0.13)", "rgba(0, 0, 0, 0.33)"]
+)
+ALLOWED_RGB_AFTER_VALUES = set(
+    ["color(srgb 0 0 0 / 0.6)", "color(srgb 0.984314 0.984314 0.996078 / 0.6)"]
+)
+
 
 # Set search region
 @pytest.fixture()

--- a/tests/find_toolbar/test_find_in_pdf.py
+++ b/tests/find_toolbar/test_find_in_pdf.py
@@ -1,4 +1,3 @@
-
 from selenium.webdriver import Firefox
 
 from modules.browser_object import FindToolbar

--- a/tests/find_toolbar/test_find_in_pdf.py
+++ b/tests/find_toolbar/test_find_in_pdf.py
@@ -1,8 +1,5 @@
-import logging
-from time import sleep
 
 from selenium.webdriver import Firefox
-from selenium.webdriver.common.keys import Keys
 
 from modules.browser_object import FindToolbar
 from modules.page_base import BasePage

--- a/tests/form_autofill/test_address_autofill_attribute.py
+++ b/tests/form_autofill/test_address_autofill_attribute.py
@@ -32,7 +32,8 @@ def test_address_attribute_selection(driver: Firefox, country_code: str):
     # Get the first element from the autocomplete dropdown
     first_item = autofill_popup_panel.get_nth_element(1)
     actual_value = autofill_popup_panel.hover_over_element(
-        first_item
+        first_item,
+        chrome=True
     ).get_primary_value(first_item)
 
     # Get the primary value (street address) from the first item in the dropdown and assert that the actual value

--- a/tests/form_autofill/test_address_autofill_attribute.py
+++ b/tests/form_autofill/test_address_autofill_attribute.py
@@ -32,8 +32,7 @@ def test_address_attribute_selection(driver: Firefox, country_code: str):
     # Get the first element from the autocomplete dropdown
     first_item = autofill_popup_panel.get_nth_element(1)
     actual_value = autofill_popup_panel.hover_over_element(
-        first_item,
-        chrome=True
+        first_item, chrome=True
     ).get_primary_value(first_item)
 
     # Get the primary value (street address) from the first item in the dropdown and assert that the actual value

--- a/tests/form_autofill/test_name_autofill_attribute.py
+++ b/tests/form_autofill/test_name_autofill_attribute.py
@@ -32,7 +32,8 @@ def test_address_attribute_selection(driver: Firefox, country_code: str):
     # Get the first element from the autocomplete dropdown
     first_item = autofill_popup_panel.get_nth_element(1)
     actual_value = autofill_popup_panel.hover_over_element(
-        first_item
+        first_item,
+        chrome=True
     ).get_primary_value(first_item)
 
     # Get the primary value (street address) from the first item in the dropdown and assert that the actual value

--- a/tests/form_autofill/test_name_autofill_attribute.py
+++ b/tests/form_autofill/test_name_autofill_attribute.py
@@ -32,8 +32,7 @@ def test_address_attribute_selection(driver: Firefox, country_code: str):
     # Get the first element from the autocomplete dropdown
     first_item = autofill_popup_panel.get_nth_element(1)
     actual_value = autofill_popup_panel.hover_over_element(
-        first_item,
-        chrome=True
+        first_item, chrome=True
     ).get_primary_value(first_item)
 
     # Get the primary value (street address) from the first item in the dropdown and assert that the actual value

--- a/tests/form_autofill/test_telephone_autofill_attribute.py
+++ b/tests/form_autofill/test_telephone_autofill_attribute.py
@@ -33,7 +33,7 @@ def test_telephone_attribute_autofill(driver: Firefox, country_code: str):
     first_item = autofill_popup_obj.get_nth_element("1")
 
     # get relevant fields
-    autofill_popup_obj.hover_over_element(first_item)
+    autofill_popup_obj.hover_over_element(first_item, chrome=True)
     actual_value = autofill_popup_obj.get_primary_value(first_item)
     normalized_number = util.normalize_phone_number(actual_value)
     original_number = util.normalize_phone_number(autofill_sample_data.telephone)


### PR DESCRIPTION
# Description

Finishes verifying elements of the intervention card in firefox

## Bugzilla bug ID

**ID:** 1902765
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1902765

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

Finishes

# Screenshots / Explanations

N/a

# Comments / Concerns

1. In selenium, the behaviour is similar to private browsing mode so only 2 results show up instead of the typical 8 with the search suggestions.
2. Added a helper method that gets all children of a webelement. Moved hover element into page base for support in all BOM/POMs
