### PR TITLE
Clear Recent History Option Displayed

### DIFF
--- a/collect_executables.py
+++ b/collect_executables.py
@@ -3,7 +3,6 @@ Use -g to get geckodriver, otherwise you will get Fx.
 Set env var FX_CHANNEL to get non-beta, blank string for Release.
 Set env var FX_LOCALE to get a different locale build."""
 
-import json
 from os import environ
 from platform import uname
 from sys import argv, exit

--- a/modules/data/panel_ui.components.json
+++ b/modules/data/panel_ui.components.json
@@ -133,6 +133,12 @@
         "groups": []
     },
 
+    "clear-recent-history": {
+        "selectorData" :"appMenuClearRecentHistory",
+        "strategy": "id",
+        "groups": []
+    },
+
     "panel-ui-history-recent-history-container": {
         "selectorData": "appMenu_historyMenu",
         "strategy": "id",

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -3,10 +3,8 @@ import logging
 import os
 import platform
 import re
-import signal
 from copy import deepcopy
 from pathlib import Path
-from subprocess import check_output
 from typing import List, Union
 
 from pypom import Page

--- a/tests/bookmarks_and_history/test_clear_recent_history_displayed.py
+++ b/tests/bookmarks_and_history/test_clear_recent_history_displayed.py
@@ -2,6 +2,7 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import PanelUi
 
+
 def test_clear_recent_history_displayed(driver: Firefox):
     """
     C172043: Clear recent history panel displayed

--- a/tests/bookmarks_and_history/test_clear_recent_history_displayed.py
+++ b/tests/bookmarks_and_history/test_clear_recent_history_displayed.py
@@ -1,0 +1,17 @@
+from selenium.webdriver import Firefox
+
+from modules.browser_object import PanelUi
+
+def test_clear_recent_history_displayed(driver: Firefox):
+    """
+    C172043: Clear recent history panel displayed
+    """
+    panel_ui = PanelUi(driver).open()
+
+    panel_ui.open_panel_menu()
+    with driver.context(driver.CONTEXT_CHROME):
+        panel_ui.get_element("panel-ui-history").click()
+
+        panel_ui.element_exists("clear-recent-history")
+        panel_ui.element_visible("clear-recent-history")
+        panel_ui.element_clickable("clear-recent-history")

--- a/tests/menus/test_frequently_used_context_menu.py
+++ b/tests/menus/test_frequently_used_context_menu.py
@@ -8,7 +8,7 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import ContextMenu, Devtools, Navigation
 from modules.page_object import ExamplePage
-from modules.util import BrowserActions, Utilities
+from modules.util import Utilities
 
 WIN_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("win")
 

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -6,7 +6,7 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import ImageContextMenu, Navigation, TabBar
 from modules.page_object import GenericPage
-from modules.util import BrowserActions, Utilities
+from modules.util import Utilities
 
 LINK_IMAGE_URL = (
     "https://en.wikipedia.org/wiki/Firefox#/media/File:Firefox_logo,_2019.svg"

--- a/tests/pdf_viewer/conftest.py
+++ b/tests/pdf_viewer/conftest.py
@@ -13,6 +13,7 @@ def set_prefs():
     """Set prefs"""
     return []
 
+
 @pytest.fixture()
 def delete_files(sys_platform):
     """Remove the files after the test finishes, should work for Mac/Linux/MinGW"""

--- a/tests/pdf_viewer/test_download_pdf_with_form_fields.py
+++ b/tests/pdf_viewer/test_download_pdf_with_form_fields.py
@@ -1,13 +1,16 @@
-from time import sleep
 import os
+from time import sleep
 
 import pytest
 from selenium.webdriver import Firefox
+
 from modules.page_object_generics import GenericPdf
 
 
 @pytest.mark.headed
-def test_download_pdf_with_form_fields(driver: Firefox, fillable_pdf_url: str, downloads_folder: str, sys_platform):
+def test_download_pdf_with_form_fields(
+    driver: Firefox, fillable_pdf_url: str, downloads_folder: str, sys_platform
+):
     """
     C1020326 Download pdf with form fields
     """
@@ -50,8 +53,10 @@ def test_download_pdf_with_form_fields(driver: Firefox, fillable_pdf_url: str, d
     saved_pdf_location = os.path.join(downloads_folder, file_name)
 
     # Verify if the file exists
-    assert os.path.exists(saved_pdf_location), f"The file was not downloaded to {saved_pdf_location}."
+    assert os.path.exists(
+        saved_pdf_location
+    ), f"The file was not downloaded to {saved_pdf_location}."
 
     # Open the saved pdf and check if the edited field is displayed
-    driver.get('file://' + os.path.realpath(saved_pdf_location))
+    driver.get("file://" + os.path.realpath(saved_pdf_location))
     assert pdf_page.get_element("edited-name-field").is_displayed()

--- a/tests/pdf_viewer/test_pdf_input_numbers.py
+++ b/tests/pdf_viewer/test_pdf_input_numbers.py
@@ -1,4 +1,3 @@
-import os
 import time
 
 import pytest

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import pytest
 from selenium.webdriver import Firefox


### PR DESCRIPTION
# Description

Verify that the Clear Recent History window is displayed

## Bugzilla bug ID

**Testrail:** https://mozilla.testrail.io/index.php?/cases/view/172043 
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1910747

## Type of change

Please delete options that are not relevant.

- [x] New Test

# How does this resolve / make progress on that bug?

Finishes

# Screenshots / Explanations

N/A

# Comments / Concerns

N/A
