### PR TITLE
Detected blocked trackers 

### DIFF
--- a/modules/browser_object_tracker_panel.py
+++ b/modules/browser_object_tracker_panel.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Set
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.remote.webelement import WebElement
@@ -14,6 +14,58 @@ class TrackerPanel(BasePage):
     """
 
     URL_TEMPLATE = ""
+
+    def verify_allowed_blocked_trackers(
+        self, allowed: Set[str], blocked: Set[str]
+    ) -> bool:
+        """
+        Given two sets of strings, one representing the allowed names of the type of trackers and one representing the blocked types of trackres,
+        this function will return True if the tracking panel matches all of the entries in the sets, False if otherwise.
+
+        Note: Strings in the set MUST be exactly the ones displayed in the tracker panel, otherwise this might fail.
+
+        Example usage:
+        blocked = set(["Cross-Site Tracking Cookies"])
+        allowed = set(["Tracking Content"])
+
+        assert tracker_panel.verify_allowed_blocked_trackers(allowed, blocked)
+        """
+        rm_blocked = False
+        rm_allowed = False
+
+        tracker_item_container = self.get_element("tracking-item-container")
+        all_tracking_items = self.get_all_children(tracker_item_container)
+
+        for item in all_tracking_items:
+            # encounter a header (everything after it is blocked/allowed in the list)
+            inner_html = item.get_attribute("innerHTML")
+            if "Blocked" in inner_html:
+                rm_blocked = True
+                continue
+            elif "Allowed" in inner_html:
+                rm_allowed = True
+                rm_blocked = False
+                continue
+
+            # assign a temp memory location, assign the set to it depending on the header seen earlier
+            rm_set = set()
+            to_rm_item = ""
+            if rm_blocked:
+                rm_set = blocked
+            elif rm_allowed:
+                rm_set = allowed
+
+            # go through the possible strings to look for, remove it if appropriate
+            for item in rm_set:
+                if item in inner_html:
+                    to_rm_item = item
+                    break
+            if to_rm_item != "":
+                rm_set.remove(to_rm_item)
+
+        if len(blocked) == 0 and len(allowed) == 0:
+            return True
+        return False
 
     def wait_for_blocked_tracking_icon(
         self, nav: Navigation, page: BasePage
@@ -48,6 +100,35 @@ class TrackerPanel(BasePage):
             logging.warning(
                 "The shield icon was not active after refreshing mulitple times, the test has timed out."
             )
+        return self
+
+    def wait_for_trackers(self, nav: Navigation, page: BasePage) -> BasePage:
+        """
+        Waits for trackers to appear
+
+        Remember to open the passed in page beforehand, this waits for the page to load.
+
+        Example Usage:
+        first_tracker_website.open()
+        tracker_panel.wait_for_blocked_tracking_icon(nav, first_tracker_website)
+        """
+
+        def message_not_present() -> bool:
+            nav.get_element("refresh-button").click()
+            with self.driver.context(self.driver.CONTEXT_CONTENT):
+                page.open()
+                page.wait_for_page_to_load()
+            self.get_element("shield-icon").click()
+            no_trackers_message = self.get_element("no-trackers-message")
+            if no_trackers_message.get_attribute("hidden") == "true":
+                return True
+            return False
+
+        try:
+            with self.driver.context(self.context_id):
+                self.wait.until(lambda _: message_not_present())
+        except TimeoutException:
+            logging.warning("No trackers were ever detected after the timeout period.")
         return self
 
     def verify_tracker_shield_indicator(self, nav: Navigation) -> BasePage:

--- a/modules/browser_object_tracker_panel.py
+++ b/modules/browser_object_tracker_panel.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Set
+from typing import List, Set, Optional
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.remote.webelement import WebElement
@@ -16,7 +16,7 @@ class TrackerPanel(BasePage):
     URL_TEMPLATE = ""
 
     def verify_allowed_blocked_trackers(
-        self, allowed: Set[str], blocked: Set[str]
+        self, allowed: Optional[Set[str]] = None, blocked: Optional[Set[str]] = None
     ) -> bool:
         """
         Given two sets of strings, one representing the allowed names of the type of trackers and one representing the blocked types of trackres,
@@ -30,6 +30,11 @@ class TrackerPanel(BasePage):
 
         assert tracker_panel.verify_allowed_blocked_trackers(allowed, blocked)
         """
+        if allowed is None:
+            allowed = set()
+        if blocked is None:
+            blocked = set()
+
         rm_blocked = False
         rm_allowed = False
 

--- a/modules/browser_object_tracker_panel.py
+++ b/modules/browser_object_tracker_panel.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Set, Optional
+from typing import List, Optional, Set
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.remote.webelement import WebElement

--- a/modules/browser_object_tracker_panel.py
+++ b/modules/browser_object_tracker_panel.py
@@ -19,7 +19,7 @@ class TrackerPanel(BasePage):
         self, allowed: Optional[Set[str]] = None, blocked: Optional[Set[str]] = None
     ) -> bool:
         """
