### PR TITLE
Vs/never remember history test

### DIFF
--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -387,5 +387,11 @@
         "selectorData": "description[data-l10n-id='history-dontremember-description']",
         "strategy": "css",
         "groups": []
+    },
+
+    "history_menulist": {
+        "selectorData": "historyMode",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/modules/page_object_about_prefs.py
+++ b/modules/page_object_about_prefs.py
@@ -322,3 +322,9 @@ class AboutPrefs(BasePage):
         Gets the webelement for the iframe that commonly appears in about:preferences
         """
         return self.get_element("browser-popup")
+
+    def get_history_menulist(self) -> WebElement:
+        """
+        Gets the webelement for the list of history items that appear in about:preferences
+        """
+        return self.get_element("history_menulist")

--- a/tests/preferences/test_never_remember_history.py
+++ b/tests/preferences/test_never_remember_history.py
@@ -1,0 +1,52 @@
+import os
+import time
+
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+
+from modules.page_object import AboutPrefs
+
+
+# make sure Firefox remembers history
+@pytest.fixture()
+def add_prefs():
+    return [("browser.privatebrowsing.autostart", False)]
+
+
+def test_never_remember_history(driver: Firefox, sys_platform: str):
+    """
+    C143604: Make sure to set the pref via about:preferences, then check in about:config that the pref has been changed
+    """
+
+    AboutPrefs(driver, category="privacy").open()
+
+    # Change the settings to not remember the browser history
+    history_menulist = driver.find_element(By.ID, "historyMode")
+    menulist_popup = history_menulist.find_element(By.TAG_NAME, "menupopup")
+    options = menulist_popup.find_elements(By.TAG_NAME, "menuitem")
+
+    # Scrolling for visibility
+    driver.execute_script("arguments[0].scrollIntoView();", history_menulist)
+    time.sleep(1)
+    current_selection = history_menulist.get_attribute("value")
+
+    if current_selection != "dontremember":
+        for option in options:
+            if option.get_attribute("value") == "dontremember":
+                option.click()
+                break
+
+    # Verify that the pref is set to True
+    profile_path = driver.capabilities["moz:profile"]
+    prefs_file_path = os.path.join(profile_path, "prefs.js")
+
+    # Read the contents of the 'prefs.js' file to check for the preference
+    with open(prefs_file_path, "r") as prefs_file:
+        prefs_content = prefs_file.read()
+
+    # Check that the preference is now True
+    preference_string = 'user_pref("browser.privatebrowsing.autostart", true);'
+    assert (
+        preference_string in prefs_content
+    ), f"The preference {preference_string} is not set correctly."

--- a/tests/preferences/test_never_remember_history.py
+++ b/tests/preferences/test_never_remember_history.py
@@ -19,10 +19,10 @@ def test_never_remember_history(driver: Firefox, sys_platform: str):
     C143604: Make sure to set the pref via about:preferences, then check in about:config that the pref has been changed
     """
 
-    AboutPrefs(driver, category="privacy").open()
+    about_prefs = AboutPrefs(driver, category="privacy").open()
 
     # Change the settings to not remember the browser history
-    history_menulist = driver.find_element(By.ID, "historyMode")
+    history_menulist = about_prefs.get_history_menulist()
     menulist_popup = history_menulist.find_element(By.TAG_NAME, "menupopup")
     options = menulist_popup.find_elements(By.TAG_NAME, "menuitem")
 


### PR DESCRIPTION
# Description

This tests that browser.privatebrowsing.autostart" preference is set from False to True when choosing to never remember history.

## Bugzilla bug ID

**Testrail:** https://mozilla.testrail.io/index.php?/cases/view/143604
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1905169

## Type of change

Please delete options that are not relevant.

- [x] New Test
- [ ] New POM
- [ ] Other Changes (Please specify)

# How does this resolve / make progress on that bug?

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
