### PR TITLE
vs/mark hanging test as unstable

### DIFF
--- a/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
+++ b/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
@@ -17,6 +17,7 @@ themes = {
 
 alpenglow_map = {"light": "rgba(255, 255, 255, 0.76)", "dark": "rgba(40, 29, 78, 0.96)"}
 
+@pytest.mark.unstable
 
 @pytest.mark.ci
 def test_redirect_to_addons(driver: Firefox):


### PR DESCRIPTION
Marking a test as unstable since it leaves the Smoke tests hanging.