### PR TITLE
Anca/save login via save password doorhanger

### DIFF
--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -323,7 +323,7 @@ class LoginAutofill(Autofill):
         def submit(self) -> None:
             if self.submit_button is None:
                 self.submit_button = self.parent.get_element("submit-button-login")
-            self.submit_button.get_element()
+            self.submit_button.click()
 
 
 class AddressFill(Autofill):

--- a/tests/password_manager/test_save_login_via_doorhanger.py
+++ b/tests/password_manager/test_save_login_via_doorhanger.py
@@ -1,0 +1,54 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation, TabBar
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object import LoginAutofill
+
+
+@pytest.fixture()
+def test_case():
+    return "2243016"
+
+
+@pytest.fixture()
+def set_prefs():
+    """Set prefs"""
+    return [("signon.rememberSignons", True), ("signon.autofillForms", True)]
+
+
+def test_save_login_via_doorhanger(driver: Firefox):
+    """
+    C2243016 -  Verify that Firefox successfully saves login credentials via the save password doorhanger and
+    autofill them on subsequent access
+    """
+
+    login_autofill = LoginAutofill(driver).open()
+    autofill_popup_panel = AutofillPopup(driver)
+    tabs = TabBar(driver)
+    nav = Navigation(driver)
+
+    # Creating an instance of the LoginForm within the LoginAutofill page object
+    login_form = LoginAutofill.LoginForm(login_autofill)
+
+    # Fill in the login form in demo page, save the login credentials via the doorhanger and see the doorhanger is
+    # dismissed
+    login_form.fill_username("testUser")
+    login_form.fill_password("testPassword")
+    login_form.submit()
+
+    autofill_popup_panel.click_doorhanger_button("save")
+    nav.element_not_visible("password-notification-key")
+
+    # Open demo page in a new tab
+    tabs.switch_to_new_tab()
+    login_autofill.open()
+
+    # Verify the username field has the saved value
+    username_element = login_autofill.get_element("username-login-field")
+    assert username_element.get_attribute("value") == "testUser"
+
+    # Verify the password field is filled with a value that match the length of the saved password
+    password_element = login_autofill.get_element("password-login-field")
+    masked_password_value = password_element.get_attribute("value")
+    assert len(masked_password_value) == 12


### PR DESCRIPTION
### Description

- Verify that Firefox successfully saves login credentials via the save password doorhanger and autofill them on subsequent access.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2243016**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1920203**

### Type of change

- [ x] New Test

### How does this resolve / make progress on that bug?
- Completed

### Screenshots / Explanations
- N/A 

### Comments / Concerns
- In this test, I can only verify the length of the password field's value, not the actual password itself. this limitation exists because the password field content is masked (for security reasons) and cannot be directly accessed. Therefore, to validate the presence of a password, I assert that the length of the masked value matches the expected length.
