### PR TITLE
Hani/add password non ascii chars

### DIFF
--- a/modules/data/about_logins.components.json
+++ b/modules/data/about_logins.components.json
@@ -66,6 +66,15 @@
         "strategy": "class",
         "shadowParent": "form-actions-row",
         "groups": []
+    },
+
+    "login-list-item": {
+        "selectorData": "list-item",
+        "strategy": "class",
+        "shadowParent": "login-list",
+        "groups": [
+            "doNotCache"
+        ]
     }
 
 }

--- a/tests/credential/test_add_password_non_ascii_chars.py
+++ b/tests/credential/test_add_password_non_ascii_chars.py
@@ -29,3 +29,9 @@ def test_add_password_non_ascii_chars(driver: Firefox):
         }
     )
 
+    # Check password added in the listbox
+    about_logins.get_element("login-list-item")
+    logins = about_logins.get_elements("login-list-item")
+    mozilla_login = next(login for login in logins if login.get_attribute("title") == "mozilla.org")
+    assert mozilla_login
+

--- a/tests/credential/test_add_password_non_ascii_chars.py
+++ b/tests/credential/test_add_password_non_ascii_chars.py
@@ -1,0 +1,31 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+
+from modules.page_object import AboutLogins
+
+
+@pytest.fixture()
+def test_case():
+    return "2241113"
+
+
+def test_add_password_non_ascii_chars(driver: Firefox):
+    """
+    C2241113 Add password - non-ascii characters
+    """
+    # instantiate object
+    about_logins = AboutLogins(driver).open()
+
+    # Click on the "Add password" button
+    about_logins.click_add_login_button()
+
+    # Complete all the fields with valid data and click the "Save" button.
+    about_logins.create_new_login(
+        {
+            "origin": "mozilla.org",
+            "username": "Â£$Âµâ†’â€œ",
+            "password": "Â£$Âµâ†’â€œ",
+        }
+    )
+


### PR DESCRIPTION
### Description

Verify that a password with non-ascii characters can be added and saved.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2241113**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1920183**

### Type of change

Please delete options that are not relevant.

- [ ] New Test

### How does this resolve / make progress on that bug?

Completed

### Screenshots / Explanations

N/A

### Comments / Concerns

N/A
