### PR TITLE
As/awesome bar doesn't recognized visited pb sites

### DIFF
--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -220,5 +220,17 @@
         "selectorData": "identity-popup-more-info",
         "strategy": "id",
         "groups": []
+    },
+
+    "search-result-url": {
+        "selectorData": ".urlbarView-title.urlbarView-overflowable[is-url='']",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "search-result-action-term": {
+        "selectorData": ".urlbarView-action",
+        "strategy": "css",
+        "groups": []
     }
 }

--- a/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
+++ b/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
@@ -1,4 +1,3 @@
-import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation

--- a/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
+++ b/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
@@ -9,11 +9,6 @@ FACEBOOK_URL = "https://www.facebook.com/"
 AMAZON_URL = "https://www.amazon.com/"
 
 
-@pytest.fixture()
-def add_prefs():
-    return []
-
-
 def test_websites_visited_in_private_browser_not_displayed_in_awesome_bar(
     driver: Firefox,
 ):

--- a/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
+++ b/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
@@ -1,0 +1,45 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation
+from modules.browser_object_panel_ui import PanelUi
+
+YOUTUBE_URL = "https://www.youtube.com/"
+FACEBOOK_URL = "https://www.facebook.com/"
+AMAZON_URL = "https://www.amazon.com/"
+
+
+@pytest.fixture()
+def add_prefs():
+    return []
+
+
+def test_websites_visited_in_private_browser_not_displayed_in_awesome_bar(
+    driver: Firefox,
+):
+    """
+    C101665 - Verify the visited websites from the Private Browsing session are not displayed inside the normal session
+    Awesome Bar
+    """
+
+    initial_window_handle = driver.current_window_handle
+
+    nav = Navigation(driver)
+    panel_ui = PanelUi(driver)
+    panel_ui.open_private_window()
+    panel_ui.switch_to_new_window()
+
+    for url in [YOUTUBE_URL, FACEBOOK_URL, AMAZON_URL]:
+        driver.get(url)
+
+    driver.switch_to.window(initial_window_handle)
+
+    for url in [YOUTUBE_URL, FACEBOOK_URL, AMAZON_URL]:
+        nav.type_in_awesome_bar(url)
+        url_element = nav.get_element("search-result-url")
+        action_element = nav.get_element("search-result-action-term")
+
+        # Check that the URLS are displayed in search results with the term "Visit"
+        assert (url_element.text, action_element.text) == (url, "Visit")
+
+        nav.clear_awesome_bar()

--- a/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
+++ b/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
@@ -7,6 +7,8 @@ YOUTUBE_URL = "https://www.youtube.com/"
 FACEBOOK_URL = "https://www.facebook.com/"
 AMAZON_URL = "https://www.amazon.com/"
 
+WEBSITES = [YOUTUBE_URL, FACEBOOK_URL, AMAZON_URL]
+
 
 def test_websites_visited_in_private_browser_not_displayed_in_awesome_bar(
     driver: Firefox,
@@ -17,18 +19,18 @@ def test_websites_visited_in_private_browser_not_displayed_in_awesome_bar(
     """
 
     initial_window_handle = driver.current_window_handle
-
     nav = Navigation(driver)
     panel_ui = PanelUi(driver)
+
     panel_ui.open_private_window()
     panel_ui.switch_to_new_window()
 
-    for url in [YOUTUBE_URL, FACEBOOK_URL, AMAZON_URL]:
+    for url in WEBSITES:
         driver.get(url)
 
     driver.switch_to.window(initial_window_handle)
 
-    for url in [YOUTUBE_URL, FACEBOOK_URL, AMAZON_URL]:
+    for url in WEBSITES:
         nav.type_in_awesome_bar(url)
         url_element = nav.get_element("search-result-url")
         action_element = nav.get_element("search-result-action-term")


### PR DESCRIPTION
# Description
Checks that visited websites in Private Browsing session are not displayed inside the normal session Awesome Bar address list

## Bugzilla bug ID

**Testrail: https://testrail.stage.mozaws.net/index.php?/cases/view/101665**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1905180**
 
## Type of change

Please delete options that are not relevant.

- [x ] New Test

# How does this resolve / make progress on that bug?
Completed

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
