### PR TITLE
Anca/ Trigger primary password prompt on about:logins access via hamburger menu

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -947,13 +947,6 @@ Description: Shadow parent of the OK and cancel button
 Location: about:preferences#privacy Primary Password popup
 Path to .json: modules/data/about_prefs.components.json
 ```
-```
-Selector Name: set-primary-password-prompt-message
-Selector Data: "commonDialogWindow"
-Description: Prompt message after setting primary password
-Location: about:preferences#privacy Primary Password
-Path to .json: modules/data/about_prefs.components.json
-```
 #### about_profiles
 ```
 Selector Name: profile-container

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -287,6 +287,27 @@ Description: Remove button
 Location: The Remove button inside the confirmation dialog
 Path to .json: modules/data/about_logins.components.json
 ```
+```
+Selector Name: show-password-checkbox
+Selector Data: "input.reveal-password-checkbox"
+Description: Show password eye icon
+Location: Inside about:logins page, next to the password field
+Path to .json: modules/data/about_logins.components.json
+```
+```
+Selector Name: primary-password-prompt
+Selector Data: "commonDialogWindow"
+Description: Primary password prompt
+Location: Alert on the about:logins page
+Path to .json: modules/data/about_logins.components.json
+```
+```
+Selector Name: primary-password-dialog-input-field
+Selector Data: "password1Textbox"
+Description: Input field inside Primary password prompt
+Location: Alert on the about:logins page
+Path to .json: modules/data/about_logins.components.json
+```
 #### about_newtab
 ```
 Selector Name: incontent-search-input
