### PR TITLE
Anca/ Several improvements to my password manager tests

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1058,6 +1058,13 @@ Description: "Add" button
 Location: Inside the "Saved payment methods" form in the Saved payment methods section on the about:preferences#privacy page
 Path to .json: modules/data/autofill_popup.components.json
 ```
+```
+Selector Name: password-update-doorhanger
+Selector Data: "//*[contains(@class, 'popup-notification-description') and @popupid='password']"
+Description: The password update doorhanger
+Location: In the Navigation bar, next to the url input field, after the key icon was pressed
+Path to .json: modules/data/autofill_popup.components.json
+```
 #### context_menu
 ```
 Selector Name: context-menu-search-selected-text
@@ -1257,9 +1264,16 @@ Path to .json: modules/data/context_menu.components.json
 ```
 ```
 Selector Name: context-menu-manage-passwords
-Selector Data: selectorData": "manage-saved-logins
+Selector Data: selectorData": "manage-saved-logins"
 Description: Manage Passwords button
 Location: Any login form field context menu
+Path to .json: modules/data/context_menu.components.json
+```
+```
+Selector Name: context-menu-reveal-password
+Selector Data: selectorData": "context-reveal-password"
+Description: Context menu option from Password field
+Location: Login page - Password field context menu
 Path to .json: modules/data/context_menu.components.json
 ```
 #### credit_card_fill
@@ -2147,13 +2161,6 @@ Selector Name: password-notification-key
 Selector Data: "box#notification-popup-box image#password-notification-icon.notification-anchor-icon"
 Description: The key icon
 Location: In the Navigation bar, next to the url input field
-Path to .json: modules/data/navigation.components.json
-```
-```
-Selector Name: password-update-doorhanger
-Selector Data: "//*[contains(@class, 'popup-notification-description') and @popupid='password']"
-Description: The password update doorhanger
-Location: In the Navigation bar, next to the url input field, after the key icon was pressed
 Path to .json: modules/data/navigation.components.json
 ```
 #### panel_ui

--- a/conftest.py
+++ b/conftest.py
@@ -23,12 +23,6 @@ TESTRAIL_FX_DESK_PRJ = "17"
 TESTRAIL_RUN_FMT = "[{channel} {major}] Automated testing {major}.{minor}b{build}"
 
 
-@pytest.fixture
-def json_metadata():
-    # Initialize an empty dictionary to store metadata
-    return {}
-
-
 def screenshot_content(driver: Firefox, opt_ci: bool, test_name: str) -> None:
     """
     Screenshots the current browser, saves with appropriate test name and date for reference

--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,12 @@ TESTRAIL_FX_DESK_PRJ = "17"
 TESTRAIL_RUN_FMT = "[{channel} {major}] Automated testing {major}.{minor}b{build}"
 
 
+@pytest.fixture
+def json_metadata():
+    # Initialize an empty dictionary to store metadata
+    return {}
+
+
 def screenshot_content(driver: Firefox, opt_ci: bool, test_name: str) -> None:
     """
     Screenshots the current browser, saves with appropriate test name and date for reference

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -52,6 +52,12 @@
         "selectorData": "option[data-l10n-id='credit-card-label-number-name-expiration-2']",
         "strategy": "css",
         "groups": []
+     },
+
+    "password-update-doorhanger": {
+        "selectorData": "//*[contains(@class, 'popup-notification-description') and @popupid='password']",
+        "strategy": "xpath",
+        "groups": []
     }
 }
 

--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -179,5 +179,11 @@
         "selectorData": "manage-saved-logins",
         "strategy": "id",
         "groups": []
+     },
+
+    "context-menu-reveal-password": {
+        "selectorData": "context-reveal-password",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -461,11 +461,5 @@
         "selectorData": "box#notification-popup-box image#password-notification-icon.notification-anchor-icon",
         "strategy": "css",
         "groups": []
-    },
-
-    "password-update-doorhanger": {
-        "selectorData": "//*[contains(@class, 'popup-notification-description') and @popupid='password']",
-        "strategy": "xpath",
-        "groups": []
     }
 }

--- a/tests/password_manager/test_about_logins_navigation_from_hamburger_menu.py
+++ b/tests/password_manager/test_about_logins_navigation_from_hamburger_menu.py
@@ -17,7 +17,10 @@ def test_about_logins_navigation_from_password_hamburger_menu(driver: Firefox):
     panel_ui = PanelUi(driver)
     tabs = TabBar(driver)
 
