### PR TITLE
Anca/Doh enforces secure dns resolution

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -329,6 +329,14 @@ Description: Save edited login
 Location: The about:login's main login page after editing a login
 Path to .json: modules/data/about_logins.components.json
 ```
+#### about_networking
+```
+Selector Name: networking-sidebar-category
+Selector Data: "div.category[id='category-{name}']"
+Description: The tab category in the sidebar
+Location: Sidebar of about:networking page
+Path to .json: modules/data/about_networking.components.json
+```
 #### about_newtab
 ```
 Selector Name: incontent-search-input
@@ -1029,6 +1037,20 @@ Selector Name: httpsonly-radio-disabled
 Selector Data: "radio[data-l10n-id='httpsonly-radio-disabled']"
 Description: Radio Button to turn Https Only Mode to disabled for all pages
 Location: about:preferences#privacy
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-status
+Selector Data: "dohStatus"
+Description: Status of DoH
+Location: Inside the first frame of the DoH section in about:preferences#general
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-resolver
+Selector Data: "dohResolver"
+Description: The name of the DoH provider
+Location: Inside the first frame of the DoH section in about:preferences#general
 Path to .json: modules/data/about_prefs.components.json
 ```
 #### about_profiles

--- a/modules/data/about_networking.components.json
+++ b/modules/data/about_networking.components.json
@@ -1,0 +1,7 @@
+{
+    "networking-sidebar-category": {
+        "selectorData": "div.category[id='category-{name}']",
+        "strategy": "css",
+        "groups": []
+    }
+}

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -542,5 +542,17 @@
         "selectorData": "radio[data-l10n-id='httpsonly-radio-disabled']",
         "strategy": "css",
         "groups": []
+    },
+
+    "doh-status": {
+        "selectorData": "dohStatus",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "doh-resolver": {
+        "selectorData": "dohResolver",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -198,3 +198,18 @@ class AboutTelemetry(BasePage):
     """
 
     URL_TEMPLATE = "about:telemetry"
+
+
+class AboutNetworking(BasePage):
+    """
+    POM for about:networking page
+    """
+
+    URL_TEMPLATE = "about:networking"
+
+    def select_network_category(self, option: str):
+        """
+        Clicks the corresponding sidebar tab in the about:networking page.
+        """
+        # Use dynamic ID based on the option name
+        self.get_element("networking-sidebar-category", labels=[option]).click()

--- a/tests/bookmarks_and_history/test_history_menu_from_different_places.py
+++ b/tests/bookmarks_and_history/test_history_menu_from_different_places.py
@@ -86,6 +86,7 @@ def test_history_menu_in_different_places(driver: Firefox):
         panel_ui.navigate_to_customize_toolbar()
         customize_firefox.add_widget_to_toolbar("library")
 
+        tabs.new_tab_by_button()
         tabs.switch_to_new_tab()
 
         nav.click_on("library-button")

--- a/tests/networking/test_default_dns_protection.py
+++ b/tests/networking/test_default_dns_protection.py
@@ -1,0 +1,62 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+
+from modules.browser_object import TabBar
+from modules.page_object import AboutNetworking, AboutPrefs
+
+
+@pytest.fixture()
+def test_case():
+    return "2300296"
+
+
+@pytest.fixture()
+def set_prefs():
+    return [
+        ("browser.search.region", "US"),
+        ("doh-rollout.home-region", "US"),
+        ("doh-rollout.mode", 2),
+    ]
+
+
+TEST_URL = "https://www.wikipedia.org/"
+
+
+def test_doh_enforces_secure_dns_resolution(driver: Firefox):
+    """
+    C2300296 - Verify that default DNS over HTTPS (DoH) settings enforce secure DNS resolution
+    """
+
+    # Instantiate objects
+    prefs = AboutPrefs(driver, category="privacy")
+    networking = AboutNetworking(driver)
+    tabs = TabBar(driver)
+
+    # Confirm the default DoH settings
+    prefs.open()
+    doh_status_element = prefs.get_element("doh-status")
+    assert doh_status_element.text == "Status: Active"
+
+    doh_resolver_element = prefs.get_element("doh-resolver")
+    assert doh_resolver_element.text == "Provider: Cloudflare"
+
+    # Open the test site and subsequently the networking#dns page
+    driver.get(TEST_URL)
+
+    tabs.new_tab_by_button()
+    tabs.switch_to_new_tab()
+    networking.open()
+    networking.select_network_category("dns")
+
+    # Check that the test site is resolved using TRR (true)
+    rows = driver.find_elements(
+        By.CSS_SELECTOR, "#dns_content tr"
+    )  # Fetch all rows in the DNS table
+
+    for row in rows:
+        cells = row.find_elements(By.TAG_NAME, "td")
+        if cells[0].text == "www.wikipedia.org":
+            trr_status = cells[2].text  # Third column for TRR
+            assert trr_status == "true"
+            break

--- a/tests/networking/test_default_dns_protection.py
+++ b/tests/networking/test_default_dns_protection.py
@@ -35,11 +35,8 @@ def test_doh_enforces_secure_dns_resolution(driver: Firefox):
 
     # Confirm the default DoH settings
     prefs.open()
-    doh_status_element = prefs.get_element("doh-status")
-    assert doh_status_element.text == "Status: Active"
-
-    doh_resolver_element = prefs.get_element("doh-resolver")
-    assert doh_resolver_element.text == "Provider: Cloudflare"
+    prefs.element_has_text("doh-status", "Status: Active")
+    prefs.element_has_text("doh-resolver", "Provider: Cloudflare")
 
     # Open the test site and subsequently the networking#dns page
     driver.get(TEST_URL)


### PR DESCRIPTION
### Description
-  Verify that  DNS over HTTPS (DoH) feature is active, using Cloudflare as the default provider. It verifies that a random test page is resolved with TRR set to true, ensuring that DNS queries for the domain are securely processed via DoH, reflecting the correct configuration and expected behavior of secure DNS resolution.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2300296**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1925596**

### Type of change

- [x] New Test
- [x] Other Changes 
   - Added a new class in about pages POM for the networking page
   - Added an about networking json
   
### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A