### PR TITLE
hy/Test Cryptominers are blocked and shown in Standard mode Info panel

### DIFF
--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -184,5 +184,18 @@
         "selectorData": "//div[@data-text-ad]//a",
         "strategy": "xpath",
         "groups": []
+    },
+
+    "shield-icon": {
+        "selectorData": "tracking-protection-icon-container",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "cryptominers": {
+        "selectorData": ".protections-popup-category.subviewbutton.subviewbutton-iconic.subviewbutton-nav.blocked",
+        "strategy": "css",
+        "groups": []
     }
+
 }

--- a/tests/security_and_privacy/conftest.py
+++ b/tests/security_and_privacy/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.fixture()
+def suite_id():
+    return ("X", "Security and Privacy")
+
+
+@pytest.fixture()
+def set_prefs():
+    """Set prefs"""
+    return []

--- a/tests/security_and_privacy/conftest.py
+++ b/tests/security_and_privacy/conftest.py
@@ -3,18 +3,12 @@ import pytest
 
 @pytest.fixture()
 def suite_id():
-    return ("X", "Security and Privacy")
+    return ("5833", "Security and Privacy")
 
 
 @pytest.fixture()
-def add_prefs():
-    return []
-
-
-@pytest.fixture()
-def set_prefs(add_prefs=None):
+def set_prefs(add_prefs: dict):
     """Set prefs"""
     prefs = []
-    if add_prefs is not None:
-        prefs.extend(add_prefs)
+    prefs.extend(add_prefs)
     return prefs

--- a/tests/security_and_privacy/conftest.py
+++ b/tests/security_and_privacy/conftest.py
@@ -7,6 +7,14 @@ def suite_id():
 
 
 @pytest.fixture()
-def set_prefs():
-    """Set prefs"""
+def add_prefs():
     return []
+
+
+@pytest.fixture()
+def set_prefs(add_prefs=None):
+    """Set prefs"""
+    prefs = []
+    if add_prefs is not None:
+        prefs.extend(add_prefs)
+    return prefs

--- a/tests/security_and_privacy/test_cryptominers_blocked_and_shown_in_info_panel.py
+++ b/tests/security_and_privacy/test_cryptominers_blocked_and_shown_in_info_panel.py
@@ -2,7 +2,7 @@ from time import sleep
 from selenium.webdriver import Firefox
 from modules.browser_object_navigation import Navigation
 
-url = "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting_and_cryptomining.html"
+cryptominers_url = "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting_and_cryptomining.html"
 
 
 def test_cryptominers_blocked_and_shown_in_info_panel(driver: Firefox):
@@ -11,8 +11,8 @@ def test_cryptominers_blocked_and_shown_in_info_panel(driver: Firefox):
     """
     # Access URL, needed sleep otherwise cryptomining will be displayed as unblocked
     nav = Navigation(driver)
-    sleep(2)
-    driver.get(url)
+    sleep(4)
+    driver.get(cryptominers_url)
 
     # Click on the shield icon and verify that cryptominers are blocked
     with driver.context(driver.CONTEXT_CHROME):

--- a/tests/security_and_privacy/test_cryptominers_blocked_and_shown_in_info_panel.py
+++ b/tests/security_and_privacy/test_cryptominers_blocked_and_shown_in_info_panel.py
@@ -1,0 +1,20 @@
+from time import sleep
+from selenium.webdriver import Firefox
+from modules.browser_object_navigation import Navigation
+
+url = "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting_and_cryptomining.html"
+
+
+def test_cryptominers_blocked_and_shown_in_info_panel(driver: Firefox):
+    """
+    C450232: Cryptominers are blocked and shown in Standard mode in the Information pannel
+    """
+    # Access URL, needed sleep otherwise cryptomining will be displayed as unblocked
+    nav = Navigation(driver)
+    sleep(2)
+    driver.get(url)
+
+    # Click on the shield icon and verify that cryptominers are blocked
+    with driver.context(driver.CONTEXT_CHROME):
+        nav.get_element("shield-icon").click()
+        assert nav.get_element("cryptominers").is_displayed()

--- a/tests/security_and_privacy/test_cryptominers_blocked_and_shown_in_info_panel.py
+++ b/tests/security_and_privacy/test_cryptominers_blocked_and_shown_in_info_panel.py
@@ -1,8 +1,14 @@
 from time import sleep
+
+import pytest
 from selenium.webdriver import Firefox
 from modules.browser_object_navigation import Navigation
 
-cryptominers_url = "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting_and_cryptomining.html"
+CRYPTOMINERS_URL = "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting_and_cryptomining.html"
+
+@pytest.fixture()
+def add_prefs():
+    return []
 
 
 def test_cryptominers_blocked_and_shown_in_info_panel(driver: Firefox):
@@ -12,7 +18,7 @@ def test_cryptominers_blocked_and_shown_in_info_panel(driver: Firefox):
     # Access URL, needed sleep otherwise cryptomining will be displayed as unblocked
     nav = Navigation(driver)
     sleep(4)
-    driver.get(cryptominers_url)
+    driver.get(CRYPTOMINERS_URL)
 
     # Click on the shield icon and verify that cryptominers are blocked
     with driver.context(driver.CONTEXT_CHROME):


### PR DESCRIPTION
# Description

This test verifies that cryptominers are blocked and shown in Standard mode in the Information panel.

## Bugzilla bug ID

**Testrail: https://testrail.stage.mozaws.net/index.php?/cases/view/450232**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1905192**

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

N/A

# Screenshots / Explanations

N/A

# Comments / Concerns

Maybe there is a better way to do assertion on cryptominers displacement in the Information panel.
