### PR TITLE
Pat/Added test to verify Microphone only permission prompt is successfully displayed

### DIFF
--- a/tests/notifications/test_microphone_permissions_notification.py
+++ b/tests/notifications/test_microphone_permissions_notification.py
@@ -1,0 +1,50 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation
+from modules.page_object_generics import GenericPage
+
+
+@pytest.fixture()
+def test_case():
+    return "122536"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "microphone-only": {
+            "selectorData": 'input[type="button"][value="Microphone"]',
+            "strategy": "css",
+            "groups": [],
+        }
+    }
+
+
+@pytest.fixture()
+def set_prefs():
+    """Set prefs"""
+    return [("media.navigator.streams.fake", True)]
+
+
+TEST_URL = "https://mozilla.github.io/webrtc-landing/gum_test.html"
+
+
+def test_microphone_permissions_notification(driver: Firefox, temp_selectors):
+    """
+    C122536 - Verify that Microphone only permission prompt is successfully displayed when the website asks for microphone permissions
+    """
+    # Instatiate Objects
+    nav = Navigation(driver)
+    web_page = GenericPage(driver, url=TEST_URL).open()
+    web_page.elements |= temp_selectors
+
+    # Trigger the popup notification asking for camera permissions
+    web_page.click_on("microphone-only")
+
+    # Verify that the notification is displayed
+    nav.element_attribute_contains("popup-notification", "label", "Allow ")
+    nav.element_attribute_contains("popup-notification", "name", "mozilla.github.io")
+    nav.element_attribute_contains(
+        "popup-notification", "endlabel", " to use your microphone?"
+    )

--- a/tests/notifications/test_microphone_permissions_notification.py
+++ b/tests/notifications/test_microphone_permissions_notification.py
@@ -7,7 +7,7 @@ from modules.page_object_generics import GenericPage
 
 @pytest.fixture()
 def test_case():
-    return "122538"
+    return "122539"
 
 
 @pytest.fixture()
@@ -32,7 +32,7 @@ TEST_URL = "https://mozilla.github.io/webrtc-landing/gum_test.html"
 
 def test_microphone_permissions_notification(driver: Firefox, temp_selectors):
     """
-    C122538 - Verify that Microphone only permission prompt is successfully displayed when the website asks for microphone permissions
+    C122539 - Verify that Microphone only permission prompt is successfully displayed when the website asks for microphone permissions
     """
     # Instatiate Objects
     nav = Navigation(driver)

--- a/tests/notifications/test_microphone_permissions_notification.py
+++ b/tests/notifications/test_microphone_permissions_notification.py
@@ -7,7 +7,7 @@ from modules.page_object_generics import GenericPage
 
 @pytest.fixture()
 def test_case():
-    return "122536"
+    return "122538"
 
 
 @pytest.fixture()
@@ -32,7 +32,7 @@ TEST_URL = "https://mozilla.github.io/webrtc-landing/gum_test.html"
 
 def test_microphone_permissions_notification(driver: Firefox, temp_selectors):
     """
-    C122536 - Verify that Microphone only permission prompt is successfully displayed when the website asks for microphone permissions
+    C122538 - Verify that Microphone only permission prompt is successfully displayed when the website asks for microphone permissions
     """
     # Instatiate Objects
     nav = Navigation(driver)


### PR DESCRIPTION
### Description

Added test to verify that the Microphone only permission prompt is successfully displayed when the website asks for microphone permissions

### Bugzilla bug ID

**Testrail:** https://mozilla.testrail.io/index.php?/cases/view/122534
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1920221

### Type of change

Please delete options that are not relevant.

- [x] New Test

### How does this resolve / make progress on that bug?
Completed

### Screenshots / Explanations
NA

### Comments / Concerns
NA
