### PR TITLE
As/empty history state in normal session for PB sites

### DIFF
--- a/modules/browser_object_panel_ui.py
+++ b/modules/browser_object_panel_ui.py
@@ -141,3 +141,12 @@ class PanelUi(BasePage):
         with self.driver.context(self.driver.CONTEXT_CHROME):
             self.get_element("panel-ui-new-private-window").click()
         return self
+
+    def open_history_menu(self) -> BasePage:
+        """
+        Opens the History menu
+        """
+        self.open_panel_menu()
+        with self.driver.context(self.driver.CONTEXT_CHROME):
+            self.get_element("panel-ui-history").click()
+        return self

--- a/modules/data/panel_ui.components.json
+++ b/modules/data/panel_ui.components.json
@@ -125,6 +125,12 @@
         "selectorData": "appMenu-new-private-window-button2",
         "strategy": "id",
         "groups": []
+    },
+
+    "recent-history-content": {
+        "selectorData": "#appMenu_historyMenu .toolbarbutton-text",
+        "strategy": "css",
+        "groups": []
     }
 
 }

--- a/tests/security_and_privacy/test_private_session_history_exclusion.py
+++ b/tests/security_and_privacy/test_private_session_history_exclusion.py
@@ -1,0 +1,41 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_panel_ui import PanelUi
+
+YOUTUBE_URL = "https://www.youtube.com/"
+FACEBOOK_URL = "https://www.facebook.com/"
+AMAZON_URL = "https://www.amazon.com/"
+
+
+@pytest.fixture()
+def add_prefs():
+    return []
+
+
+def test_websites_visited_in_private_browser_not_displayed_in_history(driver: Firefox):
+    """
+    C101663 - Verify the visited websites from the Private Browsing session are not displayed inside the normal session
+    History menu
+    """
+
+    initial_window_handle = driver.current_window_handle
+
+    panel_ui = PanelUi(driver).open()
+    panel_ui.open_private_window()
+    panel_ui.switch_to_new_window()
+
+    driver.get(YOUTUBE_URL)
+    driver.get(FACEBOOK_URL)
+    driver.get(AMAZON_URL)
+
+    driver.switch_to.window(initial_window_handle)
+
+    panel_ui.open_history_menu()
+    with panel_ui.driver.context(panel_ui.driver.CONTEXT_CHROME):
+        empty_label = panel_ui.get_element("recent-history-content").get_attribute(
+            "value"
+        )
+        assert (
+            empty_label == "(Empty)"
+        ), f"Expected history to be empty, but found '{empty_label}'"

--- a/tests/sync_and_fxa/test_new_fxa.py
+++ b/tests/sync_and_fxa/test_new_fxa.py
@@ -15,6 +15,9 @@ def acct_password():
     return "Test123???"
 
 
+@pytest.mark.skip(
+    "Stop spamming stage with fake accounts; remove when we implement acct delete"
+)
 def test_sync_new_fxa(driver: Firefox, fxa_url: str, new_fxa_prep: dict, get_otp_code):
     """C131094: The user is able to create a new Firefox Account"""
 


### PR DESCRIPTION
# Description

Verify the visited websites from the Private Browsing session are not displayed inside the normal session History menu

## Bugzilla bug ID

**Testrail: https://testrail.stage.mozaws.net/index.php?/cases/view/101663**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1905179**

## Type of change

Please delete options that are not relevant.

- [x ] New Test

# How does this resolve / make progress on that bug?
Completed

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
