### PR TITLE
Add CI for MacOS and Windows

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,6 +22,7 @@ jobs:
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
+          echo "@@@SHELL ${0}"
           ./collect_executables.sh;
           rm ./pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,8 +4,6 @@ name: Mac and Windows Smoke
 run-name: ${{ github.actor }} is running smoke tests
 on:
   pull_request:
-    - created
-    - edited
 
 jobs:
   Smoke-Windows:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,7 +3,9 @@ name: Mac and Windows Smoke
 
 run-name: ${{ github.actor }} is running smoke tests
 on:
-  pull_request: created
+  pull_request:
+    - created
+    - edited
 
 jobs:
   Smoke-Windows:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,10 +8,28 @@ on:
   pull_request:
     types: created
 jobs:
-  Smoke-Win-and-Mac:
-    runs-on:
-      - windows-latest
-      - macos-latest
+  Smoke-Windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          mkdir -p artifacts;
+          pip3 install 'pipenv==2023.11.15';
+          pip3 install 'ruff>=0.4.8,<0.5';
+          ./collect_executables.sh;
+          rm ./pyproject.toml;
+          mv ./ci_pyproject.toml ./pyproject.toml;
+          pipenv install;
+      - name: Run Smoke Tests in Win
+        run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 .
+  Smoke-MacOS:
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,12 +1,12 @@
+---
 name: Mac and Windows Smoke
 
 run-name: ${{ github.actor }} is running smoke tests
 on:
   push:
-    branches: ["bc/gha"]
+    branches: "bc/gha"
   pull_request:
-    types:
-      - created
+    types: created
 jobs:
   Smoke-Windows:
     runs-on: windows-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -27,12 +27,14 @@ jobs:
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;
       - name: Run Smoke Tests in Win
-        run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 .
+        run: |
+          pipenv run pytest --fx-executable ./firefox/firefox -n 4 .
+          mv artifacts artifacts-win
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: test artifacts
-          path: artifacts
+          path: artifacts-win
   Smoke-MacOS:
     runs-on: macos-latest
     steps:
@@ -52,9 +54,11 @@ jobs:
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;
       - name: Run Smoke Tests in MacOS
-        run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests
+        run: |
+          pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests
+          mv artifacts artifacts-mac
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: test artifacts
-          path: artifacts
+          path: artifacts-mac

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,9 +3,7 @@ name: Mac and Windows Smoke
 
 run-name: ${{ github.actor }} is running smoke tests
 on:
-  push:
-    branches: "bc/gha"
-  pull_request:
+  pull_request: created
 
 jobs:
   Smoke-Windows:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,7 +28,7 @@ jobs:
           pipenv install;
       - name: Run Smoke Tests in Win
         run: |
-          pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests/preferences
+          pipenv run pytest --fx-executable ./firefox/firefox -n 4 .
           mv artifacts artifacts-win
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,6 +2,8 @@ name: Mac and Windows Smoke
 
 run-name: ${{ github.actor }} is running smoke tests
 on:
+  push:
+    branches: ["bc/gha"]
   pull_request:
     types:
       - created

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: test artifacts
+          name: artifacts-win
           path: artifacts-win
   Smoke-MacOS:
     runs-on: macos-latest
@@ -60,5 +60,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: test artifacts
+          name: artifacts-mac
           path: artifacts-mac

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,5 +46,5 @@ jobs:
           rm ./pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;
-      - name: Run Smoke Tests in Win
-        run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 .
+      - name: Run Smoke Tests in MacOS
+        run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests/[amt]*

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Python 3.13
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -49,7 +49,7 @@ jobs:
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
-          ./collect_executables.sh;
+          bash collect_executables.sh;
           rm ./pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,27 @@
+name: Mac and Windows Smoke
+
+run-name: ${{ github.actor }} is running smoke tests
+on:
+  pull_request:
+    types:
+      - created
+jobs:
+  Smoke-Windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          mkdir -p artifacts;
+          pip3 install 'pipenv==2023.11.15';
+          pip3 install 'ruff>=0.4.8,<0.5';
+          ./collect_executables.sh;
+          mv ./ci_pyproject.toml ./pyproject.toml;
+          pipenv install;
+      - name: Run Smoke Tests in Win
+        run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 .

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,8 +22,7 @@ jobs:
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
-          echo "@@@SHELL ${0}"
-          ./collect_executables.sh;
+          bash collect_executables.sh;
           rm ./pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Python 3.13
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -23,7 +23,7 @@ jobs:
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
           ./collect_executables.sh;
