### PR TITLE
Anca/Bookmark opened in New Private Window via toolbar context menu

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1508,6 +1508,20 @@ Description: Context menu option from Password field
 Location: Login page - Password field context menu
 Path to .json: modules/data/context_menu.components.json
 ```
+```
+Selector Name: context-menu-toolbar-open-new-private-window
+Selector Data: selectorData": "placesContext_open:newprivatewindow"
+Description: Context menu option from a Toolbar bookmark
+Location: Toolbar - any bookmark context menu
+Path to .json: modules/data/context_menu.components.json
+```
+```
+Selector Name: context-menu-toolbar-open-new-window
+Selector Data: selectorData": "placesContext_open:newwindow"
+Description: Context menu option from a Toolbar bookmark
+Location: Toolbar - any bookmark context menu
+Path to .json: modules/data/context_menu.components.json
+```
 #### credit_card_fill
 ```
 Selector Name: form-field

--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -185,5 +185,17 @@
         "selectorData": "context-reveal-password",
         "strategy": "id",
         "groups": []
+    },
+
+    "context-menu-toolbar-open-in-new-private-window": {
+        "selectorData": "placesContext_open:newprivatewindow",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "context-menu-toolbar-open-in-new-window": {
+        "selectorData": "placesContext_open:newwindow",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/bookmarks_and_history/test_open_bookmark_in_private_window_via_toolbar_context_menu.py
+++ b/tests/bookmarks_and_history/test_open_bookmark_in_private_window_via_toolbar_context_menu.py
@@ -1,0 +1,46 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import ContextMenu, Navigation, PanelUi, TabBar
+from modules.page_object_generics import GenericPage
+
+
+@pytest.fixture()
+def test_case():
+    return "2084553"
+
+
+URL_TO_BOOKMARK = "https://www.mozilla.org/"
+
+
+def test_open_bookmark_in_new_private_window_via_toolbar_context_menu(driver: Firefox):
+    """
+    C2084553: Verify that a bookmarked page can be open in a New Private Window from Toolbar context menu.
+    """
+
+    # Instantiate object
+    nav = Navigation(driver)
+    panel = PanelUi(driver)
+    tabs = TabBar(driver)
+    context_menu = ContextMenu(driver)
+    page = GenericPage(driver, url=URL_TO_BOOKMARK).open()
+
+    # Bookmark the test page via star button
+    nav.add_bookmark_via_star()
+
+    # In a new tab, right-click the bookmarked page in the toolbar and select 'Open in New Private Window' from the
+    # context menu
+    with driver.context(driver.CONTEXT_CHROME):
+        tabs.new_tab_by_button()
+        bookmarked_page = panel.get_element(
+            "bookmark-by-title", labels=["Internet for people"]
+        )
+        context_menu.context_click(bookmarked_page)
+        context_menu.get_element(
+            "context-menu-toolbar-open-in-new-private-window"
+        ).click()
+
+    # Verify that the test page is opened in a new private window
+    driver.switch_to.window(driver.window_handles[-1])
+    nav.element_visible("private-browsing-icon")
+    page.url_contains("mozilla")


### PR DESCRIPTION
### Description

Verify that a bookmarked page can be open in a New Private Window from Toolbar context menu

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2084553**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1930228**

### Type of change

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
