### PR TITLE
Bc/private downloads

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,6 +21,7 @@ jobs:
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
           bash collect_executables.sh;
+          sleep 3;
           rm ./pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;
@@ -48,6 +49,7 @@ jobs:
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
           bash collect_executables.sh;
+          sleep 3;
           rm ./pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;

--- a/collect_executables.sh
+++ b/collect_executables.sh
@@ -105,6 +105,7 @@ do
     sleep 0.2
 done
 chmod +x geckodriver
+./geckodriver --version
 
 if [[ $SYSTEM_NAME == "linux" ]]
 then

--- a/modules/browser_object.py
+++ b/modules/browser_object.py
@@ -1,3 +1,4 @@
+from modules.browser_object_about_downloads_context_menu import *
 from modules.browser_object_about_prefs_cc_popup import *
 from modules.browser_object_autofill_popup import *
 from modules.browser_object_credit_card_popup import *
@@ -10,7 +11,5 @@ from modules.browser_object_panel_ui import *
 from modules.browser_object_search_bar_context_menu import *
 from modules.browser_object_tab_context_menu import *
 from modules.browser_object_tabbar import *
-from modules.browser_object_tracker_panel import *
-
-from modules.browser_object_about_downloads_context_menu import *
 from modules.browser_object_toolbar import *
+from modules.browser_object_tracker_panel import *

--- a/modules/browser_object.py
+++ b/modules/browser_object.py
@@ -11,3 +11,6 @@ from modules.browser_object_search_bar_context_menu import *
 from modules.browser_object_tab_context_menu import *
 from modules.browser_object_tabbar import *
 from modules.browser_object_tracker_panel import *
+
+from modules.browser_object_about_downloads_context_menu import *
+from modules.browser_object_toolbar import *

--- a/modules/browser_object_about_downloads_context_menu.py
+++ b/modules/browser_object_about_downloads_context_menu.py
@@ -1,5 +1,7 @@
-from modules.browser_object_context_menu import ContextMenu
 import logging
+
+from modules.browser_object_context_menu import ContextMenu
+
 
 class AboutDownloadsContextMenu(ContextMenu):
     """
@@ -7,7 +9,9 @@ class AboutDownloadsContextMenu(ContextMenu):
     """
 
     def has_all_options_available(self) -> bool:
-        for elname in [k for k, v in self.elements.items() if "downloadOption" in v["groups"]]:
+        for elname in [
+            k for k, v in self.elements.items() if "downloadOption" in v["groups"]
+        ]:
             logging.info(f"elname {elname}")
-            self.element_visible(elname)
+            self.element_exists(elname)
         return True

--- a/modules/browser_object_about_downloads_context_menu.py
+++ b/modules/browser_object_about_downloads_context_menu.py
@@ -1,0 +1,13 @@
+from modules.browser_object_context_menu import ContextMenu
+import logging
+
+class AboutDownloadsContextMenu(ContextMenu):
+    """
+    Browser object model for the context menu for right clicking a download in About:Downloads
+    """
+
+    def has_all_options_available(self) -> bool:
+        for elname in [k for k, v in self.elements.items() if "downloadOption" in v["groups"]]:
+            logging.info(f"elname {elname}")
+            self.element_visible(elname)
+        return True