-          rm ./.pyproject.toml;
+          rm ./pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;
       - name: Run Smoke Tests in Win

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v3
         with:
           python-version: "3.11"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v3
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           mkdir -p artifacts;

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,6 +23,7 @@ jobs:
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
           ./collect_executables.sh;
+          rm ./.pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;
       - name: Run Smoke Tests in Win

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,7 +28,7 @@ jobs:
           pipenv install;
       - name: Run Smoke Tests in Win
         run: |
-          pipenv run pytest --fx-executable ./firefox/firefox -n 4 .
+          pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests/preferences
           mv artifacts artifacts-win
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,8 +8,10 @@ on:
   pull_request:
     types: created
 jobs:
-  Smoke-Windows:
-    runs-on: windows-latest
+  Smoke-Win-and-Mac:
+    runs-on:
+      - windows-latest
+      - macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,6 +28,11 @@ jobs:
           pipenv install;
       - name: Run Smoke Tests in Win
         run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 .
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test artifacts
+          path: artifacts
   Smoke-MacOS:
     runs-on: macos-latest
     steps:
@@ -47,4 +52,9 @@ jobs:
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;
       - name: Run Smoke Tests in MacOS
-        run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests/[amt]*
+        run: pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test artifacts
+          path: artifacts

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -7,7 +7,7 @@ echo "~~collect executables~~"
 ## Determine OS and arch
 UNAME_A=$(uname -a)
 echo "uname -a: ${UNAME_A}"
-if [ -n "$WSL_DISTRO_NAME" ]
+if [ -n "$WSL_DISTRO_NAME" ] || [[ $UNAME_A == *"MINGW"* ]]
 then
     SYSTEM_NAME="win"
 else

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -37,11 +37,6 @@ else
     fi
 fi
 
-if [[ "$SYSTEM_NAME" == "win" ]] && [[ -z $ARCH ]] && [[ $BITS = "64" ]]
-then
-    BITS=32
-fi
-
 if [[ $SYSTEM_NAME == "win" ]]
 then
     EXT="zip"

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "~~collect executables~~"
 
 # Usage: ./collect_executables.sh [channel]
 # Collects geckodriver and Fx, default channel is Beta.

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -10,6 +10,12 @@ echo "uname -a: ${UNAME_A}"
 if [ -n "$WSL_DISTRO_NAME" ] || [[ $UNAME_A == *"MINGW"* ]]
 then
     SYSTEM_NAME="win"
+    if [[ $UNAME_A == *"x86_64"* ]]
+    then
+        BITS="64"
+    else
+        BITS="32"
+    fi
 else
     if [[ $UNAME_A == *"Darwin"* ]]
     then
@@ -85,6 +91,7 @@ FX_LOC=$(echo "$FX_LINK_HTML" | awk -F '"' '{print $2}')
 
 curl -O "$FX_LOC"
 
+ls geckodriver*
 mv "geckodriver*.${EXT}" "geckodriver.${EXT}"
 if [[ $EXT == "zip" ]]
 then

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -44,13 +44,10 @@ fi
 
 # Find the version of Geckodriver that matches arch
 FILENAME="-${SYSTEM_NAME}${BITS}${ARCH}.${EXT}"
-echo "$FILENAME"
-
 # 20 is arbitrary and may break if future releases of Geckodriver have more than 20 channels
 for i in {0..20}
 do
     GECKO_LINK=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq ".[\"assets\"][${i}][\"browser_download_url\"]" | tr -d '"')
-    echo "$GECKO_LINK"
     if [[ $GECKO_LINK == *"${FILENAME}"* ]] && [[ $GECKO_LINK != *".asc" ]]
     then
         curl -OL "$GECKO_LINK"

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -50,9 +50,9 @@ echo "$FILENAME"
 for i in {0..20}
 do
     GECKO_LINK=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq ".[\"assets\"][${i}][\"browser_download_url\"]" | tr -d '"')
+    echo "$GECKO_LINK"
     if [[ $GECKO_LINK == *"${FILENAME}"* ]] && [[ $GECKO_LINK != *".asc" ]]
     then
-        echo "$GECKO_LINK"
         curl -OL "$GECKO_LINK"
     fi
 done

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -5,6 +5,7 @@
 
 ## Determine OS and arch
 UNAME_A=$(uname -a)
