### PR TITLE
Anca/autosaved password when generated from context menu

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -224,6 +224,27 @@ Description: New login page's Save button
 Location: The about:login's new login page
 Path to .json: modules/data/about_logins.components.json
 ```
+```
+Selector Name: website-address
+Selector Data: ".origin-input"
+Description: The website address row
+Location: The about:login's main login page
+Path to .json: modules/data/about_logins.components.json
+```
+```
+Selector Name: username-field
+Selector Data: ".detail-row input[name='username']"
+Description: The Username field
+Location: The about:login's main login page
+Path to .json: modules/data/about_logins.components.json
+```
+```
+Selector Name: password-field
+Selector Data: ".detail-row .reveal-password-wrapper input.password-display, .detail-row .reveal-password-wrapper input[name='password']"
+Description: The Password field
+Location: The about:login's main login page
+Path to .json: modules/data/about_logins.components.json
+```
 #### about_newtab
 ```
 Selector Name: incontent-search-input
@@ -1220,6 +1241,13 @@ Description: Context menu option "Paste"
 Location: Any text field cntext menu
 Path to .json: modules/data/context_menu.components.json
 ```
+```
+Selector Name: context-menu-suggest-strong-password
+Selector Data: "fill-login-generated-password"
+Description: Context menu option from Password field
+Location: Login page - Password field context menu
+Path to .json: modules/data/context_menu.components.json
+```
 #### credit_card_fill
 ```
 Selector Name: form-field
@@ -1443,6 +1471,13 @@ Selector Name: submit-button-login
 Selector Data: /html/body/div[1]/form[2]/input[3]
 Description: Login submit button
 Location: Submit button in the login demo page 
+Path to .json: modules/data/login_autofill.components.json
+```
+```
+Selector Name: generated-securely-password
+Selector Data: ".autocomplete-richlistbox .autocomplete-richlistitem[ac-value='Use a Securely Generated Password']"
+Description: Use a Securely Generated Password option
+Location: The dropdown under the password field in a login page
 Path to .json: modules/data/login_autofill.components.json
 ```
 #### navigation
@@ -1885,6 +1920,20 @@ Selector Name: bookmark-current-tab
 Selector Data: panelMenuBookmarkThisPage
 Description: Bookmark current tab button
 Location: Menu button / hamburger menu
+Path to .json: modules/data/navigation.components.json
+```
+```
+Selector Name: password-notification-key
+Selector Data: "box#notification-popup-box image#password-notification-icon.notification-anchor-icon"
+Description: The key icon
+Location: In the Navigation bar, next to the url input field
+Path to .json: modules/data/navigation.components.json
+```
+```
+Selector Name: password-update-doorhanger
+Selector Data: "//*[contains(@class, 'popup-notification-description') and @popupid='password']"
+Description: The password update doorhanger
+Location: In the Navigation bar, next to the url input field, after the key icon was pressed
 Path to .json: modules/data/navigation.components.json
 ```
 #### panel_ui

--- a/modules/data/about_logins.components.json
+++ b/modules/data/about_logins.components.json
@@ -66,6 +66,27 @@
         "strategy": "class",
         "shadowParent": "form-actions-row",
         "groups": []
+    },
+
+    "website-address": {
+        "selectorData": ".origin-input",
+        "strategy": "css",
+        "shadowParent": "login-item",
+        "groups": []
+    },
+
+    "username-field": {
+        "selectorData": ".detail-row input[name='username']",
+        "strategy": "css",
+        "shadowParent": "login-item",
+        "groups": []
+    },
+
+    "password-field": {
+        "selectorData": ".detail-row .reveal-password-wrapper input.password-display, .detail-row .reveal-password-wrapper input[name='password']",
+        "strategy": "css",
+        "shadowParent": "login-item",
+        "groups": []
     }
 
 }

--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -167,5 +167,11 @@
         "selectorData": "context-paste",
         "strategy": "id",
         "groups": []
+    },
+
+    "context-menu-suggest-strong-password": {
+        "selectorData": "fill-login-generated-password",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/modules/data/login_autofill.components.json
+++ b/modules/data/login_autofill.components.json
@@ -47,5 +47,11 @@
         "selectorData": "/html/body/div[1]/form[2]/input[3]",
         "strategy": "xpath",
         "groups": []
+    },
+
+     "generated-securely-password": {
+        "selectorData": ".autocomplete-richlistbox .autocomplete-richlistitem[ac-value='Use a Securely Generated Password']",
+        "strategy": "css",
+        "groups": []
     }
 }

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -455,5 +455,17 @@
         "selectorData": "menuitem[label='Gort! Klaatu barada nikto!']",
         "strategy": "css",
         "groups": []
+     },
+
+    "password-notification-key": {
+        "selectorData": "box#notification-popup-box image#password-notification-icon.notification-anchor-icon",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "password-update-doorhanger": {
+        "selectorData": "//*[contains(@class, 'popup-notification-description') and @popupid='password']",
+        "strategy": "xpath",
+        "groups": []
     }
 }

