### PR TITLE
hy/ Edit test: Add delete_files for test download pdf with form fields

### DIFF
--- a/tests/pdf_viewer/test_download_pdf_with_form_fields.py
+++ b/tests/pdf_viewer/test_download_pdf_with_form_fields.py
@@ -69,3 +69,4 @@ def test_download_pdf_with_form_fields(
     # Open the saved pdf and check if the edited field is displayed
     driver.get("file://" + os.path.realpath(saved_pdf_location))
     pdf_page.element_visible("edited-name-field")
+    

--- a/tests/pdf_viewer/test_download_pdf_with_form_fields.py
+++ b/tests/pdf_viewer/test_download_pdf_with_form_fields.py
@@ -68,4 +68,4 @@ def test_download_pdf_with_form_fields(
 
     # Open the saved pdf and check if the edited field is displayed
     driver.get("file://" + os.path.realpath(saved_pdf_location))
-    assert pdf_page.get_element("edited-name-field").is_displayed()
+    pdf_page.element_visible("edited-name-field")

--- a/tests/pdf_viewer/test_download_pdf_with_form_fields.py
+++ b/tests/pdf_viewer/test_download_pdf_with_form_fields.py
@@ -6,8 +6,19 @@ from selenium.webdriver import Firefox
 from modules.page_object_generics import GenericPdf
 
 
+@pytest.fixture()
+def delete_files_regex_string():
+    return r"i-9.*\.pdf"
+
+
 @pytest.mark.headed
-def test_download_pdf_with_form_fields(driver: Firefox, fillable_pdf_url: str, downloads_folder: str, sys_platform):
+def test_download_pdf_with_form_fields(
+        driver: Firefox,
+        fillable_pdf_url: str,
+        downloads_folder: str,
+        sys_platform,
+        delete_files,
+):
     """
     C1020326 Download pdf with form fields
     """


### PR DESCRIPTION
# Description

Add delete files for test download pdf with form fields PR168

## Bugzilla bug ID

**[Testrail](https://mozilla.testrail.io/index.php?/cases/view/1020326)**
**[Link](https://bugzilla.mozilla.org/show_bug.cgi?id=1910713)**

## Type of change

Please delete options that are not relevant.

- [x] Other Changes (Please specify)

# How does this resolve / make progress on that bug?

Editing test download pdf with form fields PR168

# Screenshots / Explanations

N/A

# Comments / Concerns

N/A
