### PR TITLE
Anca/Delete login

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -266,6 +266,27 @@ Description: Password count
 Location: The about:login's main login page
 Path to .json: modules/data/about_logins.components.json
 ```
+```
+Selector Name: remove-login-button-main-page
+Selector Data: "delete-button"
+Description: Remove button
+Location: The about:login's main login page
+Path to .json: modules/data/about_logins.components.json
+```
+```
+Selector Name: remove-login-confirmation-dialog
+Selector Data: "confirmation-dialog"
+Description: Remove login confirmation dialog
+Location: The confirmation dialog trigered by Remove button in about:login
+Path to .json: modules/data/about_logins.components.json
+```
+```
+Selector Name: remove-login-button-confirmation-dialog
+Selector Data: "confirm-button"
+Description: Remove button
+Location: The Remove button inside the confirmation dialog
+Path to .json: modules/data/about_logins.components.json
+```
 #### about_newtab
 ```
 Selector Name: incontent-search-input

--- a/modules/data/about_logins.components.json
+++ b/modules/data/about_logins.components.json
@@ -121,8 +121,26 @@
         "selectorData": "list-item",
         "strategy": "class",
         "shadowParent": "login-list",
-        "groups": [
-            "doNotCache"
-        ]
+        "groups": ["doNotCache"]
+    },
+
+    "remove-login-button-main-page": {
+        "selectorData": "delete-button",
+        "strategy": "css",
+        "shadowParent": "login-item",
+        "groups": []
+    },
+
+    "remove-login-confirmation-dialog": {
+        "selectorData": "confirmation-dialog",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "remove-login-button-confirmation-dialog": {
+        "selectorData": "confirm-button",
+        "strategy": "class",
+        "shadowParent": "remove-login-confirmation-dialog",
+        "groups": []
     }
 }

--- a/tests/password_manager/test_add_primary_password.py
+++ b/tests/password_manager/test_add_primary_password.py
@@ -1,5 +1,4 @@
 import pytest
-
 from selenium.webdriver import Firefox
 from selenium.webdriver.support import expected_conditions as EC
 

--- a/tests/password_manager/test_delete_login.py
+++ b/tests/password_manager/test_delete_login.py
@@ -1,0 +1,36 @@
+import pytest
+
+from modules.page_object_about_pages import AboutLogins
+from modules.page_object_autofill import LoginAutofill
+
+
+@pytest.fixture()
+def test_case():
+    return "2241120"
+
+
+def test_delete_login(driver_and_saved_logins):
+    """
+    C2241120 - Verify that by clicking the "Remove" button in about:logins main page, the last saved login
+    is deleted.
+    """
+    # Adds 6 fake logins in about:login
+    driver, usernames, logins = driver_and_saved_logins
+
+    about_logins = AboutLogins(driver).open()
+    login_autofill = LoginAutofill(driver)
+
+    # Verify the initial number of saved passwords
+    password_count = about_logins.get_element("password-count")
+    login_autofill.wait.until(
+        lambda _: password_count.get_attribute("innerText") == "6 passwords"
+    )
+
+    # Delete the last saved login
+    about_logins.get_element("remove-login-button-main-page").click()
+    about_logins.get_element("remove-login-button-confirmation-dialog").click()
+
+    # Verify that the saved passwords count decreases by 1
+    login_autofill.wait.until(
+        lambda _: password_count.get_attribute("innerText") == "5 passwords"
+    )


### PR DESCRIPTION
### Description

- Verify that clicking the 'Remove' button in about:logins deletes the most recently saved login.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2241120**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1920186**

### Type of change

Please delete options that are not relevant.

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
