### PR TITLE
Anca/Print to PDF

### DIFF
--- a/tests/printing_ui/test_print_to_pdf.py
+++ b/tests/printing_ui/test_print_to_pdf.py
@@ -2,10 +2,11 @@ import os
 from time import sleep
 
 import pytest
-from pynput.keyboard import Controller, Key
+from pynput.keyboard import Controller
 from selenium.webdriver import Firefox
 
 from modules.browser_object_panel_ui import PanelUi
+from modules.page_object_generics import GenericPdf
 
 
 @pytest.fixture()
@@ -39,6 +40,7 @@ def test_print_to_pdf(
 
     keyboard = Controller()
     panel_ui = PanelUi(driver)
+    pdf = GenericPdf(driver)
 
     driver.get(TEST_PAGE)
 
@@ -48,19 +50,18 @@ def test_print_to_pdf(
         panel_ui.select_panel_setting("print-option")
 
     # Allow time for the Save As dialog to appear
-    sleep(2)
+    sleep(5)
 
     # Type a file name in the native dialog and save the PDF
     keyboard.type("wikipedia.pdf")
-    keyboard.press(Key.enter)
-    keyboard.release(Key.enter)
+    pdf.handle_os_download_confirmation(keyboard, sys_platform)
 
     # Set the expected download path and the expected PDF name
     expected_file_name = "wikipedia.pdf"
     saved_pdf_location = os.path.join(downloads_folder, expected_file_name)
 
     # Allow time for the file to be saved
-    sleep(2)
+    sleep(3)
 
     # Verify if the PDF file was saved in the downloads folder
     assert os.path.exists(

--- a/tests/printing_ui/test_print_to_pdf.py
+++ b/tests/printing_ui/test_print_to_pdf.py
@@ -1,0 +1,74 @@
+import os
+from time import sleep
+
+import pytest
+from pynput.keyboard import Controller, Key
+from selenium.webdriver import Firefox
+
+from modules.browser_object_panel_ui import PanelUi
+
+
+@pytest.fixture()
+def test_case():
+    return "965142"
+
+
+@pytest.fixture()
+def delete_files_regex_string():
+    return r".*wikipedia.pdf"
+
+
+@pytest.fixture()
+def set_prefs():
+    return [("print.always_print_silent", True)]
+
+
+TEST_PAGE = "https://en.wikipedia.org"
+
+
+@pytest.mark.headed
+def test_print_to_pdf(
+    driver: Firefox,
+    downloads_folder: str,
+    sys_platform,
+    delete_files,
+):
+    """
+    C965142 - Verify that the user can print a webpage to PDF
+    """
+
+    keyboard = Controller()
+    panel_ui = PanelUi(driver)
+
+    driver.get(TEST_PAGE)
+
+    # Select Print option from Hamburger Menu in order to trigger the silent printing
+    with driver.context(driver.CONTEXT_CHROME):
+        panel_ui.open_panel_menu()
+        panel_ui.select_panel_setting("print-option")
+
+    # Allow time for the Save As dialog to appear
+    sleep(2)
+
+    # Type a file name in the native dialog and save the PDF
+    keyboard.type("wikipedia.pdf")
+    keyboard.press(Key.enter)
+    keyboard.release(Key.enter)
+
+    # Set the expected download path and the expected PDF name
+    expected_file_name = "wikipedia.pdf"
+    saved_pdf_location = os.path.join(downloads_folder, expected_file_name)
+
+    # Allow time for the file to be saved
+    sleep(2)
+
+    # Verify if the PDF file was saved in the downloads folder
+    assert os.path.exists(
+        saved_pdf_location
+    ), f"The file was not downloaded to {saved_pdf_location}."
+
+    print(
+        f"Test passed: The file {expected_file_name} has been downloaded and is present at {saved_pdf_location}."
+    )
+
+    driver.quit()


### PR DESCRIPTION
### Description

- Verify that a webpage can be printed to PDF

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/965142**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1925549**

### Type of change

- [ x] New Test

### How does this resolve / make progress on that bug?

- In progress

### Screenshots / Explanations

- N/A

### Comments / Concerns

- I wasn't able to access the Print Preview destination dropdown, so instead, I set print.always_print_silent to True. This allows printing to proceed directly without the preview dialog. When no other printer is configured, the system defaults to PDF, allowing me to complete the test. Note that with this approach, the file name isn't automatically populated in the Save Output dialog. The File name field is left empty, so I had to enter it manually.
