### PR TITLE
Add mark for audio

### DIFF
--- a/tests/audio_video/test_allow_audio_video_functionality.py
+++ b/tests/audio_video/test_allow_audio_video_functionality.py
@@ -22,6 +22,7 @@ TEST_URL = "https://www.mlb.com/video/rockies-black-agree-on-extension"
 
 
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
+@pytest.mark.audio
 def test_allow_audio_video_functionality(driver: Firefox):
     """
     C330155 : 'Allow Audio and Video' functionality

--- a/tests/drag_and_drop/test_paste_image_text.py
+++ b/tests/drag_and_drop/test_paste_image_text.py
@@ -56,7 +56,9 @@ COPY_URL = "https://1stwebdesigner.com/image-file-types/"
 
 
 @pytest.mark.headed
-@pytest.mark.xfail(platform.system() == "Windows", reason="A pref needs to be set only on windows.")  
+@pytest.mark.xfail(
+    platform.system() == "Windows", reason="A pref needs to be set only on windows."
+)
 # Ref to Windows bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1857764
 def test_paste_image_text(driver: Firefox, sys_platform, temp_selectors):
     """

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -12,6 +12,7 @@ from modules.util import Utilities
 def test_case():
     return "2637622"
 
+
 @pytest.fixture()
 def delete_files_regex_string():
     return rf"{SAVED_FILENAME}"

--- a/tests/scrolling_panning_zooming/test_default_zoom_persists.py
+++ b/tests/scrolling_panning_zooming/test_default_zoom_persists.py
@@ -2,13 +2,12 @@ import logging
 import time
 
 import pytest
-
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
 
-from modules.page_object_generics import GenericPage
-from modules.page_object import AboutPrefs
 from modules.browser_object import TabBar
+from modules.page_object import AboutPrefs
+from modules.page_object_generics import GenericPage
 
 
 @pytest.fixture()
@@ -45,7 +44,9 @@ def test_default_zoom_across_tabs(driver: Firefox):
         # Open a new tab if not the first iteration
         if index > 0:
             tabs.new_tab_by_button()
-            driver.switch_to.window(driver.window_handles[-1])  # Switch to the newly opened tab
+            driver.switch_to.window(
+                driver.window_handles[-1]
+            )  # Switch to the newly opened tab
 
         # Load the test URL in the current tab
         page = GenericPage(driver, url=test_url)

--- a/tests/scrolling_panning_zooming/test_zoom_from_menu_bar.py
+++ b/tests/scrolling_panning_zooming/test_zoom_from_menu_bar.py
@@ -17,8 +17,8 @@ def test_case():
 
 TEST_PAGE = "https://www.example.com"
 
-@pytest.mark.unstable
 
+@pytest.mark.unstable
 @pytest.mark.skipif(
     platform.system() == "Darwin", reason="Cannot access menubar in MacOS"
 )
@@ -121,4 +121,3 @@ def test_zoom_from_menu_bar(driver: Firefox):
     menu_bar.click_on("menu-bar-zoom")
     menu_bar.click_and_hide_menu("menu-bar-zoom-reset")
     menu_bar.click_and_hide_menu("view-menu-button")
-    

--- a/tests/scrolling_panning_zooming/test_zoom_text_only.py
+++ b/tests/scrolling_panning_zooming/test_zoom_text_only.py
@@ -1,9 +1,8 @@
 import pytest
-
 from selenium.webdriver import Firefox
 
-from modules.page_object import GenericPage, AboutPrefs, AboutConfig
-from modules.browser_object import PanelUi, Navigation
+from modules.browser_object import Navigation, PanelUi
+from modules.page_object import AboutConfig, AboutPrefs, GenericPage
 
 
 @pytest.fixture()
@@ -17,23 +16,23 @@ def temp_selectors():
         "yahoo-logo": {
             "selectorData": "sfp-placeholder",
             "strategy": "id",
-            "groups": []
-        }, 
+            "groups": [],
+        },
         "yahoo-login-button": {
             "selectorData": "hd_nav_item",
             "strategy": "class",
-            "groups": []
+            "groups": [],
         },
         "duckduckgo-logo": {
             "selectorData": "minimal-homepage_logoHorizontal__Q_hjO",
             "strategy": "class",
-            "groups": []
-        }, 
-        "duckduckgo-tagline" : {
+            "groups": [],
+        },
+        "duckduckgo-tagline": {
             "selectorData": "minimal-homepage_taglineText__owJPH",
             "strategy": "class",
-            "groups": []
-        }
+            "groups": [],
+        },
     }
 
 