--- a/modules/browser_object_about_downloads_context_menu.py
+++ b/modules/browser_object_about_downloads_context_menu.py
@@ -8,10 +8,12 @@ class AboutDownloadsContextMenu(ContextMenu):
     Browser object model for the context menu for right clicking a download in About:Downloads
     """
 
-    def has_all_options_available(self) -> bool:
-        for elname in [
-            k for k, v in self.elements.items() if "downloadOption" in v["groups"]
-        ]:
-            logging.info(f"elname {elname}")
-            self.element_exists(elname)
-        return True
+    def has_all_options_available(self) -> ContextMenu:
+        """Timeout unless all items labeled downloadOption are present, else return self"""
+        with self.driver.context(self.context_id):
+            for elname in [
+                k for k, v in self.elements.items() if "downloadOption" in v["groups"]
+            ]:
+                logging.info(f"elname {elname}")
+                self.element_exists(elname)
+        return self

--- a/modules/browser_object_toolbar.py
+++ b/modules/browser_object_toolbar.py
@@ -6,9 +6,12 @@ from modules.page_base import BasePage
 
 
 class Toolbar(BasePage):
+    """BOM for the toolbar, other than the awesome bar and the panel UI"""
+
     URL_TEMPLATE = ""
 
     def wait_for_item_to_download(self, filename: str) -> BasePage:
+        """Check the downloads tool in the toolbar to wait for a given file to download"""
         original_timeout = self.driver.timeouts.implicit_wait
         try:
             # Whatever our timeout, we want to lengthen it because downloads

--- a/modules/browser_object_toolbar.py
+++ b/modules/browser_object_toolbar.py
@@ -1,0 +1,9 @@
+from modules.page_base import BasePage
+
+class Toolbar(BasePage):
+
+    URL_TEMPLATE = ""
+
+    def wait_for_item_to_download(self, filename: str) -> BasePage:
+        self.element_visible("downloads-item-by-file", labels=[filename])
+        return self

--- a/modules/browser_object_toolbar.py
+++ b/modules/browser_object_toolbar.py
@@ -1,9 +1,30 @@
+from time import sleep
+
+from selenium.webdriver.support import expected_conditions as EC
+
 from modules.page_base import BasePage
 
-class Toolbar(BasePage):
 
+class Toolbar(BasePage):
     URL_TEMPLATE = ""
 
     def wait_for_item_to_download(self, filename: str) -> BasePage:
-        self.element_visible("downloads-item-by-file", labels=[filename])
+        original_timeout = self.driver.timeouts.implicit_wait
+        try:
+            # Whatever our timeout, we want to lengthen it because downloads
+            self.driver.implicitly_wait(original_timeout * 2)
+            self.element_visible("downloads-item-by-file", labels=[filename])
+            self.expect_not(
+                EC.element_attribute_to_include(
+                    self.get_selector("downloads-button"), "animate"
+                )
+            )
+            with self.driver.context(self.context_id):
+                self.driver.execute_script(
+                    "arguments[0].setAttribute('hidden', true)",
+                    self.get_element("downloads-button"),
+                )
+        finally:
+            self.driver.implicitly_wait(original_timeout)
+
         return self

--- a/modules/data/about_downloads.components.json
+++ b/modules/data/about_downloads.components.json
@@ -1,0 +1,13 @@
+{
+    "no-downloads-label": {
+        "selectorData": "downloadsListEmptyDescription",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "download-target": {
+        "selectorData": "downloadTarget",
+        "strategy": "class",
+        "groups": []
+    }
+}

--- a/modules/data/about_downloads_context_menu.components.json
+++ b/modules/data/about_downloads_context_menu.components.json
@@ -1,0 +1,43 @@
+{
+    "context": "chrome",
+    "do-not-cache": true,
+    "show-in-file-browser": {
+        "selectorData": "downloadShowMenuItem",
+        "strategy": "class",
+        "groups": [
+            "downloadOption"
+        ]
+    },
+
+    "copy-download-link": {
+        "selectorData": "downloadCopyLocationMenuItem",
+        "strategy": "class",
+        "groups": [
+            "downloadOption"
+        ]
+    },
+
+    "delete": {
+        "selectorData": "downloadDeleteFileMenuItem",
+        "strategy": "class",
+        "groups": [
+            "downloadOption"
+        ]
+    },
+
+    "remove-from-history": {
+        "selectorData": "downloadRemoveFromHistoryMenuItem",
+        "strategy": "class",
+        "groups": [
+            "downloadOption"
+        ]
+    },
+
+    "clear-downloads": {
+        "selectorData": "menuitem[data-l10n-id='downloads-cmd-clear-downloads']",
+        "strategy": "css",
+        "groups": [
+            "downloadOption"
+        ]
+    }
+}

--- a/modules/data/about_downloads_context_menu.components.json
+++ b/modules/data/about_downloads_context_menu.components.json
@@ -1,8 +1,41 @@
 {
     "context": "chrome",
     "do-not-cache": true,
+    "downloads-panel": {
+        "selectorData": "downloadsPanel",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "menu-root": {
+        "selectorData": "downloadsContextMenu",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "open-in-system-viewer": {
+        "selectorData": "downloadUseSystemDefaultMenuItem",
+        "strategy": "class",
+        "groups": [
+        ]
+    },
+
+    "always-open-in-system-viewer": {
+        "selectorData": "downloadAlwaysUseSystemDefaultMenuItem",
+        "strategy": "class",
+        "groups": [
+        ]
+    },
+
     "show-in-file-browser": {
         "selectorData": "downloadShowMenuItem",
+        "strategy": "class",
+        "groups": [
+        ]
+    },
+
+    "go-to-download-page": {
+        "selectorData": "downloadOpenReferrerMenuItem",
         "strategy": "class",
         "groups": [
             "downloadOption"

--- a/modules/data/generic_page.components.json
+++ b/modules/data/generic_page.components.json
@@ -51,5 +51,11 @@
         "selectorData": "dnt-on",
         "strategy": "id",
         "groups": []
+    },
+
+    "pdf-link": {
+        "selectorData": "a[href$='.pdf']",
+        "strategy": "css",
+        "groups": []
     }
 }

--- a/modules/data/hyperlink_context_menu.components.json
+++ b/modules/data/hyperlink_context_menu.components.json
@@ -13,6 +13,12 @@
         "groups": []
     },
 
+    "context-menu-save-link": {
+        "selectorData": "context-savelink",
+        "strategy": "id",
+        "groups": []
+    },
+
     "context-menu-open-in-private-window": {
         "selectorData": "context-openlinkprivate",
         "strategy": "id",

--- a/modules/data/toolbar.components.json
+++ b/modules/data/toolbar.components.json
@@ -1,0 +1,9 @@
+{
+    "context": "chrome",
+    "do-not-cache": true,
+    "downloads-item-by-file": {
+        "selectorData": ".downloadMainArea image[src*='{filename}']",
+        "strategy": "css",
+        "groups": []
+    }
+}

--- a/modules/data/toolbar.components.json
+++ b/modules/data/toolbar.components.json
@@ -1,9 +1,22 @@
 {
     "context": "chrome",
     "do-not-cache": true,
+
+    "downloads-button": {
+        "selectorData": "downloads-button",
+        "strategy": "id",
+        "groups": []
+    },
+
     "downloads-item-by-file": {
         "selectorData": ".downloadMainArea image[src*='{filename}']",
         "strategy": "css",
+        "groups": []
+    },
+
+    "blank-space-to-left": {
+        "selectorData": "customizableui-special-spring1",
+        "strategy": "id",
         "groups": []
     }
 }

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Union
 
 from pypom import Page
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException, NoAlertPresentException
 from selenium.webdriver import ActionChains, Firefox
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -568,6 +568,18 @@ class BasePage(Page):
         """Get list of all window handles, switch to the newly opened tab"""
         handles = self.driver.window_handles
         self.driver.switch_to.window(handles[-1])
+        return self
+
+    def switch_to_alert(self) -> Page:
+        """Wait for an alert to appear, then switch to it"""
+        def alert_present(driver) -> bool:
+            try:
+                driver.switch_to.alert
+                return True
+            except NoAlertPresentException:
+                return False
+
+        self.expect(alert_present)
         return self
 
     def wait_for_num_windows(self, num: int) -> Page:

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from typing import List, Union
 
 from pypom import Page
-from selenium.common.exceptions import NoSuchElementException, TimeoutException, NoAlertPresentException
+from selenium.common.exceptions import (
+    NoAlertPresentException,
+    NoSuchElementException,
+    TimeoutException,
+)
 from selenium.webdriver import ActionChains, Firefox
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -330,12 +334,14 @@ class BasePage(Page):
         """
         return self.get_element(name, multiple=True, labels=labels)
 
