### PR TITLE
Fix test misusing context menu item clicking

### DIFF
--- a/tests/bookmarks_and_history/test_delete_other_bookmarks.py
+++ b/tests/bookmarks_and_history/test_delete_other_bookmarks.py
@@ -9,21 +9,22 @@ from modules.classes.bookmark import Bookmark
 from modules.page_object import GenericPage
 from modules.util import BrowserActions
 
-
 BOOKMARK_URL = "about:robots"
 BOOKMARK_URL_2 = "about:cache"
 
 
 WIN_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("win")
 
+
 @pytest.fixture()
 def test_case():
     return "2084524"
 
+
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
 def test_delete_other_bookmarks(driver: Firefox):
     """
-        C2084524: Verify that a user can Delete a bookmark from 'Other Bookmarks' folder
+    C2084524: Verify that a user can Delete a bookmark from 'Other Bookmarks' folder
     """
     nav = Navigation(driver)
     GenericPage(driver, url=BOOKMARK_URL).open()
@@ -51,4 +52,3 @@ def test_delete_other_bookmarks(driver: Firefox):
         nav.context_click("bookmark-about-robots")
         context_menu.click_and_hide_menu("context-menu-delete-page")
         nav.element_not_visible("bookmark-about-robots")
-

--- a/tests/menus/test_tab_context_menu_close.py
+++ b/tests/menus/test_tab_context_menu_close.py
@@ -73,7 +73,7 @@ def test_close_multiple_tabs_other_tabs(driver: Firefox):
     # grab second tab and close all other tabs using the context menu
     second_tab = tabs.get_tab(2)
     tabs.context_click(second_tab)
-    tab_context_menu.click_and_hide_menu("context-menu-close-multiple-tabs")
+    tab_context_menu.click_context_item("context-menu-close-multiple-tabs")
 
     tabs.context_click(second_tab)
     tab_context_menu.click_and_hide_menu("context-menu-close-multiple-tabs-other-tabs")

--- a/tests/password_manager/test_about_logins_navigation_from_context_menu.py
+++ b/tests/password_manager/test_about_logins_navigation_from_context_menu.py
@@ -23,7 +23,7 @@ def test_about_logins_navigation_from_login_form_context_menu(driver: Firefox):
     # Access the manage passwords in context menu from the username field in the demo login form
     username_field = login.get_element("username-field")
     login.context_click(username_field)
-    context_menu.click_context_item("context-menu-manage-passwords")
+    context_menu.click_and_hide_menu("context-menu-manage-passwords")
 
     # Verify that the about:logins page is opened in a new tab
     tabs.wait_for_num_tabs(2)

--- a/tests/pdf_viewer/test_download_pdf_from_context_menu.py
+++ b/tests/pdf_viewer/test_download_pdf_from_context_menu.py
@@ -40,7 +40,7 @@ def test_download_pdf_from_context_menu(
     # Right-click on the body of the file and select Save page as
     pdf.context_click(body)
     context_menu = ContextMenu(driver)
-    context_menu.click_context_item("context-menu-save-page-as")
+    context_menu.click_and_hide_menu("context-menu-save-page-as")
 
     # Allow time for the save dialog to appear and handle prompt
     sleep(2)


### PR DESCRIPTION
### Description
I discovered some tests were improperly using `context_click_item()` instead of `click_and_hide_menu()`. The latter clicks the item and ensures the context menu is closed. We should favor its use, unless it is needed by the test to have the context menu remain open.   `click_and_hide_menu()` ensures menus are closed and not blocking next steps.  This PR refactors tests that didn't need to keep the menu open after the menu option was clicked.

#### Bugzilla bug ID
none filed

#### Type of change
- [X] test case stabilization


