### PR TITLE
Add test case for C2245178 -Primary password setup

### DIFF
--- a/tests/preferences/test_setup_primary_password.py
+++ b/tests/preferences/test_setup_primary_password.py
@@ -1,0 +1,52 @@
+import pytest
+import time
+from selenium.webdriver import Firefox
+@pytest.fixture()
+def test_case():
+    return "C2245178"
+def test_primary_password_setup(driver: Firefox):
+    """
+    C2245178 - Primary Password Setup
+    """
+    driver.get("about:preferences#privacy")
+    time.sleep(2)
+    assert driver.execute_script("""
+        const checkbox = document.querySelector('#useMasterPassword');
+        if (checkbox && !checkbox.checked) {
+            checkbox.click();
+            return true;
+        }
+        return checkbox ? checkbox.checked : false;
+    """), "Failed to click checkbox"
+    
+    time.sleep(2)
+    password_data = {
+        "primary_password": "TestPassword123",
+        "confirm_password": "TestPassword123"
+    }
+    
+    assert driver.execute_script(f"""
+        return new Promise(resolve => {{
+            const doc = document.querySelector('browser.dialogFrame').contentDocument;
+            const pw1 = doc.querySelector('input#pw1');
+            const pw2 = doc.querySelector('input#pw2');
+            if (!pw1 || !pw2) return resolve(false);
+            pw1.value = "{password_data['primary_password']}";
+            pw2.value = "{password_data['confirm_password']}";
+            [pw1, pw2].forEach(i => i.dispatchEvent(new Event('input', {{bubbles: true}})));
+            setTimeout(() => {{
+                const okButton = doc.querySelector('dialog#changemp')?.shadowRoot
+                    ?.querySelector('button[dlgtype="accept"][label="OK"]');
+                okButton ? (okButton.click(), resolve(true)) : resolve(false);
+            }}, 1000);
+        }});
+    """), "Failed to set password"
+    time.sleep(2)
+    
+    # Try to handle the alert
+    driver.switch_to.alert.accept()
+    time.sleep(2)
+    assert driver.execute_script("""
+        return document.querySelector('#useMasterPassword')?.checked;
+    """), "Verification failed"
+    driver.quit()


### PR DESCRIPTION
### Description

Automates the Primary Password setup in Firefox for test case C2245178. Verifies functionality and handles confirmation dialogs.

### Bugzilla bug ID

**Testrail:** C2245178
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1920205

### Type of change

- [ ] New Test

### How does this resolve / make progress on that bug?

Automates testing of the Primary Password feature, ensuring expected functionality.

### Screenshots / Explanations

No Screenshots available.

### Comments / Concerns

Couldn't find suitable functions in the AboutPrefs class; this could be achieved using the classes I built as well (which is not in this PR but in my local repo).