--- a/tests/bookmarks_and_history/test_delete_other_bookmarks.py
+++ b/tests/bookmarks_and_history/test_delete_other_bookmarks.py
@@ -9,21 +9,22 @@ from modules.classes.bookmark import Bookmark
 from modules.page_object import GenericPage
 from modules.util import BrowserActions
 
-
 BOOKMARK_URL = "about:robots"
 BOOKMARK_URL_2 = "about:cache"
 
 
 WIN_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("win")
 
+
 @pytest.fixture()
 def test_case():
     return "2084524"
 
+
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
 def test_delete_other_bookmarks(driver: Firefox):
     """
-        C2084524: Verify that a user can Delete a bookmark from 'Other Bookmarks' folder
+    C2084524: Verify that a user can Delete a bookmark from 'Other Bookmarks' folder
     """
     nav = Navigation(driver)
     GenericPage(driver, url=BOOKMARK_URL).open()
@@ -51,4 +52,3 @@ def test_delete_other_bookmarks(driver: Firefox):
         nav.context_click("bookmark-about-robots")
         context_menu.click_and_hide_menu("context-menu-delete-page")
         nav.element_not_visible("bookmark-about-robots")
-

--- a/tests/downloads/test_set_always_ask_file_type.py
+++ b/tests/downloads/test_set_always_ask_file_type.py
@@ -13,6 +13,7 @@ from modules.page_object import AboutPrefs
 def test_case():
     return "1756752"
 
+
 @pytest.fixture()
 def delete_files_regex_string():
     return r"pdf-example-bookmarks.pdf"

--- a/tests/password_manager/test_auto_saved_generated_password_context_menu.py
+++ b/tests/password_manager/test_auto_saved_generated_password_context_menu.py
@@ -1,0 +1,58 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import ContextMenu, Navigation, TabBar
+from modules.page_object import AboutLogins, LoginAutofill
+
+
+@pytest.fixture()
+def test_case():
+    return "2248176"
+
+
+@pytest.fixture()
+def set_prefs():
+    """Set prefs"""
+    return [("signon.rememberSignons", True)]
+
+
+def test_auto_saved_generated_password_context_menu(driver: Firefox):
+    """
+    C2241087 - Securely Generated Password is auto-saved when generated from password field context menu
+    """
+
+    context_menu = ContextMenu(driver)
+    tabs = TabBar(driver)
+    login_autofill = LoginAutofill(driver).open()
+    nav = Navigation(driver)
+    about_logins = AboutLogins(driver)
+
+    # Select "Suggest Strong Password..." from password field context menu
+    password_field = login_autofill.get_element("password-login-field")
+    login_autofill.context_click(password_field)
+    context_menu.click_context_item("context-menu-suggest-strong-password")
+
+    # Select "Use a Securely Generated Password" in password field and check the "Update password" doorhanger
+    # is displayed
+    with driver.context(driver.CONTEXT_CHROME):
+        login_autofill.get_element("generated-securely-password").click()
+        nav.element_visible("password-notification-key")
+        nav.click_on("password-notification-key")
+        update_doorhanger = nav.get_element("password-update-doorhanger")
+        assert update_doorhanger.text == "Update password for mozilla.github.io?"
+
+    # Navigate to about:logins page
+    tabs.switch_to_new_tab()
+    about_logins.open()
+
+    # Verify the website address saves the correct value
+    website_address_element = about_logins.get_element("website-address")
+    assert website_address_element.get_attribute("href") == "https://mozilla.github.io/"
+
+    # Verify the username field has no value
+    username_element = about_logins.get_element("username-field")
+    assert username_element.get_attribute("placeholder") == "(no username)"
+
+    # Verify the password field is filled with a value
+    password_element = about_logins.get_element("password-field")
+    assert password_element.get_attribute("tabindex") == "-1"

--- a/tests/pdf_viewer/test_download_triggered_on_content_disposition_attachment.py
+++ b/tests/pdf_viewer/test_download_triggered_on_content_disposition_attachment.py
@@ -13,6 +13,7 @@ from modules.page_object import AboutPrefs, GenericPdf
 def test_case():
     return "936502"
 
+
 @pytest.fixture()
 def delete_files_regex_string():
     return r"pdf-example-bookmarks.pdf"
@@ -23,7 +24,9 @@ CONTENT_DISPOSITION_ATTACHMENT_URL = (
 )
 
 
-def test_download_panel_triggered_on_content_disposition_attachment(driver: Firefox, delete_files):
+def test_download_panel_triggered_on_content_disposition_attachment(
+    driver: Firefox, delete_files
+):
     """
     C936502: Ensure that the Always ask option in Firefox Applications settings
     triggers the download panel for PDFs with Content-Disposition: attachment.


### PR DESCRIPTION
### Description

Verify  that "Securely Generated Password" is auto-saved when generated from password field context menu

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2248176**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1920209**

### Type of change

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

### Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
