### PR TITLE
Pat/fix hanging credit card test

### DIFF
--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -21,8 +21,7 @@ def test_case():
 tabs = [i for i in range(4)]
 
 
-# @pytest.mark.xfail(platform.system() == "Linux", reason="Autofill Linux instability")
-@pytest.mark.unstable
+@pytest.mark.xfail(platform.system() == "Linux", reason="Autofill Linux instability")
 @pytest.mark.parametrize("num_tabs", tabs)
 def test_edit_credit_card_profile(driver: Firefox, num_tabs: int, hard_quit):
     """
@@ -33,7 +32,7 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int, hard_quit):
     about_prefs_obj = AboutPrefs(driver, category="privacy")
     util = Utilities()
     browser_action_obj = BrowserActions(driver)
-    credit_card_fill_obj = CreditCardFill(driver).open()
+    credit_card_fill_obj = CreditCardFill(driver)
     autofill_popup_obj = AutofillPopup(driver)
 
     # fill in cc information


### PR DESCRIPTION
### Description
Attempt to stop the edit_credit_card test from hanging windows ci again

### Bugzilla bug ID

**Testrail:**
**Link:**

### Type of change

Please delete options that are not relevant.

- [ ] New Test
- [ ] New POM
- [ ] Other Changes (Please specify)

### How does this resolve / make progress on that bug?

Please describe the progress or significance with respect to the bug listed above.

### Screenshots / Explanations

Please upload any relevant media or add a relevant description with respect to the bug listed above.

### Comments / Concerns

Please add a short blurb about any comments or concerns that this change might cause.
