### PR TITLE
As/ blocking social media trackers

### DIFF
--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -188,6 +188,6 @@ class Navigation(BasePage):
         """
         Clicks the shield icon and opens the panel associated with it
         """
-        # self.set_chrome_context()
-        self.get_element("shield-icon").click()
-        return self
+        with self.driver.context(self.context_id):
+            self.get_element("shield-icon").click()
+            return self

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -240,6 +240,12 @@
         "groups": []
     },
 
+    "cookies-second-menu-item": {
+        "selectorData": "isolateCookiesSocialMedia",
+        "strategy": "id",
+        "groups": []
+    },
+
     "cookies-manage-data": {
         "selectorData": "siteDataSettings",
         "strategy": "id",

--- a/modules/data/tracker_panel.components.json
+++ b/modules/data/tracker_panel.components.json
@@ -61,5 +61,17 @@
             "doNotCache",
             "requiredForPage"
         ]
+    },
+
+    "social-media-tracker-content": {
+        "selectorData": "protections-popup-category-socialblock",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "social-media-subview": {
+        "selectorData": "protections-popup-socialblockView",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/security_and_privacy/test_blocking_social_media_trackers.py
+++ b/tests/security_and_privacy/test_blocking_social_media_trackers.py
@@ -1,0 +1,46 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_navigation import Navigation
+from modules.browser_object_tracker_panel import TrackerPanel
+from modules.page_object_about_prefs import AboutPrefs
+
+SOCIAL_MEDIA_TRACKERS_URL = "https://panopticlick.eff.org/"
+# SOCIAL_MEDIA_TRACKERS_URL = "https://www.facebook.com/"  # alternative site
+
+
+@pytest.fixture()
+def add_prefs():
+    return [
+        ("network.cookie.cookieBehavior", 0),
+        ("privacy.trackingprotection.pbmode.enabled", False),
+        ("privacy.trackingprotection.cryptomining.enabled", False),
+        ("privacy.trackingprotection.fingerprinting.enabled", False),
+        ("privacy.fingerprintingProtection.pbmode", False),
+    ]
+
+
+@pytest.mark.xfail  # blocked by bug 1866005
+def test_blocking_social_media_trackers(driver: Firefox):
+    """
+    C446406: Ensure that ETP Custom mode with the option "Cross-site tracking cookies, and isolate other
+    cross-site cookies" set in the Cookies section blocks social media trackers.
+    """
+    nav = Navigation(driver)
+    tracker_panel = TrackerPanel(driver)
+    about_prefs = AboutPrefs(driver, category="privacy").open()
+
+    about_prefs.get_element("cookies-checkbox")
+    about_prefs.get_element("cookies-second-menu-item").click()
+
+    driver.get(SOCIAL_MEDIA_TRACKERS_URL)
+    nav.open_tracker_panel()
+
+    driver.set_context(driver.CONTEXT_CHROME)
+
+    tracker_panel.get_element("social-media-tracker-content").click()
+    social_media_subview_title = tracker_panel.get_element("social-media-subview")
+    assert (
+        social_media_subview_title.get_attribute("title")
+        == "Social Media Trackers Blocked"
+    )

--- a/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
+++ b/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
@@ -2,7 +2,7 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation, PanelUi
-from modules.page_object import AboutPrefs, GenericPage, GoogleSearch
+from modules.page_object import AboutPrefs, GoogleSearch
 from modules.util import BrowserActions
 
 


### PR DESCRIPTION
# Description

Verify that ETP Custom mode with the option "Cross-site tracking cookies, and isolate other cross-site cookies" set in the Cookies section blocks social media trackers.

## Bugzilla bug ID

**Testrail: https://testrail.stage.mozaws.net/index.php?/cases/view/446406**
**Link : https://bugzilla.mozilla.org/show_bug.cgi?id=1905201**

## Type of change

Please delete options that are not relevant.

- [ x] New Test

# How does this resolve / make progress on that bug?
Completed

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns
Marked with xfail  due to bug [1866005](https://bugzilla.mozilla.org/show_bug.cgi?id=1866005).

Please add a short blurb about any comments or concerns that this change might cause.