+echo "uname -a: ${UNAME_A}"
 if [ -n "$WSL_DISTRO_NAME" ]
 then
     SYSTEM_NAME="win"

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -86,8 +86,8 @@ FX_LOC=$(echo "$FX_LINK_HTML" | awk -F '"' '{print $2}')
 
 curl -O "$FX_LOC"
 
-ls geckodriver*
-mv "geckodriver*.${EXT}" "geckodriver.${EXT}"
+GD_FILE=$(ls geckodriver*)
+mv "$GD_FILE" "geckodriver.${EXT}"
 if [[ $EXT == "zip" ]]
 then
     unzip geckodriver.zip

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -83,6 +83,8 @@ FX_LOC=$(echo "$FX_LINK_HTML" | awk -F '"' '{print $2}')
 
 curl -O "$FX_LOC"
 
+sleep 3
+
 mv geckodriver*.tar.gz geckodriver.tar.gz
 tar -xvzf geckodriver.tar.gz
 chmod +x geckodriver

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -6,6 +6,7 @@ echo "~~collect executables~~"
 
 ## Determine OS and arch
 UNAME_A=$(uname -a)
+## Save the system arch info
 echo "uname -a: ${UNAME_A}"
 if [ -n "$WSL_DISTRO_NAME" ] || [[ $UNAME_A == *"MINGW"* ]]
 then

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -51,7 +51,6 @@ echo "FILENAME ${FILENAME}"
 for i in {0..20}
 do
     GECKO_LINK=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq ".[\"assets\"][${i}][\"browser_download_url\"]" | tr -d '"')
-    echo "$GECKO_LINK"
     if [[ $GECKO_LINK == *"${FILENAME}"* ]] && [[ $GECKO_LINK != *".asc" ]]
     then
         curl -OL "$GECKO_LINK"

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -94,6 +94,16 @@ then
 else
     tar -xvzf geckodriver.tar.gz
 fi
+
+# Wait up to 10 seconds for geckodriver to exist
+for ((i=0; i<200; i++))
+do
+    if [ -f geckodriver ]
+    then
+        break
+    fi
+    sleep 0.2
+done
 chmod +x geckodriver
 
 if [[ $SYSTEM_NAME == "linux" ]]

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -49,6 +49,7 @@ FILENAME="-${SYSTEM_NAME}${BITS}${ARCH}.${EXT}"
 for i in {0..20}
 do
     GECKO_LINK=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq ".[\"assets\"][${i}][\"browser_download_url\"]" | tr -d '"')
+    echo "$GECKO_LINK"
     if [[ $GECKO_LINK == *"${FILENAME}"* ]] && [[ $GECKO_LINK != *".asc" ]]
     then
         curl -OL "$GECKO_LINK"

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -43,6 +43,7 @@ fi
 
 # Find the version of Geckodriver that matches arch
 FILENAME="-${SYSTEM_NAME}${BITS}${ARCH}.${EXT}"
+echo "$FILENAME"
 
 # 20 is arbitrary and may break if future releases of Geckodriver have more than 20 channels
 for i in {0..20}
