### PR TITLE
As/website opened in a new window is displayed at the top of the recent history menu list

### DIFF
--- a/tests/bookmarks_and_history/test_opened_website_in_new_window_present_in_toolbar_history.py
+++ b/tests/bookmarks_and_history/test_opened_website_in_new_window_present_in_toolbar_history.py
@@ -26,7 +26,7 @@ def test_the_website_opened_in_new_window_is_present_in_history_menu(driver: Fir
     panel_ui.open_panel_menu()
     panel_ui.select_panel_setting("panel-ui-new-window")
     tabs.wait_for_num_tabs(2)
-    driver.switch_to.window(driver.window_handles[-1])
+    tabs.switch_to_new_window()
 
     GenericPage(driver, url=YOUTUBE_URL).open()
 

--- a/tests/bookmarks_and_history/test_opened_website_in_new_window_present_in_toolbar_history.py
+++ b/tests/bookmarks_and_history/test_opened_website_in_new_window_present_in_toolbar_history.py
@@ -1,0 +1,40 @@
+from selenium.webdriver import Firefox
+
+from modules.browser_object_panel_ui import PanelUi
+from modules.browser_object_tabbar import TabBar
+from modules.page_object_generics import GenericPage
+
+FACEBOOK_URL = "https://www.facebook.com/"
+AMAZON_URL = "https://www.amazon.com/"
+YOUTUBE_URL = "https://www.youtube.com/"
+
+WEBSITES = [FACEBOOK_URL, AMAZON_URL]
+
+
+def test_the_website_opened_in_new_window_is_present_in_history_menu(driver: Firefox):
+    """
+    C118805 - Verify that the website opened in new window is displayed in the Toolbar History submenu on top of the
+    list
+    """
+
+    for url in WEBSITES:
+        GenericPage(driver, url=url).open()
+
+    tabs = TabBar(driver)
+    panel_ui = PanelUi(driver)
+
+    panel_ui.open_panel_menu()
+    panel_ui.select_panel_setting("panel-ui-new-window")
+    tabs.wait_for_num_tabs(2)
+    driver.switch_to.window(driver.window_handles[-1])
+
+    GenericPage(driver, url=YOUTUBE_URL).open()
+
+    panel_ui.open_history_menu()
+
+    # Verify YouTube is present in the history menu and is on top of the list as the most recent website visited
+    with driver.context(driver.CONTEXT_CHROME):
+        recent_history_elements = panel_ui.get_elements("recent-history-content")
+        assert (
+            recent_history_elements[0].get_attribute("value") == "YouTube"
+        ), "YouTube is not the first item in the recent history."

--- a/tests/pdf_viewer/test_download_pdf_with_form_fields.py
+++ b/tests/pdf_viewer/test_download_pdf_with_form_fields.py
@@ -1,13 +1,16 @@
-from time import sleep
 import os
+from time import sleep
 
 import pytest
 from selenium.webdriver import Firefox
+
 from modules.page_object_generics import GenericPdf
 
 
 @pytest.mark.headed
-def test_download_pdf_with_form_fields(driver: Firefox, fillable_pdf_url: str, downloads_folder: str, sys_platform):
+def test_download_pdf_with_form_fields(
+    driver: Firefox, fillable_pdf_url: str, downloads_folder: str, sys_platform
+):
     """
     C1020326 Download pdf with form fields
     """
@@ -50,8 +53,10 @@ def test_download_pdf_with_form_fields(driver: Firefox, fillable_pdf_url: str, d
     saved_pdf_location = os.path.join(downloads_folder, file_name)
 
     # Verify if the file exists
-    assert os.path.exists(saved_pdf_location), f"The file was not downloaded to {saved_pdf_location}."
+    assert os.path.exists(
+        saved_pdf_location
+    ), f"The file was not downloaded to {saved_pdf_location}."
 
     # Open the saved pdf and check if the edited field is displayed
-    driver.get('file://' + os.path.realpath(saved_pdf_location))
+    driver.get("file://" + os.path.realpath(saved_pdf_location))
     assert pdf_page.get_element("edited-name-field").is_displayed()


### PR DESCRIPTION
# Description

Verify that the website opened in new window is displayed in the History submenu on top of the list


## Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/118805**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1910738**
 
## Type of change

Please delete options that are not relevant.

- [x ] New Test

# How does this resolve / make progress on that bug?
Completed

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
