### PR TITLE
GHA TR reporting: literally fix everything in the world with indentation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -336,14 +336,6 @@ def pytest_sessionfinish(session):
             raise OSError("Could not find TestRail credentials")
 
         report = session.config._json_report.report
-        if report is None:
-            try:
-                with open(".report.json") as fh:
-                    report = json.load(fh)
-            except OSError:
-                raise OSError(
-                    "Report object was blank and .report.json was not found. Cannot report."
-                )
         tr_session = tri.testrail_init()
         passes = tri.collect_changes(tr_session, report)
         tri.mark_results(tr_session, passes)

--- a/conftest.py
+++ b/conftest.py
@@ -317,42 +317,42 @@ def pytest_sessionfinish(session):
                 logging.warning("Failed to kill process.")
                 pass
 
-    # TestRail reporting
-    if not os.environ.get("TESTRAIL_REPORT"):
-        logging.info(
-            "Not reporting to TestRail. Set env var TESTRAIL_REPORT to activate reporting."
-        )
-        return None
-
-    creds = get_tc_secret()
-    if creds:
-        os.environ["TESTRAIL_USERNAME"] = creds.get("TESTRAIL_USERNAME")
-        os.environ["TESTRAIL_API_KEY"] = creds.get("TESTRAIL_API_KEY")
-        os.environ["TESTRAIL_BASE_URL"] = creds.get("TESTRAIL_BASE_URL")
-    elif not os.environ.get("TESTRAIL_USERNAME"):
-        logging.error(
-            "Attempted to report to TestRail, but could not find credentials."
-        )
-        raise OSError("Could not find TestRail credentials")
-
-    report = session.config._json_report.report
-    if report is None:
-        try:
-            with open(".report.json") as fh:
-                report = json.load(fh)
-        except OSError:
-            raise OSError(
-                "Report object was blank and .report.json was not found. Cannot report."
+        # TestRail reporting
+        if not os.environ.get("TESTRAIL_REPORT"):
+            logging.info(
+                "Not reporting to TestRail. Set env var TESTRAIL_REPORT to activate reporting."
             )
-    tr_session = tri.testrail_init()
-    passes = tri.collect_changes(tr_session, report)
-    tri.mark_results(tr_session, passes)
-    with open(".tmp_testrail_info") as fh:
-        (plan_title, config) = fh.read().split("|")
-    version = plan_title.split(" ")[-1]
-    prefix = config[:3].lower()
-    with open(f"{prefix}-latest-reported-version", "w") as fh:
-        fh.write(version.split(" ")[-1])
+            return None
+
+        creds = get_tc_secret()
+        if creds:
+            os.environ["TESTRAIL_USERNAME"] = creds.get("TESTRAIL_USERNAME")
+            os.environ["TESTRAIL_API_KEY"] = creds.get("TESTRAIL_API_KEY")
+            os.environ["TESTRAIL_BASE_URL"] = creds.get("TESTRAIL_BASE_URL")
+        elif not os.environ.get("TESTRAIL_USERNAME"):
+            logging.error(
+                "Attempted to report to TestRail, but could not find credentials."
+            )
+            raise OSError("Could not find TestRail credentials")
+
+        report = session.config._json_report.report
+        if report is None:
+            try:
+                with open(".report.json") as fh:
+                    report = json.load(fh)
+            except OSError:
+                raise OSError(
+                    "Report object was blank and .report.json was not found. Cannot report."
+                )
+        tr_session = tri.testrail_init()
+        passes = tri.collect_changes(tr_session, report)
+        tri.mark_results(tr_session, passes)
+        with open(".tmp_testrail_info") as fh:
+            (plan_title, config) = fh.read().split("|")
+        version = plan_title.split(" ")[-1]
+        prefix = config[:3].lower()
+        with open(f"{prefix}-latest-reported-version", "w") as fh:
+            fh.write(version.split(" ")[-1])
 
 
 @pytest.fixture()


### PR DESCRIPTION
Things are failing in Windows GHA, possible because of the ~*°=magic=~¨´ of semantic whitespace. I think we can fix this.