### PR TITLE
Anca/Bookmark opened in New Window via toolbar context menu

### DIFF
--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -185,5 +185,17 @@
         "selectorData": "context-reveal-password",
         "strategy": "id",
         "groups": []
+    },
+
+    "context-menu-toolbar-open-in-new-private-window": {
+        "selectorData": "placesContext_open:newprivatewindow",
+        "strategy": "id",
+        "groups": []
+    },
+
+    "context-menu-toolbar-open-in-new-window": {
+        "selectorData": "placesContext_open:newwindow",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/bookmarks_and_history/test_open_bookmark_in_new_window_via_toolbar_context_menu.py
+++ b/tests/bookmarks_and_history/test_open_bookmark_in_new_window_via_toolbar_context_menu.py
@@ -1,0 +1,43 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import ContextMenu, Navigation, PanelUi, TabBar
+from modules.page_object_generics import GenericPage
+
+
+@pytest.fixture()
+def test_case():
+    return "2084552"
+
+
+URL_TO_BOOKMARK = "https://www.mozilla.org/"
+
+
+def test_open_bookmark_in_new_window_via_toolbar_context_menu(driver: Firefox):
+    """
+    C2084552: Verify that a bookmarked page can be open in a New Window from Toolbar context menu.
+    """
+
+    # Instantiate object
+    nav = Navigation(driver)
+    panel = PanelUi(driver)
+    tabs = TabBar(driver)
+    context_menu = ContextMenu(driver)
+    page = GenericPage(driver, url=URL_TO_BOOKMARK).open()
+
+    # Bookmark the test page via star button
+    nav.add_bookmark_via_star()
+
+    # In a new tab, right-click the bookmarked page in the toolbar and select 'Open in New Window' from the context menu
+    with driver.context(driver.CONTEXT_CHROME):
+        tabs.new_tab_by_button()
+        bookmarked_page = panel.get_element(
+            "bookmark-by-title", labels=["Internet for people"]
+        )
+        context_menu.context_click(bookmarked_page)
+        context_menu.get_element("context-menu-toolbar-open-in-new-window").click()
+
+    # Verify that the test page is opened in a new normal window
+    driver.switch_to.window(driver.window_handles[-1])
+    nav.element_not_visible("private-browsing-icon")
+    page.url_contains("mozilla")


### PR DESCRIPTION
### Description

Verify that a bookmarked page can be open in a New Window from Toolbar context menu

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2084552**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1930229**

### Type of change

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