-        Given two sets of strings, one representing the allowed names of the type of trackers and one representing the blocked types of trackres,
+        Given two sets of strings, one representing the allowed names of the type of trackers and one representing the blocked types of trackers,
         this function will return True if the tracking panel matches all of the entries in the sets, False if otherwise.
 
         Note: Strings in the set MUST be exactly the ones displayed in the tracker panel, otherwise this might fail.

--- a/modules/data/tracker_panel.components.json
+++ b/modules/data/tracker_panel.components.json
@@ -54,6 +54,18 @@
         "groups": []
     },
 
+    "tracking-item-container": {
+        "selectorData": "protections-popup-category-list",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "tracking-item-container-label": {
+        "selectorData": "protections-popup-cookies-category-label",
+        "strategy": "id",
+        "groups": []
+    },
+
     "shield-icon": {
         "selectorData": "tracking-protection-icon-container",
         "strategy": "id",

--- a/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
+++ b/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
@@ -2,7 +2,7 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation, PanelUi
-from modules.page_object import AboutPrefs, GenericPage, GoogleSearch
+from modules.page_object import AboutPrefs, GoogleSearch
 from modules.util import BrowserActions
 
 

--- a/tests/security_and_privacy/test_detected_blocked_trackers_found.py
+++ b/tests/security_and_privacy/test_detected_blocked_trackers_found.py
@@ -1,0 +1,12 @@
+from time import sleep
+
+from selenium.webdriver import Firefox
+
+from modules.browser_object_navigation import Navigation
+from modules.page_object_about_prefs import AboutPrefs
+
+def test_detected_blocked_trackers_found(driver: Firefox):
+    """
+    C446392: Ensure that the correct trackers are allowed and blocked
+    """
+    pass

--- a/tests/security_and_privacy/test_detected_blocked_trackers_found.py
+++ b/tests/security_and_privacy/test_detected_blocked_trackers_found.py
@@ -1,14 +1,21 @@
+import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation, TrackerPanel
 from modules.page_object import GenericPage
 
+urls = [
+    "https://www.bbc.com/",
+    "https://senglehardt.com/test/trackingprotection/test_pages/tracking_protection",
+]
 
-def test_detected_blocked_trackers_found(driver: Firefox):
+
+@pytest.mark.parametrize("url", urls)
+def test_detected_blocked_trackers_found(driver: Firefox, url: str):
     """
     C446392: Ensure that the correct trackers are allowed and blocked
     """
-    generic_page = GenericPage(driver, url="https://www.bbc.com/")
+    generic_page = GenericPage(driver, url=url)
     tracker_panel = TrackerPanel(driver)
     nav = Navigation(driver).open()
 

--- a/tests/security_and_privacy/test_detected_blocked_trackers_found.py
+++ b/tests/security_and_privacy/test_detected_blocked_trackers_found.py
@@ -1,12 +1,26 @@
-from time import sleep
-
 from selenium.webdriver import Firefox
 
-from modules.browser_object_navigation import Navigation
-from modules.page_object_about_prefs import AboutPrefs
+from modules.browser_object import Navigation, TrackerPanel
+from modules.page_object import GenericPage
+
 
 def test_detected_blocked_trackers_found(driver: Firefox):
     """
     C446392: Ensure that the correct trackers are allowed and blocked
     """
-    pass
+    generic_page = GenericPage(driver, url="https://www.bbc.com/")
+    tracker_panel = TrackerPanel(driver)
+    nav = Navigation(driver).open()
+
+    generic_page.open()
+    tracker_panel.wait_for_blocked_tracking_icon(nav, generic_page)
+    driver.set_context(driver.CONTEXT_CHROME)
+    nav.open_tracker_panel()
+
+    # instantiate test specific objs
+    blocked = set(["Cross-Site Tracking Cookies"])
+    allowed = set(["Tracking Content"])
+
+    # verify the types of trackers
+    if not tracker_panel.verify_allowed_blocked_trackers(allowed, blocked):
+        assert False, "The expected types of trackers were not in the correct section."


### PR DESCRIPTION
# Description

Ensures that on certain websites, the correct type of trackers are listed as "Allowed" and "Blocked"

## Bugzilla bug ID

**Testrail:** https://testrail.stage.mozaws.net/index.php?/cases/view/446392
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1905195

## Type of change

- [x] New Test

# How does this resolve / make progress on that bug?

Finishes

# Screenshots / Explanations

N/A

# Comments / Concerns

Another test uses the method I created in the BOM in this PR. Since the method is reuseable, in the future `test_trackers_crypto_fingerprint_blocked` will have to be refactored to use it. 