-    def get_parent_of(self, name: str, labels=[]) -> WebElement:
+    def get_parent_of(
+        self, reference: Union[str, tuple, WebElement], labels=[]
+    ) -> WebElement:
         """
-        Given a name (and labels if needed), return the direct parent node of the element.
+        Given a name + labels, a WebElement, or a tuple, return the direct parent node of the element.
         """
 
-        child = self.get_element(name, labels=labels)
+        child = self.fetch(reference, labels=labels)
         return child.find_element(By.XPATH, "..")
 
     def element_exists(self, name: str, labels=[]) -> Page:
@@ -383,6 +389,13 @@ class BasePage(Page):
             EC.text_to_be_present_in_element(
                 self.get_selector(name, labels=labels), text
             )
+        )
+        return self
+
+    def element_not_visible(self, name: str, labels=[]) -> Page:
+        """Expect helper: wait until element is not visible or timeout"""
+        self.expect_not(
+            EC.visibility_of_element_located(self.get_selector(name, labels=labels))
         )
         return self
 
@@ -572,6 +585,7 @@ class BasePage(Page):
 
     def switch_to_alert(self) -> Page:
         """Wait for an alert to appear, then switch to it"""
+
         def alert_present(driver) -> bool:
             try:
                 driver.switch_to.alert

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -583,19 +583,6 @@ class BasePage(Page):
         self.driver.switch_to.window(handles[-1])
         return self
 