@@ -924,6 +945,13 @@ Selector Name: primary-password-box
 Selector Data: "changemp"
 Description: Shadow parent of the OK and cancel button
 Location: about:preferences#privacy Primary Password popup
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: set-primary-password-prompt-message
+Selector Data: "commonDialogWindow"
+Description: Prompt message after setting primary password
+Location: about:preferences#privacy Primary Password
 Path to .json: modules/data/about_prefs.components.json
 ```
 #### about_profiles

--- a/modules/data/about_logins.components.json
+++ b/modules/data/about_logins.components.json
@@ -154,7 +154,7 @@
         "groups": []
     },
   
-  "remove-login-button-main-page": {
+    "remove-login-button-main-page": {
         "selectorData": "delete-button",
         "strategy": "css",
         "shadowParent": "login-item",
@@ -172,5 +172,24 @@
         "strategy": "class",
         "shadowParent": "remove-login-confirmation-dialog",
         "groups": []
+    },
+
+    "show-password-checkbox": {
+       "selectorData": "input.reveal-password-checkbox",
+       "strategy": "css",
+       "shadowParent": "login-item",
+       "groups": []
+   },
+
+    "primary-password-prompt": {
+       "selectorData": "commonDialogWindow",
+       "strategy": "id",
+       "groups": ["doNotCache"]
+   },
+
+    "primary-password-dialog-input-field": {
+       "selectorData": "password1Textbox",
+       "strategy": "id",
+       "groups": []
+       }
     }
-}

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -486,5 +486,11 @@
         "selectorData": "changemp",
         "strategy": "id",
         "groups": []
+    },
+
+    "set-primary-password-prompt-message": {
+        "selectorData": "commonDialogWindow",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -486,11 +486,5 @@
         "selectorData": "changemp",
         "strategy": "id",
         "groups": []
-    },
-
-    "set-primary-password-prompt-message": {
-        "selectorData": "commonDialogWindow",
-        "strategy": "id",
-        "groups": []
     }
 }

--- a/tests/notifications/test_deny_geolocation.py
+++ b/tests/notifications/test_deny_geolocation.py
@@ -12,13 +12,8 @@ def test_case():
 
 @pytest.fixture()
 def temp_selectors():
-    return {
-        "not-allowed": {
-            "selectorData": "geo-warn",
-            "strategy": "id",
-            "groups": []
-        }
-    }
+    return {"not-allowed": {"selectorData": "geo-warn", "strategy": "id", "groups": []}}
+
 
 TEST_URL = "https://browserleaks.com/geo"
 
@@ -38,4 +33,6 @@ def test_deny_geolocation(driver: Firefox, temp_selectors):
 
     # Check that the website cannot access the geolocation
     web_page.element_visible("not-allowed")
-    assert "PERMISSION_DENIED – User denied Geolocation" in web_page.get_element("not-allowed").get_attribute("innerHTML")
+    assert "PERMISSION_DENIED – User denied Geolocation" in web_page.get_element(
+        "not-allowed"
+    ).get_attribute("innerHTML")

--- a/tests/password_manager/test_primary_password_triggered_on_about_logins_access.py
+++ b/tests/password_manager/test_primary_password_triggered_on_about_logins_access.py
@@ -1,0 +1,103 @@
+import pytest
+from selenium.webdriver import Firefox, Keys
+from selenium.webdriver.support import expected_conditions as EC
+
+from modules.browser_object import PanelUi, TabBar
+from modules.page_object import AboutLogins, AboutPrefs
+from modules.util import BrowserActions
+
+
+@pytest.fixture()
+def test_case():
+    return "2245199"
+
+
+def test_primary_password_triggered_on_about_logins_access_via_hamburger_menu(
+    driver: Firefox,
+):
+    """
+    C2245199: Verify that the primary password prompt is triggered on accessing about:logins through Hamburger Menu.
+
+    Without restarting the browser after the primary password was set (limited action), Firefox does not
+    trigger the primary password prompt when simply opening about:logins because no encrypted data is accessed
+    initially. The prompt is triggered only when sensitive data, is accessed, requiring decryption.
+
+    Once decrypted data has been accessed (e.g., showing a saved password), Firefox recognizes the need
+    to protect further access to that data. As a result, subsequent navigation to about:logins will
+    immediately trigger the primary password prompt to prevent unauthorized access to the decrypted source.
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy").open()
+    ba = BrowserActions(driver)
+    panel_ui = PanelUi(driver)
+    tabs = TabBar(driver)
+    about_logins = AboutLogins(driver)
+
+    # Enable the setup for primary password
+    about_prefs.click_on("use-primary-password")
+    primary_pw_popup = about_prefs.get_element("browser-popup")
+    ba.switch_to_iframe_context(primary_pw_popup)
+
+    # Set primary password
+    about_prefs.get_element("enter-new-password").send_keys("securePassword1")
+    about_prefs.get_element("reenter-new-password").send_keys("securePassword1")
+    about_prefs.click_on("submit-password")
+
+    # Dismiss the success message after setting the primary password
+    with driver.context(driver.CONTEXT_CHROME):
+        about_prefs.wait_for_num_tabs(2)
+        driver.switch_to.window(driver.window_handles[-1])
+        primary_password_message_dialog = about_prefs.get_element(
+            "set-primary-password-prompt-message"
+        )
+        primary_password_message_dialog.send_keys(Keys.ENTER)
+
+    # Open about:logins page and create a login entry
+    tabs.switch_to_new_tab()
+    about_logins.open()
+    about_logins.click_add_login_button()
+    about_logins.create_new_login(
+        {
+            "origin": "mozilla.org",
+            "username": "username",
+            "password": "password",
+        }
+    )
+
+    # Attempt to view the saved password in order to trigger the primary password prompt
+    show_password = about_logins.get_element("show-password-checkbox")
+    about_logins.expect(EC.element_to_be_clickable(show_password))
+    about_logins.click_on(show_password)
+
+    # Dismiss the primary password prompt without entering the password
+    with driver.context(driver.CONTEXT_CHROME):
+        driver.switch_to.window(driver.window_handles[-1])
+        primary_password_prompt = about_logins.get_element("primary-password-prompt")
+        primary_password_prompt.send_keys(Keys.ESCAPE)
+
+    # Navigate to about:logins again through the hamburger menu
+    tabs.switch_to_new_tab()
+    panel_ui.open_panel_menu()
+    panel_ui.redirect_to_about_logins_page()
+
+    # Verify that the primary password prompt appears and enter the primary password
+    with driver.context(driver.CONTEXT_CHROME):
+        driver.switch_to.window(driver.window_handles[-1])
+        # Fetch a fresh reference to avoid staling
+        primary_password_prompt = about_logins.get_element("primary-password-prompt")
+        assert primary_password_prompt.is_displayed()
+
+        primary_password_input_field = about_logins.get_element(
+            "primary-password-dialog-input-field"
+        )
+        primary_password_input_field.send_keys("securePassword1")
+        primary_password_input_field.send_keys(Keys.ENTER)
+
+    # Verify that about:logins page is accessible after the primary password was entered
+    driver.switch_to.window(driver.window_handles[0])
+    assert driver.current_url.startswith("about:logins")
+
+    # Verify that the saved login is visible and accessible in the login list
+    mozilla_login = about_logins.get_element("login-list-item")
+    assert mozilla_login.get_attribute("title") == "mozilla.org"


### PR DESCRIPTION
### Description

- Verify that the primary password prompt is triggered on accessing about:logins through Hamburger Menu.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2245199**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1920207**

### Type of change

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- Note that this test requires a restart, so I had to work around it. Without restarting the browser after the primary password was set, Firefox does not trigger the primary password prompt when simply opening about:logins because no encrypted data is accessed initially. The prompt is triggered only when sensitive data, is accessed, requiring decryption. Once decrypted data has been accessed (e.g., showing a saved password), Firefox recognizes the need to protect further access to that data. As a result, subsequent navigation to about:logins will immediately trigger the primary password prompt to prevent unauthorized access to the decrypted source. 
