### PR TITLE
audio video permission notification

### DIFF
--- a/tests/notifications/test_audio_video_pemissions_notification.py
+++ b/tests/notifications/test_audio_video_pemissions_notification.py
@@ -1,0 +1,50 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation
+from modules.page_object_generics import GenericPage
+
+
+@pytest.fixture()
+def test_case():
+    return "122556"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "camera-and-microphone": {
+            "selectorData": 'input[type="button"][value="Camera & microphone"]',
+            "strategy": "css",
+            "groups": [],
+        }
+    }
+
+
+@pytest.fixture()
+def set_prefs():
+    """Set prefs"""
+    return [("media.navigator.streams.fake", True)]
+
+
+TEST_URL = "https://mozilla.github.io/webrtc-landing/gum_test.html"
+
+
+def test_microphone_permissions_notification(driver: Firefox, temp_selectors):
+    """
+    C122539 - Verify that Microphone only permission prompt is successfully displayed when the website asks for microphone permissions
+    """
+    # Instatiate Objects
+    nav = Navigation(driver)
+    web_page = GenericPage(driver, url=TEST_URL).open()
+    web_page.elements |= temp_selectors
+
+    # Trigger the popup notification asking for camera permissions
+    web_page.click_on("camera-and-microphone")
+
+    # Verify that the notification is displayed
+    nav.element_attribute_contains("popup-notification", "label", "Allow ")
+    nav.element_attribute_contains("popup-notification", "name", "mozilla.github.io")
+    nav.element_attribute_contains(
+        "popup-notification", "endlabel", " to use your camera and microphone?"
+    )

--- a/tests/notifications/test_deny_geolocation.py
+++ b/tests/notifications/test_deny_geolocation.py
@@ -12,13 +12,8 @@ def test_case():
 
 @pytest.fixture()
 def temp_selectors():
-    return {
-        "not-allowed": {
-            "selectorData": "geo-warn",
-            "strategy": "id",
-            "groups": []
-        }
-    }
+    return {"not-allowed": {"selectorData": "geo-warn", "strategy": "id", "groups": []}}
+
 
 TEST_URL = "https://browserleaks.com/geo"
 
@@ -38,4 +33,6 @@ def test_deny_geolocation(driver: Firefox, temp_selectors):
 
     # Check that the website cannot access the geolocation
     web_page.element_visible("not-allowed")
-    assert "PERMISSION_DENIED – User denied Geolocation" in web_page.get_element("not-allowed").get_attribute("innerHTML")
+    assert "PERMISSION_DENIED – User denied Geolocation" in web_page.get_element(
+        "not-allowed"
+    ).get_attribute("innerHTML")


### PR DESCRIPTION
### Description

This test verifies that when the "Camera & Microphone" button is clicked on the WebRTC test page, the correct permission prompt asking for camera and microphone access is displayed. 

### Bugzilla bug ID

**Testrail:**
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1920219

### Type of change

Please delete options that are not relevant.

- [x] New Test

### How does this resolve / make progress on that bug?

Fix the issue completely


