### PR TITLE
As/private browsing history not captured

### DIFF
--- a/tests/bookmarks_and_history/test_private_window_website_not_in_history.py
+++ b/tests/bookmarks_and_history/test_private_window_website_not_in_history.py
@@ -1,0 +1,28 @@
+from selenium.webdriver import Firefox
+
+from modules.browser_object_panel_ui import PanelUi
+from modules.page_object_generics import GenericPage
+
+YOUTUBE_URL = "https://www.youtube.com/"
+
+
+def test_opened_website_in_private_window_not_capture_in_history_list(driver: Firefox):
+    """
+    C118806 - Verify that opened websites in a New Private Window will not be displayed in the Hamburger submenu history
+    """
+
+    panel_ui = PanelUi(driver)
+    panel_ui.open_private_window()
+    panel_ui.switch_to_new_window()
+
+    GenericPage(driver, url=YOUTUBE_URL).open()
+
+    panel_ui.open_history_menu()
+
+    with driver.context(driver.CONTEXT_CHROME):
+        empty_label = panel_ui.get_element("recent-history-content").get_attribute(
+            "value"
+        )
+        assert (
+            empty_label == "(Empty)"
+        ), f"Expected history to be empty, but found '{empty_label}'"

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -22,7 +22,9 @@ def test_add_zip_type(driver: Firefox):
     about_prefs = AboutPrefs(driver, category="general")
 
     # Click on the available zip
-    web_page.find_element(By.XPATH, "//td/a[@href='/pub/firefox/releases/0.9rc/Firefox-win32-0.9rc.zip']").click()
+    web_page.find_element(
+        By.XPATH, "//td/a[@href='/pub/firefox/releases/0.9rc/Firefox-win32-0.9rc.zip']"
+    ).click()
 
     # In the download panel right-click on the download and click "Always Open Similar Files"
     with driver.context(driver.CONTEXT_CHROME):


### PR DESCRIPTION
# Description

Verify that websites opened in a New Private Window do not appear in the History submenu accessed from the hamburger menu within the private window.

## Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/118806**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1910740**

## Type of change

Please delete options that are not relevant.

- [x ] New Test
- 
# How does this resolve / make progress on that bug?
Completed

Please describe the progress or significance with respect to the bug listed above.

# Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

# Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
