### PR TITLE
Ben/check tr for used

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -209,7 +209,7 @@ def opt_window_size(request):
     return request.config.getoption("--window-size")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def sys_platform():
     return platform.system()
 
@@ -288,6 +288,9 @@ def version(fx_executable: str):
 @pytest.fixture(autouse=True, scope="session")
 def reportable(version, sys_platform):
     """Return true if we should report to TestRail"""
+
+    if not os.environ.get("TESTRAIL_REPORT"):
+        return False
 
     # Find the correct test plan
     tr_session = tri.testrail_init()

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,8 @@ from modules.taskcluster import get_tc_secret
 FX_VERSION_RE = re.compile(r"Mozilla Firefox (\d+)\.(\d\d?)b(\d\d?)")
 TESTRAIL_FX_DESK_PRJ = "17"
 TESTRAIL_RUN_FMT = "[{channel} {major}] Automated testing {major}.{minor}b{build}"
+
+# Number of suites that exist in the repo, that shouldn't report to TR. Currently meta and pocket.
 SUITE_COVERAGE_TOLERANCE = 2
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -278,7 +278,7 @@ def use_profile():
     yield False
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="session")
 def version(fx_executable: str):
     """Return the Firefox version string"""
     version = check_output([fx_executable, "--version"]).strip().decode()

--- a/conftest.py
+++ b/conftest.py
@@ -228,7 +228,7 @@ def downloads_folder(sys_platform):
         return f"/home/{user}/Downloads"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def fx_executable(request, sys_platform):
     """Get the Fx executable path based on platform and edition request."""
     version = request.config.getoption("--fx-channel")

--- a/modules/testrail.py
+++ b/modules/testrail.py
@@ -328,7 +328,7 @@ class TestRail:
         matching_group = next(c for c in configs if c.get("id") == config_group_id)
         logging.info(f"matching group|| {matching_group}")
         cfgs = [
-            c for c in matching_group.get("configs") if c.get("name") == config_name
+            c for c in matching_group.get("configs") if config_name in c.get("name")
         ]
         return cfgs
 


### PR DESCRIPTION
### Description

We check for version when we run TestRail report checks against new betas. For GHA we use the Pushbot to track the latest run version per OS in a file in the repo. For TaskCluster, we don't have access to the Pushbot (probably), so we need to actually confer with TestRail.

### Type of change

Please delete options that are not relevant.

- [x] Other Changes (Reporting)

### Screenshots / Explanations

The `reportable` fixture gets any relevant test runs associated with the current Version Under Test, and if any of them are populated, the fixture confirms that all the suites (less the number of non-reporting suites, currently `meta` and `pocket`) in the repo are covered in the report.

### Comments / Concerns

No way to force a report if the report already exists (say we want to re-run a report), even if tests were missed in one or more individual suites.