@@ -47,16 +46,14 @@ def test_zoom_text_only_from_settings(driver: Firefox, temp_selectors):
     Verify setting the default zoom level applies the chosen zoom level to all websites.
     """
     # Initializing objects
-    web_page = GenericPage(driver, url=WEBSITE_1).open()    
+    web_page = GenericPage(driver, url=WEBSITE_1).open()
     web_page.elements |= temp_selectors
     nav = Navigation(driver)
 
     # Save the original positions of elements for comparison
     driver.switch_to.new_window("tab")
     nav.search(WEBSITE_2)
-    web_page.wait.until(
-        lambda _: web_page.title_contains("DuckDuckGo")
-    )
+    web_page.wait.until(lambda _: web_page.title_contains("DuckDuckGo"))
     original_positions = save_original_positions(driver, web_page)
 
     # Set the pref to zoom text only
@@ -85,16 +82,14 @@ def test_zoom_text_only_after_restart(driver: Firefox, temp_selectors):
     about_config.toggle_true_false_config("browser.zoom.full")
 
     # Initializing objects
-    web_page = GenericPage(driver, url=WEBSITE_1).open()    
+    web_page = GenericPage(driver, url=WEBSITE_1).open()
     web_page.elements |= temp_selectors
     nav = Navigation(driver)
 
-    # Save the original positions of elements for comparison    
+    # Save the original positions of elements for comparison
     driver.switch_to.new_window("tab")
     nav.search(WEBSITE_2)
-    web_page.wait.until(
-        lambda _: web_page.title_contains("DuckDuckGo")
-    )
+    web_page.wait.until(lambda _: web_page.title_contains("DuckDuckGo"))
     original_positions = save_original_positions(driver, web_page)
 
     # Set default zoom level
@@ -117,28 +112,42 @@ def save_original_positions(driver, web_page):
     """
     driver.switch_to.window(driver.window_handles[0])
     original_website1_image_position = web_page.get_element("yahoo-logo").location["x"]
-    original_website1_text_position = web_page.get_element("yahoo-login-button").location["x"]
+    original_website1_text_position = web_page.get_element(
+        "yahoo-login-button"
+    ).location["x"]
     driver.switch_to.window(driver.window_handles[1])
-    original_website2_image_position = web_page.get_element("duckduckgo-logo").location["x"]
-    original_website2_text_position = web_page.get_element("duckduckgo-tagline").location["x"]
-    return (original_website1_image_position, original_website1_text_position, 
-            original_website2_image_position, original_website2_text_position)
+    original_website2_image_position = web_page.get_element("duckduckgo-logo").location[
+        "x"
+    ]
+    original_website2_text_position = web_page.get_element(
+        "duckduckgo-tagline"
+    ).location["x"]
+    return (
+        original_website1_image_position,
+        original_website1_text_position,
+        original_website2_image_position,
+        original_website2_text_position,
+    )
 
 
 def zoom_text_only_functionality_test(driver, nav, web_page, original_positions):
     """
     Verifies that zoom text only works
     """
-    (original_website1_image_position, original_website1_text_position, 
-            original_website2_image_position, original_website2_text_position) = original_positions
-    
+    (
+        original_website1_image_position,
+        original_website1_text_position,
+        original_website2_image_position,
+        original_website2_text_position,
+    ) = original_positions
+
     # Verify only text is enlarged
     driver.switch_to.window(driver.window_handles[0])
     new_image_position = web_page.get_element("yahoo-logo").location["x"]
     new_text_position = web_page.get_element("yahoo-login-button").location["x"]
     assert new_image_position == original_website1_image_position
     assert new_text_position < original_website1_text_position
-    
+
     # Zoom out to 90% using panel controls
     panel = PanelUi(driver)
     panel.open_panel_menu()
@@ -150,10 +159,22 @@ def zoom_text_only_functionality_test(driver, nav, web_page, original_positions)
         nav.element_attribute_contains("toolbar-zoom-level", "label", "90%")
 
     # Verify that only text is zoomed out
-    assert web_page.get_element("yahoo-logo").location["x"] == original_website1_image_position
-    assert web_page.get_element("yahoo-login-button").location["x"] > original_website1_text_position
+    assert (
+        web_page.get_element("yahoo-logo").location["x"]
+        == original_website1_image_position
+    )
+    assert (
+        web_page.get_element("yahoo-login-button").location["x"]
+        > original_website1_text_position
+    )
 
     # Verify that zoom level is default level for a different website and only text is enlarged
     driver.switch_to.window(driver.window_handles[1])
-    assert web_page.get_element("duckduckgo-logo").location["x"] == original_website2_image_position
-    assert web_page.get_element("duckduckgo-tagline").location["x"] < original_website2_text_position
+    assert (
+        web_page.get_element("duckduckgo-logo").location["x"]
+        == original_website2_image_position
+    )
+    assert (
+        web_page.get_element("duckduckgo-tagline").location["x"]
+        < original_website2_text_position
+    )


### PR DESCRIPTION
### Description
Test uses audio, it should have @pytest.mark.audio

#### Bugzilla bug ID
https://bugzilla.mozilla.org/show_bug.cgi?id=1934627

### Type of change
- [X] Minor change

### How does this resolve / make progress on that bug?

Please describe the progress or significance with respect to the bug listed above.

### Comments / Concerns
Test had been reported as "Untested" in TestRail.  Not sure if this is due to this missing mark, we'll see.