@@ -82,8 +83,6 @@ FX_LINK_HTML=$(curl -s https://download.mozilla.org/\?product\=firefox${CHANNEL}
 FX_LOC=$(echo "$FX_LINK_HTML" | awk -F '"' '{print $2}')
 
 curl -O "$FX_LOC"
-
-sleep 3
 
 mv geckodriver*.tar.gz geckodriver.tar.gz
 tar -xvzf geckodriver.tar.gz

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -45,6 +45,7 @@ fi
 
 # Find the version of Geckodriver that matches arch
 FILENAME="-${SYSTEM_NAME}${BITS}${ARCH}.${EXT}"
+echo "FILENAME ${FILENAME}"
 # 20 is arbitrary and may break if future releases of Geckodriver have more than 20 channels
 for i in {0..20}
 do
@@ -84,7 +85,7 @@ FX_LOC=$(echo "$FX_LINK_HTML" | awk -F '"' '{print $2}')
 
 curl -O "$FX_LOC"
 
-mv "geckodriver*.{$EXT}" "geckodriver.{$EXT}"
+mv "geckodriver*.${EXT}" "geckodriver.${EXT}"
 if [[ $EXT == "zip" ]]
 then
     unzip geckodriver.zip

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -84,8 +84,13 @@ FX_LOC=$(echo "$FX_LINK_HTML" | awk -F '"' '{print $2}')
 
 curl -O "$FX_LOC"
 
-mv geckodriver*.tar.gz geckodriver.tar.gz
-tar -xvzf geckodriver.tar.gz
+mv "geckodriver*.{$EXT}" "geckodriver.{$EXT}"
+if [[ $EXT == "zip" ]]
+then
+    unzip geckodriver.zip
+else
+    tar -xvzf geckodriver.tar.gz
+fi
 chmod +x geckodriver
 
 if [[ $SYSTEM_NAME == "linux" ]]

--- a/conftest.py
+++ b/conftest.py
@@ -182,7 +182,8 @@ def driver(
         yield driver
 
     finally:
-        driver.quit()
+        if "driver" in locals() or "driver" in globals():
+            driver.quit()
 
 
 @pytest.fixture()

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import platform
-from time import sleep
 from typing import Callable, List, Tuple
 
 import pytest

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import platform
+from time import sleep
 from typing import Callable, List, Tuple
 
 import pytest
@@ -166,6 +167,8 @@ def driver(
         options.binary_location = fx_executable
         for opt, value in set_prefs:
             options.set_preference(opt, value)
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            sleep(5)
         driver = webdriver.Firefox(options=options)
         separator = "x"
         if separator not in opt_window_size:

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Tuple
 
 import pytest
 from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.firefox.options import Options
 
 
@@ -167,8 +168,6 @@ def driver(
         options.binary_location = fx_executable
         for opt, value in set_prefs:
             options.set_preference(opt, value)
-        if os.environ.get("GITHUB_ACTIONS") == "true":
-            sleep(5)
         driver = webdriver.Firefox(options=options)
         separator = "x"
         if separator not in opt_window_size:
@@ -183,7 +182,8 @@ def driver(
         timeout = 30 if opt_ci else opt_implicit_timeout
         driver.implicitly_wait(timeout)
         yield driver
-
+    except WebDriverException as e:
+        print(f"exception: {e}")
     finally:
         if "driver" in locals() or "driver" in globals():
             driver.quit()

--- a/conftest.py
+++ b/conftest.py
@@ -183,7 +183,7 @@ def driver(
         driver.implicitly_wait(timeout)
         yield driver
     except WebDriverException as e:
-        print(f"exception: {e}")
+        logging.warning(f"DRIVER exception: {e}")
     finally:
         if "driver" in locals() or "driver" in globals():
             driver.quit()

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -78,7 +78,7 @@
     },
 
     "prefs-button": {
-        "selectorData": "button[label='{name}']",
+        "selectorData": "button[label^='{name}']",
         "strategy": "css",
         "groups": []
     },

--- a/modules/data/generic_page.components.json
+++ b/modules/data/generic_page.components.json
@@ -24,8 +24,8 @@
     },
 
     "wiki-search-bar": {
-        "selectorData": "searchInput",
-        "strategy": "id",
+        "selectorData": "cdx-text-input__input",
+        "strategy": "class",
         "groups": []
     },
 

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -24,4 +24,4 @@ tasks:
         ./collect_executables.sh;
         mv ./ci_pyproject.toml ./pyproject.toml;
         pipenv install;
-        pipenv run pytest --fx-executable ./firefox/firefox -n 4 .
+        pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests/sec*

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -24,4 +24,4 @@ tasks:
         ./collect_executables.sh;
         mv ./ci_pyproject.toml ./pyproject.toml;
         pipenv install;
-        pipenv run pytest --fx-executable ./firefox/firefox -n 4 tests/sec*
+        pipenv run pytest --fx-executable ./firefox/firefox -n 4 .

--- a/tests/address_bar_and_search/test_google_search_counts_us.py
+++ b/tests/address_bar_and_search/test_google_search_counts_us.py
@@ -1,12 +1,18 @@
+import sys
+from os import environ
 from time import sleep
 
+import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation
 from modules.page_object import AboutTelemetry
 from modules.util import Utilities
 
+MAC_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("darwin")
 
+
+@pytest.mark.skipif(MAC_GHA, reason="Test unstable in MacOS Github Actions")
 def test_google_search_counts_us(driver: Firefox):
     """
     C1365026, Test Google Search counts - urlbar US

--- a/tests/address_bar_and_search/test_google_search_counts_us.py
+++ b/tests/address_bar_and_search/test_google_search_counts_us.py
@@ -9,7 +9,7 @@ from modules.browser_object import Navigation
 from modules.page_object import AboutTelemetry
 from modules.util import Utilities
 
-MAC_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("darwin")
+MAC_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("darwin")
 
 
 @pytest.mark.skipif(MAC_GHA, reason="Test unstable in MacOS Github Actions")

--- a/tests/address_bar_and_search/test_google_withads_url_bar_us.py
+++ b/tests/address_bar_and_search/test_google_withads_url_bar_us.py
@@ -1,3 +1,5 @@
+import sys
+from os import environ
 from time import sleep
 
 import pytest
@@ -13,10 +15,7 @@ def add_prefs():
     return [("cookiebanners.service.mode", 1)]
 
 
-import sys
-from os import environ
-
-MAC_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("darwin")
+MAC_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("darwin")
 
 
 @pytest.mark.skipif(MAC_GHA, reason="Test unstable in MacOS Github Actions")

--- a/tests/address_bar_and_search/test_google_withads_url_bar_us.py
+++ b/tests/address_bar_and_search/test_google_withads_url_bar_us.py
@@ -13,6 +13,13 @@ def add_prefs():
     return [("cookiebanners.service.mode", 1)]
 
 
+import sys
+from os import environ
+
+MAC_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("darwin")
+
+
+@pytest.mark.skipif(MAC_GHA, reason="Test unstable in MacOS Github Actions")
 def test_google_withads_url_bar_us(driver: Firefox):
     """
     C1365070, verify that Google withads URL bar - US is recorder into telemetry

--- a/tests/language_packs/test_language_pack_install_preferences.py
+++ b/tests/language_packs/test_language_pack_install_preferences.py
@@ -1,3 +1,6 @@
+import sys
+from os import environ
+
 import pytest
 from selenium.webdriver import Firefox
 
@@ -6,9 +9,6 @@ from modules.util import BrowserActions
 
 LANGUAGES = [("it", "Imposta alternative…")]
 
-
-import sys
-from os import environ
 
 WIN_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("win")
 

--- a/tests/language_packs/test_language_pack_install_preferences.py
+++ b/tests/language_packs/test_language_pack_install_preferences.py
@@ -10,7 +10,7 @@ from modules.util import BrowserActions
 LANGUAGES = [("it", "Imposta alternative…")]
 
 
-WIN_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("win")
+WIN_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("win")
 
 
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")

--- a/tests/language_packs/test_language_pack_install_preferences.py
+++ b/tests/language_packs/test_language_pack_install_preferences.py
@@ -7,6 +7,13 @@ from modules.util import BrowserActions
 LANGUAGES = [("it", "Imposta alternative…")]
 
 
+import sys
+from os import environ
+
+WIN_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("win")
+
+
+@pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
 @pytest.mark.parametrize("shortform, localized_text", LANGUAGES)
 def test_language_pack_install_about_preferences(
     driver: Firefox, shortform: str, localized_text: str

--- a/tests/preferences/test_clear_cookie_data.py
+++ b/tests/preferences/test_clear_cookie_data.py
@@ -15,7 +15,7 @@ def test_clear_cookie_data(driver: Firefox):
     def open_clear_cookies_data_dialog():
         about_prefs.open()
         clear_data_popup = about_prefs.press_button_get_popup_dialog_iframe(
-            "Clear Data…"
+            "Clear Data"
         )
         ba.switch_to_iframe_context(clear_data_popup)
 

--- a/tests/tabs/test_mute_tabs.py
+++ b/tests/tabs/test_mute_tabs.py
@@ -1,4 +1,3 @@
-import sys
 from os import environ
 
 import pytest
@@ -7,10 +6,10 @@ from selenium.webdriver.common.by import By
 
 from modules.browser_object import TabBar
 
-WIN_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("win")
+GHA = environ.get("GITHUB_ACTIONS")
 
 
-@pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
+@pytest.mark.skipif(GHA, reason="Test unstable in Github Actions")
 @pytest.mark.audio
 def test_mute_unmute_tab(screenshot, driver: Firefox, video_url: str):
     """C134719, test that tabs can be muted and unmuted"""

--- a/tests/tabs/test_mute_tabs.py
+++ b/tests/tabs/test_mute_tabs.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 
 from modules.browser_object import TabBar
 
-GHA = environ.get("GITHUB_ACTIONS")
+GHA = environ.get("GITHUB_ACTIONS") == "true"
 
 
 @pytest.mark.skipif(GHA, reason="Test unstable in Github Actions")

--- a/tests/tabs/test_mute_tabs.py
+++ b/tests/tabs/test_mute_tabs.py
@@ -1,10 +1,16 @@
+import sys
+from os import environ
+
 import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
 
 from modules.browser_object import TabBar
 
+WIN_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("win")
 
+
+@pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
 @pytest.mark.audio
 def test_mute_unmute_tab(screenshot, driver: Firefox, video_url: str):
     """C134719, test that tabs can be muted and unmuted"""

--- a/tests/tabs/test_navigation_multiple_tabs.py
+++ b/tests/tabs/test_navigation_multiple_tabs.py
@@ -7,7 +7,7 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import TabBar
 
-WIN_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("win")
+WIN_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("win")
 
 
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")

--- a/tests/tabs/test_navigation_multiple_tabs.py
+++ b/tests/tabs/test_navigation_multiple_tabs.py
@@ -1,10 +1,16 @@
 import logging
+import sys
+from os import environ
 
+import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import TabBar
 
+WIN_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("win")
 
+
+@pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
 def test_navigation_multiple_tabs(driver: Firefox):
     # open 20 tabs
     tabs = TabBar(driver).open()

--- a/tests/theme_and_toolbar/test_installed_theme_enabled.py
+++ b/tests/theme_and_toolbar/test_installed_theme_enabled.py
@@ -6,7 +6,7 @@ from selenium.webdriver import Firefox
 
 from modules.page_object import AboutAddons, AmoThemes
 
-MAC_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("darwin")
+MAC_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("darwin")
 
 
 @pytest.mark.skipif(MAC_GHA, reason="Test unstable in MacOS Github Actions")

--- a/tests/theme_and_toolbar/test_installed_theme_enabled.py
+++ b/tests/theme_and_toolbar/test_installed_theme_enabled.py
@@ -1,3 +1,7 @@
+import sys
+from os import environ
+
+import pytest
 from selenium.webdriver import Firefox
 
 from modules.page_object import AboutAddons, AmoThemes
@@ -18,6 +22,10 @@ def test_find_more_themes(driver: Firefox):
     base.url_contains("firefox/themes")
 
 
+MAC_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("darwin")
+
+
+@pytest.mark.skipif(MAC_GHA, reason="Test unstable in MacOS Github Actions")
 def test_installed_theme_enabled(driver: Firefox):
     """
     C118174: install a theme and make sure it is set to enabled immediately

--- a/tests/theme_and_toolbar/test_installed_theme_enabled.py
+++ b/tests/theme_and_toolbar/test_installed_theme_enabled.py
@@ -6,7 +6,10 @@ from selenium.webdriver import Firefox
 
 from modules.page_object import AboutAddons, AmoThemes
 
+MAC_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("darwin")
 
+
+@pytest.mark.skipif(MAC_GHA, reason="Test unstable in MacOS Github Actions")
 def test_find_more_themes(driver: Firefox):
     """
     C118174, first part
@@ -20,9 +23,6 @@ def test_find_more_themes(driver: Firefox):
     base = about_addons
     base.url_contains("addons.mozilla.org")
     base.url_contains("firefox/themes")
-
-
-MAC_GHA = environ.get("GITHUB_ACTIONS") and sys.platform.startswith("darwin")
 
 
 @pytest.mark.skipif(MAC_GHA, reason="Test unstable in MacOS Github Actions")


### PR DESCRIPTION
# Description

- Adds GHA workflows
- Adds a Windows workflow that collects executables and runs tests against them
- Same, but for MacOS
- Marks tests that are unstable in Win
- Marks tests that are unstable in MacOS

## Bugzilla bug ID

**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1904374

## Type of change

Please delete options that are not relevant.

- [x] CI improvements

# How does this resolve / make progress on that bug?

Above and beyond that bug--more than a proof of concept, this is a full implementation of CI in Win and MacOS using Github Actions.

# Screenshots / Explanations

![Screenshot 2024-07-22 at 13 37 11](https://github.com/user-attachments/assets/7078f98e-b41f-42f5-a6be-1018fb2a910a)
![Screenshot 2024-07-22 at 13 37 20](https://github.com/user-attachments/assets/b51d957b-c497-433b-b087-c044dba3b908)
![Screenshot 2024-07-22 at 13 37 34](https://github.com/user-attachments/assets/15662aa4-378e-4564-82b1-f5c077f8744f)

# Comments / Concerns

While artifacts including the report are uploaded, they are zipped. In order to integrate with Slack reporting, we'll need to figure out how to upload without a zip, or unzip it in a workflow.
