### PR TITLE
Added test to determine Screen Share permission prompt is successfull…

### DIFF
--- a/tests/notifications/test_screen_share_permission_prompt.py
+++ b/tests/notifications/test_screen_share_permission_prompt.py
@@ -1,0 +1,36 @@
+import pytest
+from selenium.webdriver import Firefox
+from modules.browser_object import Navigation
+from modules.page_object_generics import GenericPage
+
+@pytest.fixture()
+def test_case():
+    return "122532"
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "start-capture": {
+            "selectorData": "start",
+            "strategy": "id",
+            "groups": [],
+        },
+        "not-allowed": {"selectorData": "error", "strategy": "class", "groups": []},
+    }
+
+TEST_URL = "https://storage.googleapis.com/desktop_test_assets/TestCases/ScreenShare/ShareScreen.html"
+
+def test_screen_share_permission_prompt(driver: Firefox, temp_selectors):
+    """
+    C122532 - Verify that the screen share permission prompt is successfully displayed
+    """
+
+    nav = Navigation(driver)
+    web_page = GenericPage(driver, url=TEST_URL).open()
+    web_page.elements |= temp_selectors
+
+    # Step 1: Trigger the popup notification asking for screen sharing permissions
+    web_page.click_on("start-capture")
+
+    # Determine Screen Share permission prompt is successfully displayed
+    assert nav.element_visible("popup-notification")


### PR DESCRIPTION
…y displayed

### Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Bugzilla bug ID

**Testrail:** https://mozilla.testrail.io/index.php?/cases/view/122532
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1920216

### Type of change

Please delete options that are not relevant.

- [x] New Test
- [ ] New POM
- [ ] Other Changes (Please specify)

### How does this resolve / make progress on that bug?

This is a test when merged would be consider completed in creating a test case for determining if the screen share prompt is successfully displayed following a click event interacting with the api.

### Comments / Concerns

A concern I have with respect to this PR is that, I observed in a similar [PR that is now merged](https://github.com/mozilla/fx-desktop-qa-automation/pull/259), there was a test case similar to this that involves interacting with browser popup. To interact with the pop-up, this method was called to click on `block` , 

```python
nav.element_clickable("popup-notification-block")
 nav.click_on("popup-notification-block")
  ```
Now, I am a confused because, browser notication popup are not accessible in the DOM and hence, not accessible by Selenium, so I am not sure how this would work. I would appreciate clarifications as regards this. In the meantime, I am submitting a PR. I hoping to make adjustments and corrections to the test case following feedbacks. Thanks.