### PR TITLE
Anca/ Fix cleanup action for Copy table with hyperlink test

### DIFF
--- a/tests/drag_and_drop/test_copy_hyperlink_table.py
+++ b/tests/drag_and_drop/test_copy_hyperlink_table.py
@@ -89,6 +89,9 @@ def test_copy_table_with_hyperlink(driver: Firefox, temp_selectors):
         driver.switch_to.window(driver.window_handles[0])
 
     finally:
-        # Undo the paste operation
+        # Undo the paste operation; ESC key is pressed twice to exit cell focus and clear the hover state on the link
+        web_page.perform_key_combo(Keys.ESCAPE)
+        web_page.perform_key_combo(Keys.ESCAPE)
+        web_page.perform_key_combo(Keys.UP)
         web_page.undo()
         sleep(2)


### PR DESCRIPTION
### Description
- After executing the scenario from 937418 test case, which involves pasting a table and accessing a hyperlink within a cell, simply performing an undo operation doesn't remove the pasted table from the test page.  To clear the table, first, it is necessary to reset the focus by clearing the hover state on the link  and exiting the cell.


### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/937418**
**Link https://bugzilla.mozilla.org/show_bug.cgi?id=1925574:**

### Type of change

- [x ] Other Changes - fix cleanup action

### How does this resolve / make progress on that bug?

- Fixed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
