### PR TITLE
Anca/Never save login via doorhanger (exception added)

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -842,6 +842,13 @@ Description: PDF content type options list
 Location: about:preferences#general Applications subsection
 Path to .json: modules/data/about_prefs.components.json
 ```
+```
+Selector Name: exceptions-item
+Selector Data: "//*[@id='permissionsBox']//*[@origin]"
+Description: Website list
+Location: about:preferences#privacy in Exceptions - Saved Passwords modal
+Path to .json: modules/data/about_prefs.components.json
+```
 #### about_profiles
 ```
 Selector Name: profile-container
@@ -1014,6 +1021,13 @@ Selector Name: doorhanger-dropdown-never-save-cards-button
 Selector Data: "menuitem[label='Never save cards']"
 Description: The hidden button in save credit card doorhanger.
 Location: Inside the autofill save credit card doorhanger, accessible by clicking the down arrow next to the "Not now" button
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector Name: doorhanger-never-save-login-button
+Selector Data: "menuitem[label='Never save']"
+Description: The hidden button in save login doorhanger.
+Location: Inside the autofill save login doorhanger, accessible by clicking the down arrow next to the "Not now" button
 Path to .json: modules/data/autofill_popup.components.json
 ```
 ```

--- a/conftest.py
+++ b/conftest.py
@@ -23,12 +23,6 @@ TESTRAIL_FX_DESK_PRJ = "17"
 TESTRAIL_RUN_FMT = "[{channel} {major}] Automated testing {major}.{minor}b{build}"
 
 
-@pytest.fixture
-def json_metadata():
-    # Initialize an empty dictionary to store metadata
-    return {}
-
-
 def screenshot_content(driver: Firefox, opt_ci: bool, test_name: str) -> None:
     """
     Screenshots the current browser, saves with appropriate test name and date for reference

--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,12 @@ TESTRAIL_FX_DESK_PRJ = "17"
 TESTRAIL_RUN_FMT = "[{channel} {major}] Automated testing {major}.{minor}b{build}"
 
 
+@pytest.fixture
+def json_metadata():
+    # Initialize an empty dictionary to store metadata
+    return {}
+
+
 def screenshot_content(driver: Firefox, opt_ci: bool, test_name: str) -> None:
     """
     Screenshots the current browser, saves with appropriate test name and date for reference

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -443,5 +443,11 @@
         "selectorData": "richlistitem[type='application/pdf'] menulist.actionsMenu",
         "strategy": "css",
         "groups": []
+    },
+
+    "exceptions-item": {
+        "selectorData": "//*[@id='permissionsBox']//*[@origin]",
+        "strategy": "xpath",
+        "groups": []
     }
 }

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -24,6 +24,12 @@
         "groups": []
     },
 
