### PR TITLE
Pat/tAdded test for camera permissions notification

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1635,6 +1635,13 @@ Description: Sample download file URL
 Location:
 Path to .json: modules/data/generic_page.components.json
 ```
+```
+Selector Name: popup-notification
+Selector Data: "popupnotification"
+Description: The popup notification
+Location:
+Path to .json: modules/data/generic_page.components.json
+```
 #### google_search
 ```
 Selector Name: search-bar-textarea

--- a/modules/data/generic_page.components.json
+++ b/modules/data/generic_page.components.json
@@ -70,5 +70,12 @@
         "selectorData": "a[href='https://filesamples.com/samples/document/doc/sample2.doc']",
         "strategy": "css",
         "groups": []
+    },
+
+    "popup-notification": {
+        "selectorData": "popupnotification",
+        "strategy": "tag",
+        "groups": []
+        
     }
 }

--- a/tests/notifications/conftest.py
+++ b/tests/notifications/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.fixture()
+def suite_id():
+    return ("1907", "Notifications, Push Notifications and Alerts")
+
+
+@pytest.fixture()
+def set_prefs():
+    """Set prefs"""
+    return []

--- a/tests/notifications/test_camera_permissions_notification.py
+++ b/tests/notifications/test_camera_permissions_notification.py
@@ -20,7 +20,8 @@ def temp_selectors():
 
 TEST_URL = "https://mozilla.github.io/webrtc-landing/gum_test.html"
 
-def test_camera_perms_notif(driver: Firefox, temp_selectors):
+
+def test_camera_permissions_notification(driver: Firefox, temp_selectors):
     """
     C122536 - Verify that Camera only permission prompt is successfully displayed when the website asks for camera permissions
     """
@@ -33,8 +34,8 @@ def test_camera_perms_notif(driver: Firefox, temp_selectors):
 
     # Verify that the notification is displayed
     with driver.context(driver.CONTEXT_CHROME):
-        pop_up_notification = web_page.get_element("popup-notification")
-        assert pop_up_notification.get_attribute("label") == "Allow "
-        assert pop_up_notification.get_attribute("name") == "mozilla.github.io"
-        assert pop_up_notification.get_attribute("endlabel") == " to use your camera?"
+        popup_notification = web_page.get_element("popup-notification")
+        assert popup_notification.get_attribute("label") == "Allow "
+        assert popup_notification.get_attribute("name") == "mozilla.github.io"
+        assert popup_notification.get_attribute("endlabel") == " to use your camera?"
     

--- a/tests/notifications/test_camera_perms_notif.py
+++ b/tests/notifications/test_camera_perms_notif.py
@@ -1,0 +1,40 @@
+import pytest
+
+from selenium.webdriver import Firefox
+from modules.page_object_generics import GenericPage
+
+
+@pytest.fixture()
+def test_case():
+    return "122536"
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "camera-only": {
+            "selectorData": 'input[type="button"][value="Camera"]',
+            "strategy": "css",
+            "groups": [],
+        }
+    }
+
+TEST_URL = "https://mozilla.github.io/webrtc-landing/gum_test.html"
+
+def test_camera_perms_notif(driver: Firefox, temp_selectors):
+    """
+    C122536 - Verify that Camera only permission prompt is successfully displayed when the website asks for camera permissions
+    """
+    # Instatiate Objects
+    web_page = GenericPage(driver, url=TEST_URL).open()
+    web_page.elements |= temp_selectors
+
+    # Trigger the popup notification asking for camera permissions
+    web_page.click_on("camera-only")
+
+    # Verify that the notification is displayed
+    with driver.context(driver.CONTEXT_CHROME):
+        pop_up_notification = web_page.get_element("popup-notification")
+        assert pop_up_notification.get_attribute("label") == "Allow "
+        assert pop_up_notification.get_attribute("name") == "mozilla.github.io"
+        assert pop_up_notification.get_attribute("endlabel") == " to use your camera?"
+    


### PR DESCRIPTION
### Description

Verify that Camera only permission prompt is successfully displayed when the website asks for camera permissions.

### Bugzilla bug ID

**Testrail:** https://mozilla.testrail.io/index.php?/cases/view/122536
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1920217

### Type of change

- [x] New Test

### How does this resolve / make progress on that bug?

Completed

### Screenshots / Explanations

N.A

### Comments / Concerns

N.A