### PR TITLE
Pat/added a test, did cleanup

### DIFF
--- a/tests/downloads/test_set_always_ask_file_type.py
+++ b/tests/downloads/test_set_always_ask_file_type.py
@@ -1,0 +1,45 @@
+from time import sleep
+
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+from modules.browser_object import Navigation
+from modules.page_object import AboutPrefs
+
+
+@pytest.fixture()
+def test_case():
+    return "1756752"
+
+@pytest.fixture()
+def delete_files_regex_string():
+    return r"pdf-example-bookmarks.pdf"
+
+
+CONTENT_DISPOSITION_ATTACHMENT_URL = (
+    "https://download.novapdf.com/download/samples/pdf-example-bookmarks.pdf"
+)
+
+
+def test_set_always_ask_file_type(driver: Firefox, delete_files):
+    """
+    C1756752: Ensure that the Always ask option in Firefox Applications settings
+    leads to a dialog asking "What should Firefox do with this file?" when the file type
+    is downloaded.
+    """
+    nav = Navigation(driver)
+    about_prefs = AboutPrefs(driver, category="general").open()
+
+    about_prefs.click_on("pdf-content-type")
+    about_prefs.click_on("pdf-actions-menu")
+    menu = about_prefs.get_element("pdf-actions-menu")
+    menu.send_keys(Keys.DOWN)
+    menu.send_keys(Keys.ENTER)
+
+    nav.search(CONTENT_DISPOSITION_ATTACHMENT_URL)
+    sleep(2)
+    with driver.context(driver.CONTEXT_CHROME):
+        driver.switch_to.window(driver.window_handles[-1])
+        driver.find_element(By.ID, "unknownContentTypeWindow").send_keys(Keys.ESCAPE)

--- a/tests/pdf_viewer/test_download_triggered_on_content_disposition_attachment.py
+++ b/tests/pdf_viewer/test_download_triggered_on_content_disposition_attachment.py
@@ -13,13 +13,17 @@ from modules.page_object import AboutPrefs, GenericPdf
 def test_case():
     return "936502"
 
+@pytest.fixture()
+def delete_files_regex_string():
+    return r"pdf-example-bookmarks.pdf"
+
 
 CONTENT_DISPOSITION_ATTACHMENT_URL = (
     "https://download.novapdf.com/download/samples/pdf-example-bookmarks.pdf"
 )
 
 
-def test_download_panel_triggered_on_content_disposition_attachment(driver: Firefox):
+def test_download_panel_triggered_on_content_disposition_attachment(driver: Firefox, delete_files):
     """
     C936502: Ensure that the Always ask option in Firefox Applications settings
     triggers the download panel for PDFs with Content-Disposition: attachment.


### PR DESCRIPTION
### Description

Created new test for verifying that the user can set Firefox to "Always Ask" for a file type (PDF).
Deleted the file created by test_download_triggered_on_content_disposition_attachment.py

### Bugzilla bug ID

**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1919623

### Type of change

Please delete options that are not relevant.

- [x] New Test
- [x] Other Changes (Clean up)

### How does this resolve / make progress on that bug?

Completed

### Screenshots / Explanations

N/A

### Comments / Concerns

N/A
