### PR TITLE
Pat/added test for deny geolocation permissions

### DIFF
--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -415,6 +415,12 @@
         "groups": []
     },
 
+    "popup-notification-block": {
+        "selectorData": "popup-notification-secondary-button",
+        "strategy": "class",
+        "groups": []
+    },
+
     "toolbar-history-recently-closed-tabs": {
         "selectorData": "appMenuRecentlyClosedTabs",
         "strategy": "id",

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -415,7 +415,7 @@
         "groups": []
     },
 
-    "popup-notification-block": {
+    "popup-notification-secondary-button": {
         "selectorData": "popup-notification-secondary-button",
         "strategy": "class",
         "groups": []

--- a/tests/notifications/test_deny_geolocation.py
+++ b/tests/notifications/test_deny_geolocation.py
@@ -7,7 +7,7 @@ from modules.page_object_generics import GenericPage
 
 @pytest.fixture()
 def test_case():
-    return "122534"
+    return "122613"
 
 
 @pytest.fixture()
@@ -23,9 +23,9 @@ def temp_selectors():
 TEST_URL = "https://browserleaks.com/geo"
 
 
-def test_deny_screen_capture(driver: Firefox, temp_selectors):
+def test_deny_geolocation(driver: Firefox, temp_selectors):
     """
-    C122534 - Verify that denying screen capture permissions prevents website from accessing the screen
+    C122613 - Verify that denying geolocation permissions prevents website from accessing the location
     """
     # Instatiate Objects
     nav = Navigation(driver)

--- a/tests/notifications/test_deny_geolocation.py
+++ b/tests/notifications/test_deny_geolocation.py
@@ -1,0 +1,41 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation
+from modules.page_object_generics import GenericPage
+
+
+@pytest.fixture()
+def test_case():
+    return "122534"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "not-allowed": {
+            "selectorData": "geo-warn",
+            "strategy": "id",
+            "groups": []
+        }
+    }
+
+TEST_URL = "https://browserleaks.com/geo"
+
+
+def test_deny_screen_capture(driver: Firefox, temp_selectors):
+    """
+    C122534 - Verify that denying screen capture permissions prevents website from accessing the screen
+    """
+    # Instatiate Objects
+    nav = Navigation(driver)
+    web_page = GenericPage(driver, url=TEST_URL).open()
+    web_page.elements |= temp_selectors
+
+    # Block geolocation sharing for this website
+    nav.element_clickable("popup-notification-block")
+    nav.click_on("popup-notification-block")
+
+    # Check that the website cannot access the geolocation
+    web_page.element_visible("not-allowed")
+    assert "PERMISSION_DENIED – User denied Geolocation" in web_page.get_element("not-allowed").get_attribute("innerHTML")

--- a/tests/notifications/test_deny_geolocation.py
+++ b/tests/notifications/test_deny_geolocation.py
@@ -33,8 +33,8 @@ def test_deny_geolocation(driver: Firefox, temp_selectors):
     web_page.elements |= temp_selectors
 
     # Block geolocation sharing for this website
-    nav.element_clickable("popup-notification-block")
-    nav.click_on("popup-notification-block")
+    nav.element_clickable("popup-notification-secondary-button")
+    nav.click_on("popup-notification-secondary-button")
 
     # Check that the website cannot access the geolocation
     web_page.element_visible("not-allowed")

--- a/tests/notifications/test_deny_screen_capture.py
+++ b/tests/notifications/test_deny_screen_capture.py
@@ -38,8 +38,8 @@ def test_deny_screen_capture(driver: Firefox, temp_selectors):
     web_page.click_on("start-capture")
 
     # Block screen sharing for this website
-    nav.element_clickable("popup-notification-block")
-    nav.click_on("popup-notification-block")
+    nav.element_clickable("popup-notification-secondary-button")
+    nav.click_on("popup-notification-secondary-button")
 
     # Check that the website cannot access the screen
     web_page.element_has_text(


### PR DESCRIPTION
### Description
Added test to Verify that denying geolocation permissions prevents website from accessing geolocation

### Bugzilla bug ID

**Testrail:** https://mozilla.testrail.io/index.php?/cases/view/122613
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1920215

### Type of change

Please delete options that are not relevant.

- [x] New Test

### How does this resolve / make progress on that bug?

Completed

### Screenshots / Explanations

NA

### Comments / Concerns

NA
