### PR TITLE
Anca/Copy table with hyperlink

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -166,7 +166,7 @@ jobs:
           FX_EXECUTABLE: /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox
         run: |
           /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox --version
-          pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 . || TEST_EXIT_CODE=$?
+          pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 tests/drag_and_drop || TEST_EXIT_CODE=$?
           mv artifacts artifacts-mac || true
           exit $TEST_EXIT_CODE
       - name: Commit Changed Tracker Files
@@ -186,7 +186,7 @@ jobs:
           FX_EXECUTABLE: /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox
         run: |
           mv ./ci_pyproject_headed.toml ./pyproject.toml;
-          pipenv run pytest --fx-executable="$FX_EXECUTABLE" . || TEST_EXIT_CODE=$?
+          pipenv run pytest --fx-executable="$FX_EXECUTABLE" tests/drag_and_drop || TEST_EXIT_CODE=$?
           mv -n artifacts/* artifacts-mac/ || true
           exit $TEST_EXIT_CODE
       - name: Upload artifacts

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -100,6 +100,7 @@ jobs:
           TESTRAIL_BASE_URL: ${{ secrets.TESTRAIL_BASE_URL }}
           TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
           TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
+          REPORTABLE: true
         run: |
           rm ./pyproject.toml;
           mv ./ci_pyproject_headed.toml ./pyproject.toml;
@@ -166,7 +167,7 @@ jobs:
           FX_EXECUTABLE: /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox
         run: |
           /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox --version
-          pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 tests/drag_and_drop || TEST_EXIT_CODE=$?
+          pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 . || TEST_EXIT_CODE=$?
           mv artifacts artifacts-mac || true
           exit $TEST_EXIT_CODE
       - name: Commit Changed Tracker Files
@@ -184,9 +185,10 @@ jobs:
           TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
           TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
           FX_EXECUTABLE: /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox
+          REPORTABLE: true
         run: |
           mv ./ci_pyproject_headed.toml ./pyproject.toml;
-          pipenv run pytest --fx-executable="$FX_EXECUTABLE" tests/drag_and_drop || TEST_EXIT_CODE=$?
+          pipenv run pytest --fx-executable="$FX_EXECUTABLE" . || TEST_EXIT_CODE=$?
           mv -n artifacts/* artifacts-mac/ || true
           exit $TEST_EXIT_CODE
       - name: Upload artifacts

--- a/modules/browser_object_print_preview.py
+++ b/modules/browser_object_print_preview.py
@@ -2,7 +2,6 @@ from time import sleep
 
 from selenium.common import NoAlertPresentException
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support import expected_conditions as EC
 
 from modules.browser_object_panel_ui import PanelUi
 from modules.page_base import BasePage

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -537,27 +537,27 @@ class BasePage(Page):
             self.actions.context_click(el).perform()
         return self
 
-    def copy(self, sys_platform) -> Page:
+    def copy(self) -> Page:
         """Copy the selected item"""
-        mod_key = Keys.COMMAND if sys_platform == "Darwin" else Keys.CONTROL
+        mod_key = Keys.COMMAND if self.sys_platform() == "Darwin" else Keys.CONTROL
         self.actions.key_down(mod_key)
         self.actions.send_keys("c")
         self.actions.key_up(mod_key).perform()
         time.sleep(0.5)
         return self
 
-    def paste(self, sys_platform) -> Page:
+    def paste(self) -> Page:
         """Paste the copied item"""
-        mod_key = Keys.COMMAND if sys_platform == "Darwin" else Keys.CONTROL
+        mod_key = Keys.COMMAND if self.sys_platform() == "Darwin" else Keys.CONTROL
         self.actions.key_down(mod_key)
         self.actions.send_keys("v")
         self.actions.key_up(mod_key).perform()
         time.sleep(0.5)
         return self
 
-    def undo(self, sys_platform) -> Page:
+    def undo(self) -> Page:
         """Undo last action"""
-        mod_key = Keys.COMMAND if sys_platform == "Darwin" else Keys.CONTROL
+        mod_key = Keys.COMMAND if self.sys_platform() == "Darwin" else Keys.CONTROL
         self.actions.key_down(mod_key)
         self.actions.send_keys("z")
         self.actions.key_up(mod_key).perform()

--- a/tests/drag_and_drop/test_copy_entire_row_column.py
+++ b/tests/drag_and_drop/test_copy_entire_row_column.py
@@ -16,7 +16,7 @@ SHEET1_URL = "https://docs.google.com/spreadsheets/d/1kXW-a-ElKBykGTRO9vrwajYj_A
 SHEET2_URL = "https://docs.google.com/spreadsheets/d/1kXW-a-ElKBykGTRO9vrwajYj_AHt9P-h8p3niLdXu40/edit?gid=1387427752#gid=1387427752"
 
 
-def test_copy_entire_row_column(driver: Firefox, sys_platform):
+def test_copy_entire_row_column(driver: Firefox):
     """
     C936861: Verify that copying and pasting entire rows and columns work
     """
@@ -27,12 +27,12 @@ def test_copy_entire_row_column(driver: Firefox, sys_platform):
     try:
         # Copy a row
         web_page.select_num_rows(1)
-        web_page.copy(sys_platform)
+        web_page.copy()
 
         # Paste the row in the same sheet
         for _ in range(3):
             web_page.perform_key_combo(Keys.ARROW_RIGHT, Keys.DOWN)
-        web_page.paste(sys_platform)
+        web_page.paste()
 
         # Verify that the row is pasted properly
         for i in range(1, 4):
@@ -41,12 +41,12 @@ def test_copy_entire_row_column(driver: Firefox, sys_platform):
             )
             web_page.perform_key_combo(Keys.RIGHT)
 
-        web_page.undo(sys_platform)
+        web_page.undo()
 
         # Paste the row in a different sheet
         nav.search(SHEET2_URL)
         time.sleep(2)
-        web_page.paste(sys_platform)
+        web_page.paste()
 
         # Verify that the row is pasted properly
         for i in range(1, 4):
@@ -55,18 +55,18 @@ def test_copy_entire_row_column(driver: Firefox, sys_platform):
             )
             web_page.perform_key_combo(Keys.RIGHT)
 
-        web_page.undo(sys_platform)
+        web_page.undo()
 
         # Copy a column
         nav.search(SHEET1_URL)
         time.sleep(2)
         web_page.select_num_columns(1)
-        web_page.copy(sys_platform)
+        web_page.copy()
 
         # Paste the column in the same sheet
         for _ in range(3):
             web_page.perform_key_combo(Keys.ARROW_RIGHT, Keys.DOWN)
-        web_page.paste(sys_platform)
+        web_page.paste()
 
         # Verify that the column is pasted properly
         for i in range(1, 4):
@@ -75,12 +75,12 @@ def test_copy_entire_row_column(driver: Firefox, sys_platform):
             )
             web_page.perform_key_combo(Keys.DOWN)
 
-        web_page.undo(sys_platform)
+        web_page.undo()
 
         # Paste the column in a different sheet
         nav.search(SHEET2_URL)
         time.sleep(2)
-        web_page.paste(sys_platform)
+        web_page.paste()
 
         # Verify that the column is pasted properly
         for i in range(1, 4):
@@ -90,4 +90,4 @@ def test_copy_entire_row_column(driver: Firefox, sys_platform):
             web_page.perform_key_combo(Keys.DOWN)
 
     finally:
-        web_page.undo(sys_platform)
+        web_page.undo()

--- a/tests/drag_and_drop/test_copy_entire_row_column.py
+++ b/tests/drag_and_drop/test_copy_entire_row_column.py
@@ -76,6 +76,7 @@ def test_copy_entire_row_column(driver: Firefox):
             web_page.perform_key_combo(Keys.DOWN)
 
         web_page.undo()
+        time.sleep(2)
 
         # Paste the column in a different sheet
         nav.search(SHEET2_URL)
@@ -91,3 +92,4 @@ def test_copy_entire_row_column(driver: Firefox):
 
     finally:
         web_page.undo()
+        time.sleep(2)

--- a/tests/drag_and_drop/test_copy_hyperlink_table.py
+++ b/tests/drag_and_drop/test_copy_hyperlink_table.py
@@ -35,7 +35,6 @@ expected_values = [
 
 
 @pytest.mark.headed
-@pytest.mark.unstable
 def test_copy_table_with_hyperlink(driver: Firefox, sys_platform, temp_selectors):
     """
     Verify that copying and pasting table content with hyperlinks retains the hyperlink functionality and redirects

--- a/tests/drag_and_drop/test_copy_hyperlink_table.py
+++ b/tests/drag_and_drop/test_copy_hyperlink_table.py
@@ -1,6 +1,8 @@
 from time import sleep
+
 import pytest
 from selenium.webdriver import Firefox, Keys
+
 from modules.page_object import GoogleSheets, Navigation
 
 
@@ -21,8 +23,10 @@ def temp_selectors():
 
 
 SHEET1_URL = "https://docs.google.com/spreadsheets/d/1ennETYnxeWZrUcItUxHgR8ug6EwL_QpyUFvB4I7lof4/edit?usp=sharing"
-SHEET2_URL = ("https://docs.google.com/spreadsheets/d/1ennETYnxeWZrUcItUxHgR8ug6EwL_QpyUFvB4I7lof4/edit?gid=674466887"
-              "#gid=674466887")
+SHEET2_URL = (
+    "https://docs.google.com/spreadsheets/d/1ennETYnxeWZrUcItUxHgR8ug6EwL_QpyUFvB4I7lof4/edit?gid=674466887"
+    "#gid=674466887"
+)
 
 expected_values = [
     ["Season", "Ordered", "First aired"],
@@ -30,6 +34,8 @@ expected_values = [
 ]
 
 
+@pytest.mark.headed
+@pytest.mark.unstable
 def test_copy_table_with_hyperlink(driver: Firefox, sys_platform, temp_selectors):
     """
     Verify that copying and pasting table content with hyperlinks retains the hyperlink functionality and redirects
@@ -56,13 +62,9 @@ def test_copy_table_with_hyperlink(driver: Firefox, sys_platform, temp_selectors
         # Verify that the pasted values are correct
         for row_index, row in enumerate(expected_values):
             for col_index, expected_value in enumerate(row):
-                # Wait until value is present in the cell
-                web_page.wait.until(
-                    lambda _: expected_value in web_page.get_element("formula-box-input").get_attribute("innerHTML")
+                web_page.element_attribute_contains(
+                    "formula-box-input", "innerHTML", expected_value
                 )
-                # Check that the current cell's value matches expected_value
-                actual_value = web_page.get_element("formula-box-input").get_attribute("innerHTML")
-                assert expected_value in actual_value
                 # Move to the next cell to the right
                 web_page.perform_key_combo(Keys.RIGHT)
             # Move to the beginning of the next row

--- a/tests/drag_and_drop/test_copy_hyperlink_table.py
+++ b/tests/drag_and_drop/test_copy_hyperlink_table.py
@@ -91,3 +91,4 @@ def test_copy_table_with_hyperlink(driver: Firefox, temp_selectors):
     finally:
         # Undo the paste operation
         web_page.undo()
+        sleep(2)

--- a/tests/drag_and_drop/test_copy_hyperlink_table.py
+++ b/tests/drag_and_drop/test_copy_hyperlink_table.py
@@ -35,7 +35,7 @@ expected_values = [
 
 
 @pytest.mark.headed
-def test_copy_table_with_hyperlink(driver: Firefox, sys_platform, temp_selectors):
+def test_copy_table_with_hyperlink(driver: Firefox, temp_selectors):
     """
     Verify that copying and pasting table content with hyperlinks retains the hyperlink functionality and redirects
     to the correct page.
@@ -48,11 +48,11 @@ def test_copy_table_with_hyperlink(driver: Firefox, sys_platform, temp_selectors
     try:
         # Copy the table
         web_page.select_num_rows(2)
-        web_page.copy(sys_platform)
+        web_page.copy()
 
         nav.search(SHEET2_URL)
         sleep(2)
-        web_page.paste(sys_platform)
+        web_page.paste()
         sleep(2)
 
         # Move to the starting cell (A1)
@@ -90,4 +90,4 @@ def test_copy_table_with_hyperlink(driver: Firefox, sys_platform, temp_selectors
 
     finally:
         # Undo the paste operation
-        web_page.undo(sys_platform)
+        web_page.undo()

--- a/tests/drag_and_drop/test_copy_hyperlink_table.py
+++ b/tests/drag_and_drop/test_copy_hyperlink_table.py
@@ -1,0 +1,92 @@
+from time import sleep
+import pytest
+from selenium.webdriver import Firefox, Keys
+from modules.page_object import GoogleSheets, Navigation
+
+
+@pytest.fixture()
+def test_case():
+    return "937418"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "cell-link": {
+            "selectorData": "docs-linkbubble-link-text",
+            "strategy": "id",
+            "groups": [],
+        }
+    }
+
+
+SHEET1_URL = "https://docs.google.com/spreadsheets/d/1ennETYnxeWZrUcItUxHgR8ug6EwL_QpyUFvB4I7lof4/edit?usp=sharing"
+SHEET2_URL = ("https://docs.google.com/spreadsheets/d/1ennETYnxeWZrUcItUxHgR8ug6EwL_QpyUFvB4I7lof4/edit?gid=674466887"
+              "#gid=674466887")
+
+expected_values = [
+    ["Season", "Ordered", "First aired"],
+    ["Season 1", "3/2/2010", "4/17/2011"],
+]
+
+
+def test_copy_table_with_hyperlink(driver: Firefox, sys_platform, temp_selectors):
+    """
+    Verify that copying and pasting table content with hyperlinks retains the hyperlink functionality and redirects
+    to the correct page.
+    """
+    # Initializing objects
+    web_page = GoogleSheets(driver, url=SHEET1_URL).open()
+    nav = Navigation(driver)
+    web_page.elements |= temp_selectors
+
+    try:
+        # Copy the table
+        web_page.select_num_rows(2)
+        web_page.copy(sys_platform)
+
+        nav.search(SHEET2_URL)
+        sleep(2)
+        web_page.paste(sys_platform)
+        sleep(2)
+
+        # Move to the starting cell (A1)
+        web_page.perform_key_combo(Keys.HOME)
+
+        # Verify that the pasted values are correct
+        for row_index, row in enumerate(expected_values):
+            for col_index, expected_value in enumerate(row):
+                # Wait until value is present in the cell
+                web_page.wait.until(
+                    lambda _: expected_value in web_page.get_element("formula-box-input").get_attribute("innerHTML")
+                )
+                # Check that the current cell's value matches expected_value
+                actual_value = web_page.get_element("formula-box-input").get_attribute("innerHTML")
+                assert expected_value in actual_value
+                # Move to the next cell to the right
+                web_page.perform_key_combo(Keys.RIGHT)
+            # Move to the beginning of the next row
+            web_page.perform_key_combo(Keys.HOME)
+            # Move down to the next row
+            web_page.perform_key_combo(Keys.DOWN)
+
+        # Move to the cell containing the hyperlink
+        web_page.perform_key_combo(Keys.HOME)
+        web_page.perform_key_combo(Keys.UP)
+
+        # Click on the hyperlink
+        web_page.perform_key_combo(Keys.ENTER)
+        web_page.element_clickable("cell-link")
+        web_page.click_on("cell-link")
+
+        # Verify that the user is redirected to the correct page
+        driver.switch_to.window(driver.window_handles[-1])
+        web_page.url_contains("Game_of_Thrones_season_1")
+
+        # Close the new tab and switch the focus to prevent the "Leave Page" warning from Google page
+        driver.close()
+        driver.switch_to.window(driver.window_handles[0])
+
+    finally:
+        # Undo the paste operation
+        web_page.undo(sys_platform)

--- a/tests/drag_and_drop/test_copy_table_header.py
+++ b/tests/drag_and_drop/test_copy_table_header.py
@@ -1,4 +1,4 @@
-import sys
+import platform
 import time
 
 import pytest
@@ -30,25 +30,25 @@ SHEET_SETS = {
 
 
 @pytest.mark.headed
-@pytest.mark.xfail(sys.platform == "linux", reason="Unstable in TC linux")
+@pytest.mark.xfail(platform.system == "Linux", reason="Unstable in TC linux")
 def test_copy_table_header(driver: Firefox):
     """
     C936860: Verify that copying and pasting header from tables work
     """
-    (sheet1_url, sheet2_url) = SHEET_SETS.get(sys.platform)
+    (sheet1_url, sheet2_url) = SHEET_SETS.get(platform.system())
     # Initializing objects
     web_page = GoogleSheets(driver, url=sheet1_url).open()
     nav = Navigation(driver)
 
     # Copy the header row
     web_page.select_num_rows(1)
-    web_page.copy(sys.platform)
+    web_page.copy(platform.system())
 
     try:
         # Paste the header row in the same sheet
         for _ in range(3):
             web_page.perform_key_combo(Keys.ARROW_RIGHT, Keys.DOWN)
-        web_page.paste(sys.platform)
+        web_page.paste(platform.system())
 
         # Verify that the pasted row has header attributes and the selection is pasted properly
         web_page.expect(lambda _: len(web_page.get_elements("table-options")) == 2)
@@ -62,12 +62,12 @@ def test_copy_table_header(driver: Firefox):
         web_page.element_attribute_contains(
             "formula-box-input", "innerHTML", "Column 2"
         )
-        web_page.undo(sys.platform)
+        web_page.undo(platform.system())
 
         # Paste the header row in a different sheet
         nav.search(sheet2_url)
         time.sleep(2)
-        web_page.paste(sys.platform)
+        web_page.paste(platform.system())
 
         # Verify that the pasted row has header attributes and the selection is pasted properly
         web_page.expect(lambda _: len(web_page.get_elements("table-options")) == 1)
@@ -81,6 +81,7 @@ def test_copy_table_header(driver: Firefox):
         web_page.element_attribute_contains(
             "formula-box-input", "innerHTML", "Column 2"
         )
-        web_page.undo(sys.platform)
+        web_page.undo(platform.system())
     finally:
-        web_page.undo(sys.platform)
+        web_page.undo(platform.system())
+    time.sleep(2)

--- a/tests/drag_and_drop/test_copy_table_header.py
+++ b/tests/drag_and_drop/test_copy_table_header.py
@@ -30,7 +30,6 @@ SHEET_SETS = {
 
 
 @pytest.mark.headed
-@pytest.mark.xfail(platform.system() == "Linux", reason="Unstable in TC linux")
 def test_copy_table_header(driver: Firefox):
     """
     C936860: Verify that copying and pasting header from tables work
@@ -42,13 +41,13 @@ def test_copy_table_header(driver: Firefox):
 
     # Copy the header row
     web_page.select_num_rows(1)
-    web_page.copy(platform.system())
+    web_page.copy()
 
     try:
         # Paste the header row in the same sheet
         for _ in range(3):
             web_page.perform_key_combo(Keys.ARROW_RIGHT, Keys.DOWN)
-        web_page.paste(platform.system())
+        web_page.paste()
 
         # Verify that the pasted row has header attributes and the selection is pasted properly
         web_page.expect(lambda _: len(web_page.get_elements("table-options")) == 2)
@@ -62,12 +61,12 @@ def test_copy_table_header(driver: Firefox):
         web_page.element_attribute_contains(
             "formula-box-input", "innerHTML", "Column 2"
         )
-        web_page.undo(platform.system())
+        web_page.undo()
 
         # Paste the header row in a different sheet
         nav.search(sheet2_url)
         time.sleep(2)
-        web_page.paste(platform.system())
+        web_page.paste()
 
         # Verify that the pasted row has header attributes and the selection is pasted properly
         web_page.expect(lambda _: len(web_page.get_elements("table-options")) == 1)
@@ -81,7 +80,7 @@ def test_copy_table_header(driver: Firefox):
         web_page.element_attribute_contains(
             "formula-box-input", "innerHTML", "Column 2"
         )
-        web_page.undo(platform.system())
+        web_page.undo()
     finally:
-        web_page.undo(platform.system())
+        web_page.undo()
     time.sleep(2)

--- a/tests/drag_and_drop/test_copy_table_header.py
+++ b/tests/drag_and_drop/test_copy_table_header.py
@@ -28,6 +28,7 @@ SHEET_SETS = {
 }
 
 
+@pytest.mark.headed
 def test_copy_table_header(driver: Firefox, sys_platform):
     """
     C936860: Verify that copying and pasting header from tables work

--- a/tests/drag_and_drop/test_copy_table_header.py
+++ b/tests/drag_and_drop/test_copy_table_header.py
@@ -62,6 +62,7 @@ def test_copy_table_header(driver: Firefox):
             "formula-box-input", "innerHTML", "Column 2"
         )
         web_page.undo()
+        time.sleep(2)
 
         # Paste the header row in a different sheet
         nav.search(sheet2_url)
@@ -81,6 +82,7 @@ def test_copy_table_header(driver: Firefox):
             "formula-box-input", "innerHTML", "Column 2"
         )
         web_page.undo()
+        time.sleep(2)
     finally:
         web_page.undo()
-    time.sleep(2)
+        time.sleep(2)

--- a/tests/drag_and_drop/test_copy_table_header.py
+++ b/tests/drag_and_drop/test_copy_table_header.py
@@ -12,16 +12,29 @@ def test_case():
     return "936860"
 
 
-SHEET1_URL = "https://docs.google.com/spreadsheets/d/1ra7K1TAlns-X0mG93XWXC-P3lIEtLYuvXTGOVL8IqU8/edit?gid=0#gid=0"
-SHEET2_URL = "https://docs.google.com/spreadsheets/d/1ra7K1TAlns-X0mG93XWXC-P3lIEtLYuvXTGOVL8IqU8/edit?gid=1556347227#gid=1556347227"
+SHEET_SETS = {
+    "Darwin": (
+        "https://docs.google.com/spreadsheets/d/1ra7K1TAlns-X0mG93XWXC-P3lIEtLYuvXTGOVL8IqU8/edit?gid=1469667334#gid=1469667334",
+        "https://docs.google.com/spreadsheets/d/1ra7K1TAlns-X0mG93XWXC-P3lIEtLYuvXTGOVL8IqU8/edit?gid=1776043530#gid=1776043530",
+    ),
+    "Windows": (
+        "https://docs.google.com/spreadsheets/d/1cxDppB_yNeMoUSaOqK-Hq6OS08kbOSeLck6Kypyb4zg/edit?gid=1469667334#gid=1469667334",
+        "https://docs.google.com/spreadsheets/d/1cxDppB_yNeMoUSaOqK-Hq6OS08kbOSeLck6Kypyb4zg/edit?gid=1776043530#gid=1776043530",
+    ),
+    "Linux": (
+        "https://docs.google.com/spreadsheets/d/1CuxT_RgsLonZSGXXhCgc4648mGtXUW1iii0qPwMxn3Q/edit?gid=1469667334#gid=1469667334",
+        "https://docs.google.com/spreadsheets/d/1CuxT_RgsLonZSGXXhCgc4648mGtXUW1iii0qPwMxn3Q/edit?gid=1776043530#gid=1776043530",
+    ),
+}
 
 
 def test_copy_table_header(driver: Firefox, sys_platform):
     """
     C936860: Verify that copying and pasting header from tables work
     """
+    (sheet1_url, sheet2_url) = SHEET_SETS.get(sys_platform)
     # Initializing objects
-    web_page = GoogleSheets(driver, url=SHEET1_URL).open()
+    web_page = GoogleSheets(driver, url=sheet1_url).open()
     nav = Navigation(driver)
 
     # Copy the header row
@@ -49,7 +62,7 @@ def test_copy_table_header(driver: Firefox, sys_platform):
         web_page.undo(sys_platform)
 
         # Paste the header row in a different sheet
-        nav.search(SHEET2_URL)
+        nav.search(sheet2_url)
         time.sleep(2)
         web_page.paste(sys_platform)
 

--- a/tests/drag_and_drop/test_copy_table_header.py
+++ b/tests/drag_and_drop/test_copy_table_header.py
@@ -1,3 +1,4 @@
+import sys
 import time
 
 import pytest
@@ -29,24 +30,25 @@ SHEET_SETS = {
 
 
 @pytest.mark.headed
-def test_copy_table_header(driver: Firefox, sys_platform):
+@pytest.mark.xfail(sys.platform == "linux", reason="Unstable in TC linux")
+def test_copy_table_header(driver: Firefox):
     """
     C936860: Verify that copying and pasting header from tables work
     """
-    (sheet1_url, sheet2_url) = SHEET_SETS.get(sys_platform)
+    (sheet1_url, sheet2_url) = SHEET_SETS.get(sys.platform)
     # Initializing objects
     web_page = GoogleSheets(driver, url=sheet1_url).open()
     nav = Navigation(driver)
 
     # Copy the header row
     web_page.select_num_rows(1)
-    web_page.copy(sys_platform)
+    web_page.copy(sys.platform)
 
     try:
         # Paste the header row in the same sheet
         for _ in range(3):
             web_page.perform_key_combo(Keys.ARROW_RIGHT, Keys.DOWN)
-        web_page.paste(sys_platform)
+        web_page.paste(sys.platform)
 
         # Verify that the pasted row has header attributes and the selection is pasted properly
         web_page.expect(lambda _: len(web_page.get_elements("table-options")) == 2)
@@ -60,12 +62,12 @@ def test_copy_table_header(driver: Firefox, sys_platform):
         web_page.element_attribute_contains(
             "formula-box-input", "innerHTML", "Column 2"
         )
-        web_page.undo(sys_platform)
+        web_page.undo(sys.platform)
 
         # Paste the header row in a different sheet
         nav.search(sheet2_url)
         time.sleep(2)
-        web_page.paste(sys_platform)
+        web_page.paste(sys.platform)
 
         # Verify that the pasted row has header attributes and the selection is pasted properly
         web_page.expect(lambda _: len(web_page.get_elements("table-options")) == 1)
@@ -79,6 +81,6 @@ def test_copy_table_header(driver: Firefox, sys_platform):
         web_page.element_attribute_contains(
             "formula-box-input", "innerHTML", "Column 2"
         )
-        web_page.undo(sys_platform)
+        web_page.undo(sys.platform)
     finally:
-        web_page.undo(sys_platform)
+        web_page.undo(sys.platform)

--- a/tests/drag_and_drop/test_copy_table_header.py
+++ b/tests/drag_and_drop/test_copy_table_header.py
@@ -30,7 +30,7 @@ SHEET_SETS = {
 
 
 @pytest.mark.headed
-@pytest.mark.xfail(platform.system == "Linux", reason="Unstable in TC linux")
+@pytest.mark.xfail(platform.system() == "Linux", reason="Unstable in TC linux")
 def test_copy_table_header(driver: Firefox):
     """
     C936860: Verify that copying and pasting header from tables work

--- a/tests/password_manager/test_add_primary_password.py
+++ b/tests/password_manager/test_add_primary_password.py
@@ -1,5 +1,4 @@
 import pytest
-from selenium.common.exceptions import NoAlertPresentException
 from selenium.webdriver import Firefox
 
 from modules.page_object import AboutPrefs

--- a/tests/password_manager/test_can_view_password_when_PP_enabled.py
+++ b/tests/password_manager/test_can_view_password_when_PP_enabled.py
@@ -1,5 +1,4 @@
 import pytest
-from selenium.common import NoAlertPresentException
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.keys import Keys
 

--- a/tests/password_manager/test_primary_password_triggered_on_about_logins_access.py
+++ b/tests/password_manager/test_primary_password_triggered_on_about_logins_access.py
@@ -1,5 +1,4 @@
 import pytest
-from selenium.common import NoAlertPresentException
 from selenium.webdriver import Firefox, Keys
 from selenium.webdriver.support import expected_conditions as EC
 

--- a/tests/printing_ui/test_print_to_pdf.py
+++ b/tests/printing_ui/test_print_to_pdf.py
@@ -1,13 +1,10 @@
 import logging
 import os
-from time import sleep
 
 import pytest
 from selenium.webdriver import Firefox
-from selenium.webdriver.common.keys import Keys
 
 from modules.browser_object import PrintPreview
-from modules.page_object import AboutPrefs
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Description

Ensure that copying and pasting table content with hyperlinks preserves the hyperlink functionality and redirects to the intended page.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/937418**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1925574**

### Type of change

- [x ] New Test


### How does this resolve / make progress on that bug?

- Completed, but not sure is stable enough.

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