-    def switch_to_alert(self) -> Page:
-        """Wait for an alert to appear, then switch to it"""
-
-        def alert_present(driver) -> bool:
-            try:
-                driver.switch_to.alert
-                return True
-            except NoAlertPresentException:
-                return False
-
-        self.expect(alert_present)
-        return self
-
     def wait_for_num_windows(self, num: int) -> Page:
         """Wait for the number of open tabs + windows to equal given int"""
         with self.driver.context(self.driver.CONTEXT_CONTENT):

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -642,8 +642,7 @@ class BasePage(Page):
                  if (element && element.hidePopup) {
                     element.hidePopup();
                  }"""
-        with self.driver.context(self.context_id):
-            self.driver.execute_script(script, node)
+        self.driver.execute_script(script, node)
 
     @property
     def loaded(self):

--- a/modules/page_object.py
+++ b/modules/page_object.py
@@ -1,5 +1,6 @@
 from modules.page_object_about_addons import *
 from modules.page_object_about_config import *
+from modules.page_object_about_downloads import *
 from modules.page_object_about_glean import *
 from modules.page_object_about_logins import *
 from modules.page_object_about_newtab import *

--- a/modules/page_object_about_downloads.py
+++ b/modules/page_object_about_downloads.py
@@ -25,3 +25,8 @@ class AboutDownloads(BasePage):
     def get_downloads(self) -> list:
         """Get all download targets"""
         return self.get_elements("download-target")
+
+    def wait_for_num_downloads(self, num: int) -> BasePage:
+        """Wait for the number of downloads to equal num"""
+        self.expect(lambda _: len(self.get_downloads()) == num)
+        return self

--- a/modules/page_object_about_downloads.py
+++ b/modules/page_object_about_downloads.py
@@ -13,7 +13,7 @@ class AboutDownloads(BasePage):
 
     URL_TEMPLATE = "about:downloads"
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """Checks to see if downloads page is empty"""
         found = False
         try:
@@ -21,3 +21,7 @@ class AboutDownloads(BasePage):
             found = True
         finally:
             return found
+
+    def get_downloads(self) -> list:
+        """Get all download targets"""
+        return self.get_elements("download-target")

--- a/modules/page_object_about_downloads.py
+++ b/modules/page_object_about_downloads.py
@@ -1,0 +1,23 @@
+from modules.page_base import BasePage
+
+
+class AboutDownloads(BasePage):
+    """
+    The POM for the about:downloads page
+
+    Attributes
+    ----------
+    driver: selenium.webdriver.Firefox
+        WebDriver object under test
+    """
+
+    URL_TEMPLATE = "about:downloads"
+
+    def is_empty(self):
+        """Checks to see if downloads page is empty"""
+        found = False
+        try:
+            self.element_visible("no-downloads-label")
+            found = True
+        finally:
+            return found

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -59,7 +59,8 @@ def test_downloads_from_private_not_leaked(driver: Firefox, delete_files, screen
     about_downloads = AboutDownloads(driver)
     about_downloads.open()
     if not about_downloads.is_empty():
-        screenshot("about_downloads_empty")
+        screenshot("about_downloads_not_empty")
+        logging.warning("About:Downloads is not registering as empty")
 
     opm_forms = GenericPage(driver, url=TEST_URL)
     toolbar = Toolbar(driver)

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -1,5 +1,4 @@
 import logging
-from time import sleep
 
 import pytest
 from selenium.webdriver import Firefox
@@ -75,8 +74,6 @@ def test_downloads_from_private_not_leaked(driver: Firefox):
             .startswith("File deleted")
         )
     )
-    sleep(2)
-    context_menu.hide_popup_by_class("download-status")
 
     # Check that nothing has leaked
     driver.switch_to.window(non_private_window)

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -18,6 +18,7 @@ def add_prefs():
     return [("pdfjs.disabled", True)]
 
 
+@pytest.mark.slow
 def test_downloads_from_private_not_leaked(driver: Firefox):
     """C101674 - Downloads initiated from a private window are not leaked to the non-private window"""
 
@@ -48,7 +49,7 @@ def test_downloads_from_private_not_leaked(driver: Firefox):
     # first link is large, skip it
     for link in valid_links[1 : (NUM_LINKS + 1)]:
         target = link.get_attribute("href")
-        logging.info(f"target {target}")
+        logging.info(f"Downloading target {target}:")
         logging.info(link.text)
         link.click()
         toolbar.wait_for_item_to_download(target.split("/")[-1])

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pytest
 from selenium.webdriver import Firefox
@@ -18,8 +19,19 @@ def add_prefs():
     return [("pdfjs.disabled", True)]
 
 
+@pytest.fixture()
+def delete_files():
+    """Remove the files after the test finishes, should work for Mac/Linux/MinGW"""
+    yield True
+    home_folder = os.environ.get("HOME")
+    downloads_folder = os.path.join(home_folder, "Downloads")
+    for file in os.listdir(downloads_folder):
+        if file.startswith("opm") and file.endswith("pdf"):
+            os.remove(os.path.join(downloads_folder, file))
+
+
 @pytest.mark.slow
-def test_downloads_from_private_not_leaked(driver: Firefox):
+def test_downloads_from_private_not_leaked(driver: Firefox, delete_files):
     """C101674 - Downloads initiated from a private window are not leaked to the non-private window"""
 
     # We're going to assume no downloads as every test is run in a new instance

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -75,6 +75,7 @@ def test_downloads_from_private_not_leaked(driver: Firefox):
             .startswith("File deleted")
         )
     )
+    context_menu.hide_popup_by_child_node("copy-download-link")
 
     # Check that nothing has leaked
     driver.switch_to.window(non_private_window)

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -1,0 +1,28 @@
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+
+from modules.browser_object import HyperlinkContextMenu, PanelUi
+from modules.page_object import AboutDownloads, GenericPage
+
+
+def test_downloads_from_private_not_leaked(driver: Firefox):
+    """C101674 - Downloads initiated from a private window are not leaked to the non-private window"""
+
+    # We're going to assume no downloads as every test is run in a new instance
+    panelui = PanelUi(driver).open_panel_menu()
+    panelui.select_panel_setting("new-private-window-option")
+    panelui.wait_for_num_windows(2)
+    panelui.switch_to_new_window()
+
+    about_downloads = AboutDownloads(driver)
+    about_downloads.open()
+    assert about_downloads.is_empty()
+
+    irs_forms = GenericPage(driver, url="https://www.irs.gov/forms-instructions")
+    context_menu = HyperlinkContextMenu(driver)
+    irs_forms.open()
+
+    pdf_links = irs_forms.get_elements("pdf-links")
+    for link in pdf_links[:5]:
+        irs_forms.context_click(link)
+        context_menu.click_and_hide_menu("context-menu-save-link")

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -1,14 +1,26 @@
+import logging
+from time import sleep
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 
-from modules.browser_object import HyperlinkContextMenu, PanelUi
+from modules.browser_object import AboutDownloadsContextMenu, PanelUi, Toolbar
 from modules.page_object import AboutDownloads, GenericPage
+import pytest
+
+TEST_URL = "https://www.opm.gov/forms/standard-forms/"
+
+
+@pytest.fixture()
+def add_prefs():
+    return [("pdfjs.disabled", True)]
 
 
 def test_downloads_from_private_not_leaked(driver: Firefox):
     """C101674 - Downloads initiated from a private window are not leaked to the non-private window"""
 
     # We're going to assume no downloads as every test is run in a new instance
+    non_private_window = driver.current_window_handle
     panelui = PanelUi(driver).open_panel_menu()
     panelui.select_panel_setting("new-private-window-option")
     panelui.wait_for_num_windows(2)
@@ -18,11 +30,40 @@ def test_downloads_from_private_not_leaked(driver: Firefox):
     about_downloads.open()
     assert about_downloads.is_empty()
 
-    irs_forms = GenericPage(driver, url="https://www.irs.gov/forms-instructions")
-    context_menu = HyperlinkContextMenu(driver)
-    irs_forms.open()
+    opm_forms = GenericPage(driver, url=TEST_URL)
+    toolbar = Toolbar(driver)
+    opm_forms.open()
 
-    pdf_links = irs_forms.get_elements("pdf-links")
-    for link in pdf_links[:5]:
-        irs_forms.context_click(link)
-        context_menu.click_and_hide_menu("context-menu-save-link")
+    links = opm_forms.driver.find_elements("tag name", "a")
+    valid_links = [
+        el
+        for el in links
+        if el.get_attribute("href")
+        and el.get_attribute("href").endswith(".pdf")
+        and el.is_displayed()
+    ]
+    for link in valid_links[:5]:
+        target = link.get_attribute('href')
+        logging.info(f"target {target}")
+        logging.info(link.text)
+        link.click()
+        toolbar.wait_for_item_to_download(target.split("/")[-1])
+
+    about_downloads = AboutDownloads(driver)
+    context_menu = AboutDownloadsContextMenu(driver)
+    about_downloads.open()
+    downloads = about_downloads.get_downloads()
+    assert len(downloads) == 5
+
+    first_download = downloads[0]
+    about_downloads.context_click(first_download)
+    assert context_menu.has_all_options_available()
+    context_menu.click_and_hide_menu("delete")
+
+    downloads = about_downloads.get_downloads()
+    assert len(downloads) == 4
+
+    driver.switch_to.window(non_private_window)
+    about_downloads = AboutDownloads(driver)
+    about_downloads.open()
+    assert about_downloads.is_empty()

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -45,12 +45,16 @@ def delete_files(sys_platform):
 def test_downloads_from_private_not_leaked(driver: Firefox, delete_files):
     """C101674 - Downloads initiated from a private window are not leaked to the non-private window"""
 
-    # We're going to assume no downloads as every test is run in a new instance
+    # We've deleted relevant downloads just to be safe
     non_private_window = driver.current_window_handle
     panelui = PanelUi(driver).open_panel_menu()
     panelui.select_panel_setting("new-private-window-option")
     panelui.wait_for_num_windows(2)
-    panelui.switch_to_new_window()
+
+    # Using this instead of switch_to_new_window, suspect it may be broken
+    original_window_idx = driver.window_handles.index(non_private_window)
+    private_window = driver.window_handles[1 - original_window_idx]
+    driver.switch_to.window(private_window)
 
     about_downloads = AboutDownloads(driver)
     about_downloads.open()

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -42,7 +42,7 @@ def delete_files(sys_platform):
 
 
 @pytest.mark.slow
-def test_downloads_from_private_not_leaked(driver: Firefox, delete_files):
+def test_downloads_from_private_not_leaked(driver: Firefox, delete_files, screenshot):
     """C101674 - Downloads initiated from a private window are not leaked to the non-private window"""
 
     # We've deleted relevant downloads just to be safe
@@ -58,7 +58,8 @@ def test_downloads_from_private_not_leaked(driver: Firefox, delete_files):
 
     about_downloads = AboutDownloads(driver)
     about_downloads.open()
-    assert about_downloads.is_empty()
+    if not about_downloads.is_empty():
+        screenshot("about_downloads_empty")
 
     opm_forms = GenericPage(driver, url=TEST_URL)
     toolbar = Toolbar(driver)

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -66,6 +66,7 @@ def test_downloads_from_private_not_leaked(driver: Firefox):
     about_downloads.context_click(first_download)
 
     # We are not testing all the context menu options, that should be a test in another suite
+    context_menu.has_all_options_available()
     context_menu.click_and_hide_menu("delete")
     about_downloads.expect(
         lambda _: (

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -20,14 +20,25 @@ def add_prefs():
 
 
 @pytest.fixture()
-def delete_files():
+def delete_files(sys_platform):
     """Remove the files after the test finishes, should work for Mac/Linux/MinGW"""
+
+    def _delete_files():
+        if sys_platform.startswith("Win"):
+            if os.environ.get("GITHUB_ACTIONS") == "true":
+                downloads_folder = os.path.join(
+                    "C:", "Users", "runneradmin", "Downloads"
+                )
+        else:
+            home_folder = os.environ.get("HOME")
+            downloads_folder = os.path.join(home_folder, "Downloads")
+        for file in os.listdir(downloads_folder):
+            if file.startswith("opm") and file.endswith("pdf"):
+                os.remove(os.path.join(downloads_folder, file))
+
+    _delete_files()
     yield True
-    home_folder = os.environ.get("HOME")
-    downloads_folder = os.path.join(home_folder, "Downloads")
-    for file in os.listdir(downloads_folder):
-        if file.startswith("opm") and file.endswith("pdf"):
-            os.remove(os.path.join(downloads_folder, file))
+    _delete_files()
 
 
 @pytest.mark.slow

--- a/tests/security_and_privacy/test_private_browser_password_doorhanger.py
+++ b/tests/security_and_privacy/test_private_browser_password_doorhanger.py
@@ -13,6 +13,7 @@ def add_prefs():
     return [("signon.rememberSignons", True)]
 
 
+@pytest.mark.unstable
 def test_no_password_doorhanger_private_browsing(driver: Firefox):
     """
     C101670: Ensure no save password doorhanger shows up and settings are correct


### PR DESCRIPTION
# Description

* Complete test that private mode downloads are not displayed in normal mode about:downloads
* Add POM: AboutDownloads with methods
* Add BOM: Toolbar with methods
* Add BOM: AboutDownloadsContextMenu with methods
* Ergonomics: improve `get_parent_of`, add `switch_to_alert`, `element_not_visible`, improve reliability of `hide_popup_by_child`.
* Hard waits before starting GHA pipelines

## Bugzilla bug ID

**Testrail:** https://testrail.stage.mozaws.net/index.php?/cases/view/101674
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1905185

## Type of change

Please delete options that are not relevant.

- [x] New Test
- [x] New POM
- [x] Ergo, BasePage improve

# How does this resolve / make progress on that bug?

Completes test
