### PR TITLE
Add documentation for generic_pdf selectors

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1761,6 +1761,182 @@ Description: Sample download file URL
 Location:
 Path to .json: modules/data/generic_page.components.json
 ```
+#### generic_pdf
+```
+Selector Name: highlighted-text
+Selector Data: ".textLayer .highlight.selected.appended"
+Description: attribute of text element
+Location: any element that supports the attribute (usually text)
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: html-body
+Selector Data: "html"
+Description: The html tag of the pdf
+Location: In the body of the pdf document
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: pdf-body
+Selector Data: "viewer"
+Description: The body of the pdf
+Location: The pdf document
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: zoom-out
+Selector Data: "zoomOutButton"
+Description: The zoom out button
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: zoom-in
+Selector Data: "zoomInButton"
+Description: The zoom out button
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: download-button
+Selector Data: "downloadButton"
+Description: The save button
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: zipcode-field
+Selector Data: "input[name='ZIP Code']"
+Description: The zip code input field
+Location: The test pdf page content
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: scroll-next
+Selector Data: "next"
+Description: The Next Page button
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: scroll-prev
+Selector Data: "previous"
+Description: The Previous Page button
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: pdf-page
+Selector Data: "div[data-page-number='{number}']"
+Description: The Page number input field (takes a page number)
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: page-one-item
+Selector Data: "/html/body/div[1]/div[2]/div[2]/div[2]/div[1]/div[2]/span[13]"
+Description: The Page number of the first page
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: page-input
+Selector Data: "pageNumber"
+Description: The Page field
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: toolbar-toggle
+Selector Data: "secondaryToolbarToggle"
+Description: The Tools menu button
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: toolbar-container
+Selector Data: "secondaryToolbarButtonContainer"
+Description: The Tools menu
+Location: The pdf viewer tools menu
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: toolbar-hand-tool
+Selector Data: "cursorHandTool"
+Description: The Tools menu's hand grabber curser
+Location: The pdf viewer tools menu
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: toolbar-select-tool
+Selector Data: "cursorSelectTool"
+Description: The Tools menu's select curser
+Location: The pdf viewer tools menu
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: toolbar-rotate-cw
+Selector Data: "pageRotateCw"
+Description: The rotate clockwise button
+Location: The pdf viewer tools menu
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: toolbar-rotate-ccw
+Selector Data: "pageRotateCcw"
+Description: The rotate counter clockwise button
+Location: The pdf viewer tools menu
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: first-name-field
+Selector Data: "input[name='First Name Given Name']"
+Description: The first name text imput field
+Location: The test pdf page content
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: first-checkbox
+Selector Data: "input[name='CB_1']"
+Description: The check box for option 1.
+Location: The test pdf page content
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: state-dropdown-field
+Selector Data: "select[name='State']"
+Description: The State selection menu
+Location: The test pdf page content
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: edited-name-field
+Selector Data: "input[name='First Name Given Name'][value='Mark']"
+Description: The First name field with 'Mark' in it
+Location: The test pdf page content
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: toolbar-add-image
+Selector Data: "editorStamp"
+Description: The Add or edit images button
+Location: The pdf viewer toolbar
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: toolbar-add-image-confirm
+Selector Data: "editorStampAddImage"
+Description: The Add image option
+Location: The pdf viewer toolbar when Add or edit is opened
+Path to .json: modules/data/generic_pdf.components.json
+```
+```
+Selector Name: added-goomy-image
+Selector Data: "canvas[aria-label='goomy.png']"
+Description: The Added test image label
+Location: The test pdf page content
+Path to .json: modules/data/generic_pdf.components.json
+```
 #### google_search
 ```
 Selector Name: search-bar-textarea

--- a/modules/data/generic_pdf.components.json
+++ b/modules/data/generic_pdf.components.json
@@ -1,10 +1,4 @@
 {
-    "text-layer": {
-        "selectorData": "textLayer",
-        "strategy": "class",
-        "groups": []
-    },
-
     "highlighted-text": {
         "selectorData": ".textLayer .highlight.selected.appended",
         "strategy": "css",

--- a/tests/notifications/test_webextension_completed_installation_successfully_displayed.py
+++ b/tests/notifications/test_webextension_completed_installation_successfully_displayed.py
@@ -16,7 +16,7 @@ def temp_selectors():
         "add-to-firefox": {
             "selectorData": "AMInstallButton-button",
             "strategy": "class",
-            "groups": []
+            "groups": [],
         }
     }
 
@@ -24,7 +24,9 @@ def temp_selectors():
 TEST_URL = "https://addons.mozilla.org/en-US/firefox/addon/popup-blocker/"
 
 
-def test_webextension_completed_installation_successfully_displayed(driver: Firefox, temp_selectors):
+def test_webextension_completed_installation_successfully_displayed(
+    driver: Firefox, temp_selectors
+):
     """
     C122933 - Verify that WebExtension completed installation is successfully displayed
     """
@@ -42,7 +44,9 @@ def test_webextension_completed_installation_successfully_displayed(driver: Fire
 
     # The WebExtension completed installation panel is successfully displayed
     nav.element_attribute_contains("popup-notification-panel", "buttonlabel", "Okay")
-    nav.element_attribute_contains("popup-notification-panel", "name", "Popup Blocker (strict)")
+    nav.element_attribute_contains(
+        "popup-notification-panel", "name", "Popup Blocker (strict)"
+    )
     nav.element_attribute_contains(
         "popup-notification-panel", "endlabel", " was added."
     )


### PR DESCRIPTION
### Description
Add documentation for selectors of generic_pdf.components

#### Bugzilla bug ID
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1915952

#### Type of change
- [x] documentation

#### How does this resolve / make progress on that bug?
Completes the selector documentation.
