### PR TITLE
Anca/ Autofill popup selectors

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -715,3 +715,75 @@ Description: Bookmark current tab button
 Location: Menu button / hamburger menu
 Path to .json: modules/data/navigation.components.json
 ```
+```
+### autofill_popup
+Selector name: autofill-panel
+Selector Data: PopupAutoComplete
+Description: A dropdown panel displaying autofill suggestions for input fields (addresses, credit cards,login forms)
+Location: Inside any autofill-eligible form field, triggered by user interaction such as a click or focus event
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: doorhanger-save-button
+Selector Data: button[label='Save'].popup-notification-primary-button
+Description: The "Save" button 
+Location: Inside the autofill save doorhangers (address and credit card) that is triggered in navigation bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: doorhanger-dropdown-button
+Selector Data: button[aria-label='More actions']
+Description: The down arrow next to the "Not now" button 
+Location: Inside the autofill save credit card doorhanger that is triggered in navigation bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: doorhanger-dropdown-never-save-cards-button
+Selector Data: menuitem[label='Never save cards']
+Description: The hidden button in save credit card doorhanger.
+Location: Inside the autofill save credit card doorhanger, accessible by clicking the down arrow next to the "Not now" button
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: doorhanger-update-button
+Selector Data: button[label='Update']
+Description: The "Update" button 
+Location: Inside the autofill save addreses doorhanger that is triggered in navigation bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: select-form-option
+Selector Data: .autocomplete-richlistbox .autocomplete-richlistitem
+Description: An individual entry within the autofill dropdown, representing a selectable suggestion such as a name, address, or card number
+Location: Appears as part of the dropdown under the autofill panel, within any eligible form field when suggestions are available.
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: clear-form-option
+Selector Data: .autocomplete-richlistbox .autocomplete-richlistitem[ac-value='Clear Autofill Form']
+Description: The "Clear Autofill Form" option in the dropdown that appears when interacting with an autofill-enabled input field
+Location: Appears as part of the dropdown under the autofill panel, within any eligible form field after a field was autofilled.
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: update-card-info-popup-button
+Selector Data: button[label='Update existing card']
+Description: The "Update existing card" button 
+Location: Inside the autofill save credit card doorhanger that is triggered in navigation bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: cc-saved-options
+Selector Data: option[data-l10n-id='credit-card-label-number-name-expiration-2']
+Description: The actually "Add card" modal, containing 4 fields
+Location: Inside the "Add card" form in the Saved payment methods section on the about:preferences#privacy page
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector name: cc-popup-button
+Selector Data: button[data-l10n-id='{name}']
+Description: "Add" button 
+Location: Inside the "Saved payment methods" form in the Saved payment methods section on the about:preferences#privacy page
+Path to .json: modules/data/autofill_popup.components.json
+```
+```

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -33,7 +33,7 @@ class AutofillPopup(BasePage):
         """Verifies that the autofill popup is clickable"""
         with self.driver.context(self.driver.CONTEXT_CHROME):
             self.expect(
-                EC.element_to_be_clickable(self.get_element("autofill-cc-panel"))
+                EC.element_to_be_clickable(self.get_element("select-form-option"))
             )
 
     # Interaction with popup elements

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -1,20 +1,14 @@
 {
     "context": "chrome",
-    "doorhanger-save-button": {
-        "selectorData": "button[label='Save'].popup-notification-primary-button",
-        "strategy": "css",
-        "groups": []
-    },
-
     "autofill-panel": {
         "selectorData": "PopupAutoComplete",
         "strategy": "id",
         "groups": []
     },
 
-    "autofill-item": {
-        "selectorData": "autocomplete-richlistitem",
-        "strategy": "class",
+    "doorhanger-save-button": {
+        "selectorData": "button[label='Save'].popup-notification-primary-button",
+        "strategy": "css",
         "groups": []
     },
 
@@ -48,21 +42,9 @@
          "groups": []
     },
 
-    "autofill-cc-panel": {
-        "selectorData": "autocomplete-richlistbox",
-        "strategy": "class",
-        "groups": []
-    },
-
     "update-card-info-popup-button": {
         "selectorData": "button[label='Update existing card']",
         "strategy": "css",
-        "groups": []
-    },
-
-    "autofill-profile-option": {
-        "selectorData": "autocomplete-richlistitem",
-        "strategy": "class",
         "groups": []
     },
 

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -96,7 +96,7 @@ class CreditCardFill(Autofill):
         """
         self.double_click("form-field", labels=["cc-name"])
         with self.driver.context(self.driver.CONTEXT_CHROME):
-            ccp.get_element("autofill-profile-option").click()
+            ccp.get_element("select-form-option").click()
 
         info_list = self.extract_credit_card_obj_into_list(credit_card_sample_data)
         for i in range(len(info_list)):
@@ -155,7 +155,7 @@ class CreditCardFill(Autofill):
         """
         self.double_click("form-field", labels=["cc-name"])
         with self.driver.context(self.driver.CONTEXT_CHROME):
-            credit_card_popoup_obj.get_element("autofill-profile-option").click()
+            credit_card_popoup_obj.get_element("select-form-option").click()
 
     def update_credit_card_information(
         self,

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -1,6 +1,7 @@
-import pytest
-import shutil
 import os
+import shutil
+
+import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object_context_menu import ContextMenu
@@ -13,28 +14,34 @@ from modules.page_object_prefs import AboutPrefs
 def test_case():
     return "1756743"
 
+
 ZIP_URL = "https://github.com/microsoft/api-guidelines"
+
 
 @pytest.fixture()
 def delete_files_regex_string():
     return r"api-guidelines-vNext"
 
+
 @pytest.fixture()
 def temp_selectors():
     return {
-        'github-code-button': {
-            'selectorData': ':R55ab:',
-            'strategy': 'id',
-            'groups': []
+        "github-code-button": {
+            "selectorData": ":R55ab:",
+            "strategy": "id",
+            "groups": [],
         },
-        'github-download-button': {
-            'selectorData': 'a[href="/microsoft/api-guidelines/archive/refs/heads/vNext.zip"]',
-            'strategy': 'css',
-            'groups': []
-        }
+        "github-download-button": {
+            "selectorData": 'a[href="/microsoft/api-guidelines/archive/refs/heads/vNext.zip"]',
+            "strategy": "css",
+            "groups": [],
+        },
     }
 
-def test_add_zip_type(driver: Firefox, sys_platform, home_folder, delete_files, temp_selectors):
+
+def test_add_zip_type(
+    driver: Firefox, sys_platform, home_folder, delete_files, temp_selectors
+):
     """
     C1756743: Verify that the user can add the .zip mime type to Firefox
     """
@@ -47,8 +54,8 @@ def test_add_zip_type(driver: Firefox, sys_platform, home_folder, delete_files, 
     web_page.elements |= temp_selectors
 
     # Click on the available zip
-    web_page.click_on('github-code-button')
-    web_page.click_on('github-download-button')
+    web_page.click_on("github-code-button")
+    web_page.click_on("github-download-button")
 
     # In the download panel right-click on the download and click "Always Open Similar Files"
     with driver.context(driver.CONTEXT_CHROME):

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -13,9 +13,11 @@ from modules.page_object import GenericPage
 def test_case():
     return "1756722"
 
+
 @pytest.fixture()
 def delete_files_regex_string():
     return r"\bdownload\b"
+
 
 MIXED_CONTENT_DOWNLOAD_URL = "https://b-mcb-download.glitch.me/"
 


### PR DESCRIPTION
### Description

Provide documentation for the autofill popup selectors . As part of the consoldation task (1916812), credit_card_popup.components.json and about_prefs_cc_popup.components.json were merge into autofill_popup.components.json. While working on the documentation, I noticed locators targeting the same element but using different names or/and strategies. I removed the duplicates and ensured the tests were updated accordingly.


### Bugzilla bug ID

**Testrail: N/A**
**Links:
https://bugzilla.mozilla.org/show_bug.cgi?id=1915935
https://bugzilla.mozilla.org/show_bug.cgi?id=1915914
https://bugzilla.mozilla.org/show_bug.cgi?id=1915931**

### Type of change

Please delete options that are not relevant.

- [x ] Documentation

### How does this resolve / make progress on that bug?

Completed

### Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

### Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