+    # Access Passwords inside the Hamburger Menu
     panel_ui.open_panel_menu()
     panel_ui.redirect_to_about_logins_page()
+
+    # Verify that the about:logins page is opened in a new tab
     tabs.wait_for_num_tabs(2)
     tabs.title_contains("Passwords")

--- a/tests/password_manager/test_auto_saved_generated_password_context_menu.py
+++ b/tests/password_manager/test_auto_saved_generated_password_context_menu.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import ContextMenu, Navigation, TabBar
+from modules.browser_object import AutofillPopup, ContextMenu, Navigation, TabBar
 from modules.page_object import AboutLogins, LoginAutofill
 
 
@@ -26,6 +26,7 @@ def test_auto_saved_generated_password_context_menu(driver: Firefox):
     login_autofill = LoginAutofill(driver).open()
     nav = Navigation(driver)
     about_logins = AboutLogins(driver)
+    autofill_popup_panel = AutofillPopup(driver)
 
     # Select "Suggest Strong Password..." from password field context menu
     password_field = login_autofill.get_element("password-login-field")
@@ -38,7 +39,9 @@ def test_auto_saved_generated_password_context_menu(driver: Firefox):
         login_autofill.get_element("generated-securely-password").click()
         nav.element_visible("password-notification-key")
         nav.click_on("password-notification-key")
-        update_doorhanger = nav.get_element("password-update-doorhanger")
+        update_doorhanger = autofill_popup_panel.get_element(
+            "password-update-doorhanger"
+        )
         assert update_doorhanger.text == "Update password for mozilla.github.io?"
 
     # Navigate to about:logins page

--- a/tests/password_manager/test_save_login_via_doorhanger.py
+++ b/tests/password_manager/test_save_login_via_doorhanger.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import ContextMenu, Navigation, TabBar
+from modules.browser_object import ContextMenu, Navigation
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object import LoginAutofill
 
@@ -25,7 +25,6 @@ def test_save_login_via_doorhanger(driver: Firefox):
 
     login_autofill = LoginAutofill(driver).open()
     autofill_popup_panel = AutofillPopup(driver)
-    tabs = TabBar(driver)
     nav = Navigation(driver)
     context_menu = ContextMenu(driver)
 
@@ -41,11 +40,9 @@ def test_save_login_via_doorhanger(driver: Firefox):
     autofill_popup_panel.click_doorhanger_button("save")
     nav.element_not_visible("password-notification-key")
 
-    # Open demo page in a new tab
-    tabs.switch_to_new_tab()
+    # Verify the username field has the saved value
     login_autofill.open()
 
-    # Verify the username field has the saved value
     username_element = login_autofill.get_element("username-login-field")
     assert username_element.get_attribute("value") == "testUser"
 
@@ -54,6 +51,6 @@ def test_save_login_via_doorhanger(driver: Firefox):
     login_autofill.context_click(password_field)
     context_menu.click_context_item("context-menu-reveal-password")
 
-    # Verify the password field is filled with a value that match the length of the saved password
+    # Verify the password matches the password value
     password_element = login_autofill.get_element("password-login-field")
     assert password_element.get_attribute("value") == "testPassword"

--- a/tests/password_manager/test_save_login_via_doorhanger.py
+++ b/tests/password_manager/test_save_login_via_doorhanger.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import Navigation, TabBar
+from modules.browser_object import ContextMenu, Navigation, TabBar
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object import LoginAutofill
 
@@ -27,6 +27,7 @@ def test_save_login_via_doorhanger(driver: Firefox):
     autofill_popup_panel = AutofillPopup(driver)
     tabs = TabBar(driver)
     nav = Navigation(driver)
+    context_menu = ContextMenu(driver)
 
     # Creating an instance of the LoginForm within the LoginAutofill page object
     login_form = LoginAutofill.LoginForm(login_autofill)
@@ -48,7 +49,11 @@ def test_save_login_via_doorhanger(driver: Firefox):
     username_element = login_autofill.get_element("username-login-field")
     assert username_element.get_attribute("value") == "testUser"
 
