### PR TITLE
Cookies are not Saved Private Browsing

### DIFF
--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -240,6 +240,18 @@
         "groups": []
     },
 
+    "cookies-manage-data": {
+        "selectorData": "siteDataSettings",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "cookies-manage-data-sitelist": {
+        "selectorData": "sitesList",
+        "strategy": "id",
+        "groups": []
+    },
+
     "tracking-checkbox": {
         "selectorData": "contentBlockingTrackingProtectionCheckbox",
         "strategy": "id",

--- a/modules/data/generic_page.components.json
+++ b/modules/data/generic_page.components.json
@@ -21,5 +21,17 @@
         "selectorData": "mw-mmv-image",
         "strategy": "class",
         "groups": []
+    },
+
+    "wiki-search-bar": {
+        "selectorData": "searchInput",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "wiki-search-button": {
+        "selectorData": "button[class='cdx-button cdx-button--action-default cdx-button--weight-normal cdx-button--size-medium cdx-button--framed cdx-search-input__end-button']",
+        "strategy": "css",
+        "groups": []
     }
 }

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -551,6 +551,16 @@ class BasePage(Page):
             logging.warn("Timeout waiting for the number of windows to be:", num_tabs)
         return self
 
+    def wait_for_no_children(
+        self, parent: Union[str, tuple, WebElement], labels=[]
+    ) -> Page:
+        """
+        Waits for 0 children under the given parent, the wait is instant
+        """
+        self.instawait.until(
+            lambda _: len(self.get_all_children(self.fetch(parent, labels))) == 0
+        )
+
     def switch_to_new_tab(self) -> Page:
         """Get list of all window handles, switch to the newly opened tab"""
         handles = self.driver.window_handles

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -541,6 +541,19 @@ class BasePage(Page):
             children = element.find_elements(By.XPATH, "./*")
         return children
 
+    def wait_for_no_children(
+        self, parent: Union[str, tuple, WebElement], labels=[]
+    ) -> Page:
+        """
+        Waits for 0 children under the given parent, the wait is instant (note, this changes the driver implicit wait and changes it back)
+        """
+        driver_wait = self.driver.timeouts.implicit_wait
+        self.driver.implicitly_wait(0)
+        try:
+            assert len(self.get_all_children(self.fetch(parent, labels))) == 0
+        finally:
+            self.driver.implicitly_wait(driver_wait)
+
     def wait_for_num_tabs(self, num_tabs: int) -> Page:
         """
         Waits for the driver.window_handles to be updated accordingly with the number of tabs requested
@@ -550,16 +563,6 @@ class BasePage(Page):
         except TimeoutException:
             logging.warn("Timeout waiting for the number of windows to be:", num_tabs)
         return self
-
-    def wait_for_no_children(
-        self, parent: Union[str, tuple, WebElement], labels=[]
-    ) -> Page:
-        """
-        Waits for 0 children under the given parent, the wait is instant
-        """
-        self.instawait.until(
-            lambda _: len(self.get_all_children(self.fetch(parent, labels))) == 0
-        )
 
     def switch_to_new_tab(self) -> Page:
         """Get list of all window handles, switch to the newly opened tab"""

--- a/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
+++ b/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
@@ -1,10 +1,10 @@
-import logging
-from time import sleep
+
 from selenium.webdriver import Firefox
 
+from modules.browser_object import Navigation, PanelUi
 from modules.page_object import AboutPrefs, GenericPage
-from modules.browser_object import Navigation, TabBar, PanelUi
 from modules.util import BrowserActions
+
 
 def test_cookies_not_saved_private_browsing(driver: Firefox):
     """
@@ -14,7 +14,9 @@ def test_cookies_not_saved_private_browsing(driver: Firefox):
     about_prefs = AboutPrefs(driver, category="privacy")
     panel_ui = PanelUi(driver).open()
     nav = Navigation(driver)
-    wiki_page = GenericPage(driver, url="https://ro.wikipedia.org/wiki/Pagina_principal%C4%83")
+    wiki_page = GenericPage(
+        driver, url="https://ro.wikipedia.org/wiki/Pagina_principal%C4%83"
+    )
     ba = BrowserActions(driver)
 
     # open new private window

--- a/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
+++ b/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
@@ -1,0 +1,46 @@
+import logging
+from time import sleep
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutPrefs, GenericPage
+from modules.browser_object import Navigation, TabBar, PanelUi
+from modules.util import BrowserActions
+
+def test_cookies_not_saved_private_browsing(driver: Firefox):
+    """
+    C101677: ensure that cookies are not saved after using private browsing
+    """
+    # instantiate objs
+    about_prefs = AboutPrefs(driver, category="privacy")
+    panel_ui = PanelUi(driver).open()
+    nav = Navigation(driver)
+    wiki_page = GenericPage(driver, url="https://ro.wikipedia.org/wiki/Pagina_principal%C4%83")
+    ba = BrowserActions(driver)
+
+    # open new private window
+    panel_ui.open_private_window()
+    nav.switch_to_new_window()
+
+    # open the wiki page and perform a search
+    wiki_page.open()
+    wiki_search_bar = wiki_page.get_element("wiki-search-bar")
+    wiki_search_bar.send_keys("hello")
+    wiki_page.get_element("wiki-search-button").click()
+    wiki_page.wait_for_page_to_load()
+
+    # close the page and switch to first tab
+    driver.close()
+    driver.switch_to.window(driver.window_handles[0])
+    about_prefs.open()
+
+    # get the cookies
+    about_prefs.get_element("cookies-manage-data").click()
+    iframe = about_prefs.get_iframe()
+    ba.switch_to_iframe_context(iframe)
+
+    # ensure none are listed
+    sitelist = about_prefs.get_element("cookies-manage-data-sitelist")
+    sites = about_prefs.get_all_children(sitelist)
+
+    # note when there are 0 children, this is a bit slow
+    assert len(sites) == 0

--- a/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
+++ b/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
@@ -1,4 +1,3 @@
-
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation, PanelUi

--- a/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
+++ b/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
@@ -39,9 +39,5 @@ def test_cookies_not_saved_private_browsing(driver: Firefox):
     iframe = about_prefs.get_iframe()
     ba.switch_to_iframe_context(iframe)
 
-    # ensure none are listed
-    sitelist = about_prefs.get_element("cookies-manage-data-sitelist")
-    sites = about_prefs.get_all_children(sitelist)
-
-    # note when there are 0 children, this is a bit slow
-    assert len(sites) == 0
+    # wait for no children listed in the cookies menu
+    about_prefs.wait_for_no_children("cookies-manage-data-sitelist")

--- a/tests/security_and_privacy/test_open_link_in_private_window.py
+++ b/tests/security_and_privacy/test_open_link_in_private_window.py
@@ -1,4 +1,3 @@
-
 from selenium.webdriver import Firefox
 
 from modules.browser_object import ContextMenu, Navigation

--- a/tests/security_and_privacy/test_open_link_in_private_window.py
+++ b/tests/security_and_privacy/test_open_link_in_private_window.py
@@ -1,10 +1,8 @@
-import logging
 
-import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import ContextMenu, Navigation
-from modules.page_object import ExamplePage, GenericPage
+from modules.page_object import ExamplePage
 
 
 def test_open_link_in_private_window(driver: Firefox):

--- a/tests/tabs/test_pin_tab.py
+++ b/tests/tabs/test_pin_tab.py
@@ -1,4 +1,3 @@
-
 from selenium.webdriver import Firefox
 
 from modules.browser_object import TabBar, TabContextMenu

--- a/tests/tabs/test_pin_tab.py
+++ b/tests/tabs/test_pin_tab.py
@@ -1,4 +1,3 @@
-import logging
 
 from selenium.webdriver import Firefox
 


### PR DESCRIPTION
# Description

Ensures that cookies are not saved in private browsing

## Bugzilla bug ID

**Testrail:** https://testrail.stage.mozaws.net/index.php?/cases/view/101677
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1905186

## Type of change

- [x] New Test

# How does this resolve / make progress on that bug?

Finishes

# Screenshots / Explanations

N/A

# Comments / Concerns

The `get_all_children` method is slow when there are no children. This causes the test to run ~10 seconds but that is expected behaviour. Perhaps there is a way to fix this?
