### PR TITLE
only report when report is available

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -317,34 +317,40 @@ def pytest_sessionfinish(session):
                 logging.warning("Failed to kill process.")
                 pass
 
-        # TestRail reporting
-        if not os.environ.get("TESTRAIL_REPORT"):
-            logging.info(
-                "Not reporting to TestRail. Set env var TESTRAIL_REPORT to activate reporting."
-            )
-            return None
+    # TestRail reporting
+    if not os.environ.get("TESTRAIL_REPORT"):
+        logging.info(
+            "Not reporting to TestRail. Set env var TESTRAIL_REPORT to activate reporting."
+        )
+        return None
 
-        creds = get_tc_secret()
-        if creds:
-            os.environ["TESTRAIL_USERNAME"] = creds.get("TESTRAIL_USERNAME")
-            os.environ["TESTRAIL_API_KEY"] = creds.get("TESTRAIL_API_KEY")
-            os.environ["TESTRAIL_BASE_URL"] = creds.get("TESTRAIL_BASE_URL")
-        elif not os.environ.get("TESTRAIL_USERNAME"):
-            logging.error(
-                "Attempted to report to TestRail, but could not find credentials."
-            )
-            raise OSError("Could not find TestRail credentials")
+    report = session.config._json_report.report
+    if report is None:
+        logging.warning(
+            "This thread does not have a report in its config object. Not reporting to TestRail."
+        )
+        return None
 
-        report = session.config._json_report.report
-        tr_session = tri.testrail_init()
-        passes = tri.collect_changes(tr_session, report)
-        tri.mark_results(tr_session, passes)
-        with open(".tmp_testrail_info") as fh:
-            (plan_title, config) = fh.read().split("|")
-        version = plan_title.split(" ")[-1]
-        prefix = config[:3].lower()
-        with open(f"{prefix}-latest-reported-version", "w") as fh:
-            fh.write(version.split(" ")[-1])
+    creds = get_tc_secret()
+    if creds:
+        os.environ["TESTRAIL_USERNAME"] = creds.get("TESTRAIL_USERNAME")
+        os.environ["TESTRAIL_API_KEY"] = creds.get("TESTRAIL_API_KEY")
+        os.environ["TESTRAIL_BASE_URL"] = creds.get("TESTRAIL_BASE_URL")
+    elif not os.environ.get("TESTRAIL_USERNAME"):
+        logging.error(
+            "Attempted to report to TestRail, but could not find credentials."
+        )
+        raise OSError("Could not find TestRail credentials")
+
+    tr_session = tri.testrail_init()
+    passes = tri.collect_changes(tr_session, report)
+    tri.mark_results(tr_session, passes)
+    with open(".tmp_testrail_info") as fh:
+        (plan_title, config) = fh.read().split("|")
+    version = plan_title.split(" ")[-1]
+    prefix = config[:3].lower()
+    with open(f"{prefix}-latest-reported-version", "w") as fh:
+        fh.write(version.split(" ")[-1])
 
 
 @pytest.fixture()

--- a/conftest.py
+++ b/conftest.py
@@ -327,7 +327,7 @@ def pytest_sessionfinish(session):
     report = session.config._json_report.report
     if report is None:
         logging.warning(
-            "This thread does not have a report in its config object. Not reporting to TestRail."
+            "Not reporting to TestRail. This thread does not have a report in its config object."
         )
         return None
 


### PR DESCRIPTION
Revert the "indent solution" from previous attempts, then only report to testrail if you have the report. This should fix the Win headless problem.