### PR TITLE
Pat/Closing file managers after tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -532,10 +532,8 @@ def close_file_manager(sys_platform):
     """Closes the file manager window"""
     yield
     if sys_platform == "Windows":
-        powershell_command = '''
-        Get-Process | Where-Object { $_.MainWindowTitle -eq 'File Explorer' } | ForEach-Object { $_.CloseMainWindow() }
-        '''
-        run(["powershell", "-Command", powershell_command], check=True)
+        run(["taskkill", "/F", "/IM", "explorer.exe"], check=True)
+        run(["start", "explorer.exe"], shell=True)
     elif sys_platform == "Darwin":
         applescript = '''
         tell application "Finder"

--- a/conftest.py
+++ b/conftest.py
@@ -531,7 +531,7 @@ def fillable_pdf_url():
 def close_file_manager(sys_platform):
     yield
     if sys_platform == "Windows":
-        run(["taskkill", "/IM", "WINDOWTITLE eq File Explorer"], check=True)
+        run(["taskkill", "/FI", "WINDOWTITLE eq File Explorer"], check=True)
     elif sys_platform == "Darwin":
         applescript = '''
         tell application "Finder"

--- a/conftest.py
+++ b/conftest.py
@@ -529,9 +529,13 @@ def fillable_pdf_url():
 
 @pytest.fixture()
 def close_file_manager(sys_platform):
+    """Closes the file manager window"""
     yield
     if sys_platform == "Windows":
-        run(["taskkill", "/FI", "WINDOWTITLE eq File Explorer"], check=True)
+        powershell_command = '''
+        Get-Process | Where-Object { $_.MainWindowTitle -eq 'File Explorer' } | ForEach-Object { $_.CloseMainWindow() }
+        '''
+        run(["powershell", "-Command", powershell_command], check=True)
     elif sys_platform == "Darwin":
         applescript = '''
         tell application "Finder"

--- a/conftest.py
+++ b/conftest.py
@@ -529,7 +529,7 @@ def fillable_pdf_url():
 
 
 @pytest.fixture()
-def close_file_manager(sys_platform, close_file_manager_window_name):
+def close_file_manager(sys_platform):
     """Closes the file manager window"""
     yield
     if sys_platform == "Windows":
@@ -542,12 +542,3 @@ def close_file_manager(sys_platform, close_file_manager_window_name):
         end tell
         '''
         run(["osascript", "-e", applescript], check=True)
-    elif sys_platform == "Linux":
-        window_id = check_output(["xdotool", "search", "--name", close_file_manager_window_name]).strip().decode('utf-8')
-        run(["xdotool", "windowclose", window_id], check=True)
-
-
-@pytest.fixture()
-def close_file_manager_window_name():
-    """ Tells close_file_manager linux the window name to close"""
-    return ""

--- a/conftest.py
+++ b/conftest.py
@@ -527,8 +527,9 @@ def faker_seed():
 def fillable_pdf_url():
     return "https://www.uscis.gov/sites/default/files/document/forms/i-9.pdf"
 
+
 @pytest.fixture()
-def close_file_manager(sys_platform):
+def close_file_manager(sys_platform, close_file_manager_window_name):
     """Closes the file manager window"""
     yield
     if sys_platform == "Windows":
@@ -542,5 +543,11 @@ def close_file_manager(sys_platform):
         '''
         run(["osascript", "-e", applescript], check=True)
     elif sys_platform == "Linux":
-        for manager in ["nautilus", "dolphin", "thunar", "pcmanfm"]:
-            run(["pkill", manager], check=False)
+        window_id = check_output(["xdotool", "search", "--name", close_file_manager_window_name]).strip().decode('utf-8')
+        run(["xdotool", "windowclose", window_id], check=True)
+
+
+@pytest.fixture()
+def close_file_manager_window_name():
+    """ Tells close_file_manager linux the window name to close"""
+    return ""

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ import os
 import platform
 import re
 from shutil import unpack_archive
-from subprocess import check_output
+from subprocess import check_output, run
 from typing import Callable, List, Tuple, Union
 
 import pytest
@@ -526,3 +526,19 @@ def faker_seed():
 @pytest.fixture(scope="session")
 def fillable_pdf_url():
     return "https://www.uscis.gov/sites/default/files/document/forms/i-9.pdf"
+
+@pytest.fixture()
+def close_file_manager(sys_platform):
+    yield
+    if sys_platform == "Windows":
+        run(["taskkill", "/IM", "WINDOWTITLE eq File Explorer"], check=True)
+    elif sys_platform == "Darwin":
+        applescript = '''
+        tell application "Finder"
+            close every Finder window
+        end tell
+        '''
+        run(["osascript", "-e", applescript], check=True)
+    elif sys_platform == "Linux":
+        for manager in ["nautilus", "dolphin", "thunar", "pcmanfm"]:
+            run(["pkill", manager], check=False)

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -40,7 +40,7 @@ def temp_selectors():
 
 
 def test_add_zip_type(
-    driver: Firefox, sys_platform, home_folder, delete_files, temp_selectors
+    driver: Firefox, sys_platform, home_folder, delete_files, temp_selectors, close_file_manager
 ):
     """
     C1756743: Verify that the user can add the .zip mime type to Firefox

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -22,6 +22,10 @@ ZIP_URL = "https://github.com/microsoft/api-guidelines"
 def delete_files_regex_string():
     return r"api-guidelines-vNext"
 
+@pytest.fixture()
+def close_file_manager_window_name():
+    return "api-guidelines-vNext.zip"
+
 
 @pytest.fixture()
 def temp_selectors():

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -22,10 +22,6 @@ ZIP_URL = "https://github.com/microsoft/api-guidelines"
 def delete_files_regex_string():
     return r"api-guidelines-vNext"
 
-@pytest.fixture()
-def close_file_manager_window_name():
-    return "api-guidelines-vNext.zip"
-
 
 @pytest.fixture()
 def temp_selectors():


### PR DESCRIPTION
### Description

Added a fixture that could help with clean up for tests that opens file managers.

### Bugzilla bug ID

**Testrail:**
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1921099

### Type of change

Please delete options that are not relevant.

- [x] Other Changes (Clean up)

### How does this resolve / make progress on that bug?

Fixed

### Screenshots / Explanations

NA

### Comments / Concerns

NA