+    "doorhanger-never-save-login-button": {
+        "selectorData": "menuitem[label='Never save']",
+        "strategy": "css",
+        "groups": []
+    },
+
     "doorhanger-update-button": {
         "selectorData": "button[label='Update']",
         "strategy": "css",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -252,6 +252,16 @@ class AboutPrefs(BasePage):
         iframe = self.get_element("browser-popup")
         return iframe
 
+    def get_password_exceptions_popup_iframe(self) -> WebElement:
+        """
+        Returns the iframe object for the Password Exceptions dialog panel in the popup.
+        """
+        # Click on the "Password Exceptions" button
+        self.get_element("logins-exceptions").click()
+        # Get the iframe element for the popup
+        iframe = self.get_element("browser-popup")
+        return iframe
+
     def get_clear_cookie_data_value(self) -> int:
         """
         With the 'Clear browsing data and cookies' popup open,

--- a/tests/password_manager/test_never_save_login_via_doorhanger.py
+++ b/tests/password_manager/test_never_save_login_via_doorhanger.py
@@ -1,0 +1,68 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import AutofillPopup, Navigation, TabBar
+from modules.page_object import AboutPrefs, LoginAutofill
+from modules.util import BrowserActions
+
+
+@pytest.fixture()
+def test_case():
+    return "2243012"
+
+
+@pytest.fixture()
+def set_prefs():
+    """Set prefs"""
+    return [("signon.rememberSignons", True), ("signon.autofillForms", True)]
+
+
+def test_never_save_login_via_doorhanger(driver: Firefox):
+    """
+    C22243012 - Verify that selecting the 'Never Save' option in the password doorhanger prevents Firefox from saving
+    the login credentials. Ensure that on subsequent access, the username and password fields remain empty in the
+    login form. Additionally, confirm that the demo page is correctly added to the 'Exceptions - Saved Passwords'
+    list in the browser's preferences.
+    """
+
+    login_autofill = LoginAutofill(driver).open()
+    autofill_popup_panel = AutofillPopup(driver)
+    tabs = TabBar(driver)
+    nav = Navigation(driver)
+    ba = BrowserActions(driver)
+
+    # Creating an instance of the LoginForm within the LoginAutofill page object
+    login_form = LoginAutofill.LoginForm(login_autofill)
+
+    # Fill in the login form in demo page, opt for Never Save the credentials via doorhanger and see the doorhanger is
+    # dismissed
+    login_form.fill_username("testUser")
+    login_form.fill_password("testPassword")
+    login_form.submit()
+
+    autofill_popup_panel.click_doorhanger_button("never-save-login")
+    nav.element_not_visible("password-notification-key")
+
+    # Open demo page in a new tab
+    tabs.switch_to_new_tab()
+    login_autofill.open()
+
+    # Verify the username and password filed have empty values
+    username_element = login_autofill.get_element("username-login-field")
+    assert username_element.get_attribute("value") == ""
+
+    password_element = login_autofill.get_element("password-login-field")
+    masked_password_value = password_element.get_attribute("value")
+    assert len(masked_password_value) == 0
+
+    # Navigate to about:preferences#privacy and open Exceptions - Saved Passwords modal
+    about_prefs = AboutPrefs(driver, category="privacy").open()
+    iframe = about_prefs.get_password_exceptions_popup_iframe()
+    ba.switch_to_iframe_context(iframe)
+
+    # Verify that the demo page used in the test appears in the Exceptions list
+    password_exceptions_element = about_prefs.get_element("exceptions-item")
+    assert (
+        password_exceptions_element.get_attribute("origin")
+        == "https://mozilla.github.io"
+    )

--- a/tests/password_manager/test_never_save_login_via_doorhanger.py
+++ b/tests/password_manager/test_never_save_login_via_doorhanger.py
@@ -45,11 +45,13 @@ def test_never_save_login_via_doorhanger(driver: Firefox):
     # Verify the username and password fields have empty values
     login_autofill.open()
 
+    # Verify the username field is empty
     username_element = login_autofill.get_element("username-login-field")
-    assert username_element.get_attribute("value") == ""
+    login_autofill.wait.until(lambda _: username_element.get_attribute("value") == "")
 
+    # Verify the password field is empty
     password_element = login_autofill.get_element("password-login-field")
-    assert password_element.get_attribute("value") == ""
+    login_autofill.wait.until(lambda _: password_element.get_attribute("value") == "")
 
     # Navigate to about:preferences#privacy and open Exceptions - Saved Passwords modal
     about_prefs = AboutPrefs(driver, category="privacy").open()

--- a/tests/password_manager/test_never_save_login_via_doorhanger.py
+++ b/tests/password_manager/test_never_save_login_via_doorhanger.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import AutofillPopup, Navigation, TabBar
+from modules.browser_object import AutofillPopup, Navigation
 from modules.page_object import AboutPrefs, LoginAutofill
 from modules.util import BrowserActions
 
@@ -27,7 +27,6 @@ def test_never_save_login_via_doorhanger(driver: Firefox):
 
     login_autofill = LoginAutofill(driver).open()
     autofill_popup_panel = AutofillPopup(driver)
-    tabs = TabBar(driver)
     nav = Navigation(driver)
     ba = BrowserActions(driver)
 
@@ -43,11 +42,9 @@ def test_never_save_login_via_doorhanger(driver: Firefox):
     autofill_popup_panel.click_doorhanger_button("never-save-login")
     nav.element_not_visible("password-notification-key")
 
-    # Open demo page in a new tab
-    tabs.switch_to_new_tab()
+    # Verify the username and password fields have empty values
     login_autofill.open()
 
-    # Verify the username and password filed have empty values
     username_element = login_autofill.get_element("username-login-field")
     assert username_element.get_attribute("value") == ""
 

--- a/tests/password_manager/test_never_save_login_via_doorhanger.py
+++ b/tests/password_manager/test_never_save_login_via_doorhanger.py
@@ -52,8 +52,7 @@ def test_never_save_login_via_doorhanger(driver: Firefox):
     assert username_element.get_attribute("value") == ""
 
     password_element = login_autofill.get_element("password-login-field")
-    masked_password_value = password_element.get_attribute("value")
-    assert len(masked_password_value) == 0
+    assert password_element.get_attribute("value") == ""
 
     # Navigate to about:preferences#privacy and open Exceptions - Saved Passwords modal
     about_prefs = AboutPrefs(driver, category="privacy").open()


### PR DESCRIPTION
### Description

- Verify that selecting the 'Never Save' option in the password doorhanger prevents Firefox from saving the login credentials. Ensure that on subsequent access, the username and password fields remain empty in the login form. Additionally, confirm that the page used is correctly added to the 'Exceptions - Saved Passwords' list in the browser's preferences.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2243012**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1920201**

### Type of change

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A