### PR TITLE
hy/ Test Edit bookmark via star button

### DIFF
--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -272,5 +272,17 @@
         "selectorData": "image[id='star-button'][starred='true']",
         "strategy": "css",
         "groups": []
+    },
+
+    "edit-bookmark-panel": {
+        "selectorData": "editBMPanel_namePicker",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "remove-bookmark-button": {
+        "selectorData": "editBookmarkPanelRemoveButton",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/modules/data/panel_ui.components.json
+++ b/modules/data/panel_ui.components.json
@@ -161,6 +161,35 @@
         "selectorData": "panelMenuBookmarkThisPage",
         "strategy": "id",
         "groups": []
-    }
+    },
 
+    "bookmark-location": {
+        "selectorData": "editBMPanel_folderMenuList",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "other-bookmarks": {
+        "selectorData": "editBMPanel_unfiledRootItem",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "show-editor-when-saving-checkbox": {
+        "selectorData": "editBookmarkPanel_showForNewBookmarks",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "other-bookmarks-toolbar": {
+        "selectorData": "OtherBookmarks",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "other-bookmarks-by-title": {
+        "selectorData": "menuitem.menuitem-iconic[label*='{title}']",
+        "strategy": "css",
+        "groups": []
+    }
 }

--- a/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
+++ b/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
@@ -29,12 +29,7 @@ def test_edit_bookmark_via_star_button(driver: Firefox):
         panel.get_element("other-bookmarks").click()
         nav.get_element("save-bookmark-button").click()
 
-    # Check bookmark name is changed in hamburger menu and dismiss menu
-        panel.open_bookmarks_menu()
-        panel.element_visible("bookmark-by-title", labels=["Mozilla Firefox"])
-        panel.get_element("panel-ui-button").click()
-
-    # Check location is changed in the toolbar
+    # Check bookmark name and location are changed in the bookmarks toolbar
         panel.get_element("other-bookmarks-toolbar").click()
         panel.element_visible("other-bookmarks-by-title", labels=["Mozilla Firefox"])
         panel.get_element("other-bookmarks-toolbar").click()

--- a/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
+++ b/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
@@ -2,6 +2,7 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object_navigation import Navigation
 from modules.browser_object_panel_ui import PanelUi
+from modules.page_object_generics import GenericPage
 
 URL_TO_EDIT = "https://www.mozilla.org/"
 URL_TO_SAVE = "https://monitor.mozilla.org/"
@@ -16,7 +17,7 @@ def test_edit_bookmark_via_star_button(driver: Firefox):
     panel = PanelUi(driver)
 
     # Bookmark the given website and open the edit bookmark panel
-    driver.get(URL_TO_EDIT)
+    GenericPage(driver, url=URL_TO_EDIT).open()
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("star-button").click()
         nav.get_element("save-bookmark-button").click()
@@ -49,7 +50,7 @@ def test_edit_bookmark_via_star_button(driver: Firefox):
         nav.get_element("star-button").click()
         panel.get_element("show-editor-when-saving-checkbox").click()
         nav.get_element("save-bookmark-button").click()
-    driver.get(URL_TO_SAVE)
+    GenericPage(driver, url=URL_TO_SAVE).open()
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("star-button").click()
         assert not nav.get_element("edit-bookmark-panel").is_displayed()

--- a/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
+++ b/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
@@ -41,4 +41,4 @@ def test_edit_bookmark_via_star_button(driver: Firefox):
     GenericPage(driver, url=URL_TO_SAVE).open()
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("star-button").click()
-        assert not nav.get_element("edit-bookmark-panel").is_displayed()
+        nav.element_not_visible("edit-bookmark-panel")

--- a/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
+++ b/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
@@ -42,3 +42,4 @@ def test_edit_bookmark_via_star_button(driver: Firefox):
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("star-button").click()
         nav.element_not_visible("edit-bookmark-panel")
+        

--- a/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
+++ b/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
@@ -21,30 +21,23 @@ def test_edit_bookmark_via_star_button(driver: Firefox):
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("star-button").click()
         nav.get_element("save-bookmark-button").click()
-        nav.get_element("star-button").click()
 
-    # Change bookmark name, check if it's changed and dismiss menu
+    # Change bookmark name and location
+        nav.get_element("star-button").click()
         nav.get_element("edit-bookmark-panel").send_keys("Mozilla Firefox")
+        panel.get_element("bookmark-location").click()
+        panel.get_element("other-bookmarks").click()
         nav.get_element("save-bookmark-button").click()
+
+    # Check bookmark name is changed in hamburger menu and dismiss menu
         panel.open_bookmarks_menu()
         panel.element_visible("bookmark-by-title", labels=["Mozilla Firefox"])
         panel.get_element("panel-ui-button").click()
 
-    # Change location and check if it's changed
-        nav.get_element("star-button").click()
-        panel.get_element("bookmark-location").click()
-        panel.get_element("other-bookmarks").click()
-        nav.get_element("save-bookmark-button").click()
+    # Check location is changed in the toolbar
         panel.get_element("other-bookmarks-toolbar").click()
         panel.element_visible("other-bookmarks-by-title", labels=["Mozilla Firefox"])
         panel.get_element("other-bookmarks-toolbar").click()
-
-    # remove bookmark and check that bookmark isn't displayed in bookmarks menu
-        nav.get_element("star-button").click()
-        nav.get_element("remove-bookmark-button").click()
-        panel.open_bookmarks_menu()
-        panel.element_not_visible("bookmark-by-title", labels=["Mozilla Firefox"])
-        panel.get_element("panel-ui-button").click()
 
     # Uncheck show editor when saving and verify that panel isn't displayed when bookmark a new website
         nav.get_element("star-button").click()

--- a/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
+++ b/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
@@ -1,0 +1,55 @@
+from selenium.webdriver import Firefox
+
+from modules.browser_object_navigation import Navigation
+from modules.browser_object_panel_ui import PanelUi
+
+URL_TO_EDIT = "https://www.mozilla.org/"
+URL_TO_SAVE = "https://monitor.mozilla.org/"
+
+
+def test_edit_bookmark_via_star_button(driver: Firefox):
+    """
+    C2084549: Verify that the user can Edit a Bookmark options from the Star-shaped button
+    """
+    # instantiate object
+    nav = Navigation(driver)
+    panel = PanelUi(driver)
+
+    # Bookmark the given website and open the edit bookmark panel
+    driver.get(URL_TO_EDIT)
+    with driver.context(driver.CONTEXT_CHROME):
+        nav.get_element("star-button").click()
+        nav.get_element("save-bookmark-button").click()
+        nav.get_element("star-button").click()
+
+    # Change bookmark name, check if it's changed and dismiss menu
+        nav.get_element("edit-bookmark-panel").send_keys("Mozilla Firefox")
+        nav.get_element("save-bookmark-button").click()
+        panel.open_bookmarks_menu()
+        panel.element_visible("bookmark-by-title", labels=["Mozilla Firefox"])
+        panel.get_element("panel-ui-button").click()
+
+    # Change location and check if it's changed
+        nav.get_element("star-button").click()
+        panel.get_element("bookmark-location").click()
+        panel.get_element("other-bookmarks").click()
+        nav.get_element("save-bookmark-button").click()
+        panel.get_element("other-bookmarks-toolbar").click()
+        panel.element_visible("other-bookmarks-by-title", labels=["Mozilla Firefox"])
+        panel.get_element("other-bookmarks-toolbar").click()
+
+    # remove bookmark and check that bookmark isn't displayed in bookmarks menu
+        nav.get_element("star-button").click()
+        nav.get_element("remove-bookmark-button").click()
+        panel.open_bookmarks_menu()
+        panel.element_not_visible("bookmark-by-title", labels=["Mozilla Firefox"])
+        panel.get_element("panel-ui-button").click()
+
+    # Uncheck show editor when saving and verify that panel isn't displayed when bookmark a new website
+        nav.get_element("star-button").click()
+        panel.get_element("show-editor-when-saving-checkbox").click()
+        nav.get_element("save-bookmark-button").click()
+    driver.get(URL_TO_SAVE)
+    with driver.context(driver.CONTEXT_CHROME):
+        nav.get_element("star-button").click()
+        assert not nav.get_element("edit-bookmark-panel").is_displayed()


### PR DESCRIPTION
# Description

Verify that the user can Edit a Bookmark options from the Star-shaped button.

## Bugzilla bug ID

**[Testrail](https://mozilla.testrail.io/index.php?/cases/view/2084549)**
**[Link](https://bugzilla.mozilla.org/show_bug.cgi?id=1910726)**

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

Completed

# Screenshots / Explanations

N/A

# Comments / Concerns

N/A