+    # Select Reveal password from password field context menu for headed run purpose only
+    password_field = login_autofill.get_element("password-login-field")
+    login_autofill.context_click(password_field)
+    context_menu.click_context_item("context-menu-reveal-password")
+
     # Verify the password field is filled with a value that match the length of the saved password
     password_element = login_autofill.get_element("password-login-field")
-    masked_password_value = password_element.get_attribute("value")
-    assert len(masked_password_value) == 12
+    assert password_element.get_attribute("value") == "testPassword"

--- a/tests/password_manager/test_save_login_via_doorhanger.py
+++ b/tests/password_manager/test_save_login_via_doorhanger.py
@@ -44,7 +44,9 @@ def test_save_login_via_doorhanger(driver: Firefox):
     login_autofill.open()
 
     username_element = login_autofill.get_element("username-login-field")
-    assert username_element.get_attribute("value") == "testUser"
+    login_autofill.wait.until(
+        lambda _: username_element.get_attribute("value") == "testUser"
+    )
 
     # Select Reveal password from password field context menu for headed run purpose only
     password_field = login_autofill.get_element("password-login-field")
@@ -53,4 +55,6 @@ def test_save_login_via_doorhanger(driver: Firefox):
 
     # Verify the password matches the password value
     password_element = login_autofill.get_element("password-login-field")
-    assert password_element.get_attribute("value") == "testPassword"
+    login_autofill.wait.until(
+        lambda _: password_element.get_attribute("value") == "testPassword"
+    )

--- a/tests/password_manager/test_update_login_via_doorhanger.py
+++ b/tests/password_manager/test_update_login_via_doorhanger.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import ContextMenu, Navigation, TabBar
+from modules.browser_object import ContextMenu, Navigation
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object import LoginAutofill
 
@@ -25,7 +25,6 @@ def test_update_login_via_doorhanger(driver: Firefox):
 
     login_autofill = LoginAutofill(driver).open()
     autofill_popup_panel = AutofillPopup(driver)
-    tabs = TabBar(driver)
     nav = Navigation(driver)
     context_menu = ContextMenu(driver)
 
@@ -37,8 +36,6 @@ def test_update_login_via_doorhanger(driver: Firefox):
     login_form.fill_password("testPassword")
     login_form.submit()
     autofill_popup_panel.click_doorhanger_button("save")
-
-    tabs.switch_to_new_tab()
 
     # Create new objects to prevent stale web elements
     new_login_autofill = LoginAutofill(driver).open()
@@ -56,9 +53,7 @@ def test_update_login_via_doorhanger(driver: Firefox):
     autofill_popup_panel.click_doorhanger_button("update")
     nav.element_not_visible("password-notification-key")
 
-    # Open the login form in a new tab
-    tabs.switch_to_new_tab()
-    login_autofill.open()
+    new_login_autofill.open()
 
     # Select Reveal password from password field context menu for headed run purpose only
     password_field = login_autofill.get_element("password-login-field")

--- a/tests/password_manager/test_update_login_via_doorhanger.py
+++ b/tests/password_manager/test_update_login_via_doorhanger.py
@@ -43,7 +43,9 @@ def test_update_login_via_doorhanger(driver: Firefox):
 
     # Verify the initial password value
     password_element = login_autofill.get_element("password-login-field")
-    assert password_element.get_attribute("value") == "testPassword"
+    login_autofill.wait.until(
+        lambda _: password_element.get_attribute("value") == "testPassword"
+    )
 
     # Add several characters inside the password field in demo page, update the login credentials via the doorhanger
     # and see the doorhanger is dismissed
@@ -62,4 +64,6 @@ def test_update_login_via_doorhanger(driver: Firefox):
 
     # Verify the password matches updated password value
     password_element = login_autofill.get_element("password-login-field")
-    assert password_element.get_attribute("value") == "testPasswordUpdate"
+    login_autofill.wait.until(
+        lambda _: password_element.get_attribute("value") == "testPasswordUpdate"
+    )


### PR DESCRIPTION
### Description

- Add comments to test_about_logins_navigation_from_hamburger_menu
- Move locator used in test_auto_saved_generated_password_context_menu to a better component for the overall consistency
- Change asserts in test_save_login_via_doorhanger and test_update_login_via_doorhanger to reflect the value,  not the length, as  the DOM still contains the full value of the password field regardless of its masked state.

### Bugzilla bug ID

**Testrail: N/A**
**Link: N/A**

### Type of change

- [x ] Password manager tests - improvements (see description)

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
