### PR TITLE
hy/ Test add zip type

### DIFF
--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -472,6 +472,11 @@
         "selectorData": "richlistitem[type='application/pdf'] menulist.actionsMenu",
         "strategy": "css",
         "groups": []
-    }
+    },
 
+    "zip-mime-type": {
+        "selectorData": "richlistitem[type='{item}']",
+        "strategy": "css",
+        "groups": []
+    }
 }

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -474,7 +474,7 @@
         "groups": []
     },
 
-    "zip-mime-type": {
+    "mime-type": {
         "selectorData": "richlistitem[type='{item}']",
         "strategy": "css",
         "groups": []

--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -29,5 +29,11 @@
         "selectorData": "context-savepage",
         "strategy": "id",
         "groups": []
+    },
+
+    "context-menu-always-open-similar-files": {
+        "selectorData": "downloadAlwaysOpenSimilarFilesMenuItem",
+        "strategy": "class",
+        "groups": []
     }
 }

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -272,5 +272,11 @@
         "selectorData": "image[id='star-button'][starred='true']",
         "strategy": "css",
         "groups": []
+    },
+
+    "download-panel-item": {
+        "selectorData": "downloadTarget",
+        "strategy": "class",
+        "groups": []
     }
 }

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -1,0 +1,34 @@
+from time import sleep
+
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+
+from modules.browser_object_context_menu import ContextMenu
+from modules.browser_object_navigation import Navigation
+from modules.page_object_about_prefs import AboutPrefs
+from modules.page_object_generics import GenericPage
+
+ZIP_URL = "https://ftp.mozilla.org/pub/firefox/releases/0.9rc/"
+
+
+def test_add_zip_type(driver: Firefox):
+    """
+    C1756743: Verify that the user can add the .zip mime type to Firefox
+    """
+    # instantiate object
+    web_page = GenericPage(driver, url=ZIP_URL).open()
+    nav = Navigation(driver)
+    context_menu = ContextMenu(driver)
+    about_prefs = AboutPrefs(driver, category="general")
+
+    # Click on the available zip
+    web_page.find_element(By.XPATH, "//td/a[@href='/pub/firefox/releases/0.9rc/Firefox-win32-0.9rc.zip']").click()
+
+    # In the download panel right-click on the download and click "Always Open Similar Files"
+    with driver.context(driver.CONTEXT_CHROME):
+        nav.context_click(nav.get_element("download-panel-item"))
+        context_menu.get_element("context-menu-always-open-similar-files").click()
+
+    # Open about:preferences and check that zip mime type is present in the application list
+    about_prefs.open()
+    about_prefs.element_exists("zip-mime-type", labels=["application/zip"])

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -31,4 +31,4 @@ def test_add_zip_type(driver: Firefox):
 
     # Open about:preferences and check that zip mime type is present in the application list
     about_prefs.open()
-    about_prefs.element_exists("zip-mime-type", labels=["application/zip"])
+    about_prefs.element_exists("mime-type", labels=["application/zip"])


### PR DESCRIPTION
# Description

Verify that the user can add the .zip mime type to Firefox

## Bugzilla bug ID

**[Testrail](https://mozilla.testrail.io/index.php?/cases/view/1756743)**
**[Link](https://bugzilla.mozilla.org/show_bug.cgi?id=1912103)**

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

Completed.

# Screenshots / Explanations

N/A

# Comments / Concerns

N/A
