### PR TITLE
Anca/ Geolocation prompt displayed on location request on a website

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -2310,6 +2310,13 @@ Description: Popup notification panel
 Location: Hangs from the Extensions button in toolbar once the extension is added to Firefox
 Path to .json: modules/data/navigation.components.json
 ```
+```
+Selector Name: geolocation-notification-container
+Selector Data: "popupnotification#geolocation-notification"
+Description: Geolocation prompt container
+Location: Address bar
+Path to .json: modules/data/navigation.components.json
+```
 #### panel_ui
 ```
 Selector name: panel-ui-button

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -485,5 +485,11 @@
         "selectorData": "appMenu-addon-installed-notification",
         "strategy": "id",
         "groups": []
+    },
+
+    "geolocation-notification-container": {
+    "selectorData": "popupnotification#geolocation-notification",
+    "strategy": "css",
+    "groups": []
     }
 }

--- a/tests/notifications/test_geolocation_prompt_presence.py
+++ b/tests/notifications/test_geolocation_prompt_presence.py
@@ -15,7 +15,7 @@ def test_case():
 TEST_URL = "https://www.w3schools.com/html/html5_geolocation.asp"
 
 
-def test_geolocation_prompt_is_triggered_on_request_location_on_website(
+def test_geolocation_prompt_is_triggered_on_request_location_on_a_website(
     driver: Firefox,
 ):
     """
@@ -42,6 +42,4 @@ def test_geolocation_prompt_is_triggered_on_request_location_on_website(
     ).click()
 
     # Verify that the geolocation prompt is present
-    assert nav.wait.until(
-        lambda _: nav.element_visible("geolocation-notification-container")
-    ), "Geolocation prompt did not appear within the expected time"
+    nav.wait.until(lambda _: nav.element_visible("geolocation-notification-container"))

--- a/tests/notifications/test_geolocation_prompt_presence.py
+++ b/tests/notifications/test_geolocation_prompt_presence.py
@@ -15,7 +15,9 @@ def test_case():
 TEST_URL = "https://www.w3schools.com/html/html5_geolocation.asp"
 
 
-def test_deny_geolocation(driver: Firefox):
+def test_geolocation_prompt_is_triggered_on_request_location_on_website(
+    driver: Firefox,
+):
     """
     C122611 - Verify that geolocation prompt is present when accessing a website that requests location
     """

--- a/tests/notifications/test_geolocation_prompt_presence.py
+++ b/tests/notifications/test_geolocation_prompt_presence.py
@@ -1,0 +1,45 @@
+import pytest
+from selenium.common import NoSuchElementException
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+
+from modules.browser_object import Navigation
+from modules.page_object import GenericPage
+
+
+@pytest.fixture()
+def test_case():
+    return "122611"
+
+
+TEST_URL = "https://www.w3schools.com/html/html5_geolocation.asp"
+
+
+def test_deny_geolocation(driver: Firefox):
+    """
+    C122611 - Verify that geolocation prompt is present when accessing a website that requests location
+    """
+
+    # Instantiate Objects
+    nav = Navigation(driver)
+    web_page = GenericPage(driver, url=TEST_URL).open()
+
+    # Wait for the page to fully load and manually address the cookie banner if appears, as the cookie banner
+    # dismissal preference is not effective in this context
+    nav.wait_for_page_to_load()
+    try:
+        driver.switch_to.window(driver.window_handles[-1])
+        web_page.find_element(By.ID, "accept-choices").click()
+    except NoSuchElementException:
+        # If the banner is not triggered, just continue to the next line
+        pass
+
+    # Click the 'Try It' button to trigger the geolocation prompt
+    web_page.find_element(
+        By.CSS_SELECTOR, "button.w3-btn.w3-blue.w3-round[onclick='getLocation()']"
+    ).click()
+
+    # Verify that the geolocation prompt is present
+    assert nav.wait.until(
+        lambda _: nav.element_visible("geolocation-notification-container")
+    ), "Geolocation prompt did not appear within the expected time"

--- a/tests/notifications/test_webextension_completed_installation_successfully_displayed.py
+++ b/tests/notifications/test_webextension_completed_installation_successfully_displayed.py
@@ -16,7 +16,7 @@ def temp_selectors():
         "add-to-firefox": {
             "selectorData": "AMInstallButton-button",
             "strategy": "class",
-            "groups": []
+            "groups": [],
         }
     }
 
@@ -24,7 +24,9 @@ def temp_selectors():
 TEST_URL = "https://addons.mozilla.org/en-US/firefox/addon/popup-blocker/"
 
 
-def test_webextension_completed_installation_successfully_displayed(driver: Firefox, temp_selectors):
+def test_webextension_completed_installation_successfully_displayed(
+    driver: Firefox, temp_selectors
+):
     """
     C122933 - Verify that WebExtension completed installation is successfully displayed
     """
@@ -42,7 +44,9 @@ def test_webextension_completed_installation_successfully_displayed(driver: Fire
 
     # The WebExtension completed installation panel is successfully displayed
     nav.element_attribute_contains("popup-notification-panel", "buttonlabel", "Okay")
-    nav.element_attribute_contains("popup-notification-panel", "name", "Popup Blocker (strict)")
+    nav.element_attribute_contains(
+        "popup-notification-panel", "name", "Popup Blocker (strict)"
+    )
     nav.element_attribute_contains(
         "popup-notification-panel", "endlabel", " was added."
     )


### PR DESCRIPTION
### Description

- Verify that geolocation prompt is present when accessing a website that requests location

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/122611**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1920214**

### Type of change

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
