### PR TITLE
increase test rerun delay

### DIFF
--- a/ci_pyproject.toml
+++ b/ci_pyproject.toml
@@ -16,7 +16,7 @@ markers = [
 testpaths = [
     "tests"
 ]
-addopts = "-vs --ci --run-headless --json-report --reruns 3 --reruns-delay 1 -m 'not incident and not unstable and not headed' --html=artifacts/report.html"
+addopts = "-vs --ci --run-headless --json-report --reruns 3 --reruns-delay 3 -m 'not incident and not unstable and not headed' --html=artifacts/report.html"
 
 [tool.ruff]
 target-version = "py310"

--- a/tests/address_bar_and_search/test_sap_google_adclick.py
+++ b/tests/address_bar_and_search/test_sap_google_adclick.py
@@ -14,7 +14,9 @@ def test_case():
     return "1365108"
 
 
-@pytest.mark.xfail(platform.system() == "Linux", reason="Telemetry testing unstable in Linux")
+@pytest.mark.xfail(
+    platform.system() == "Linux", reason="Telemetry testing unstable in Linux"
+)
 def test_sap_google_adclick(driver: Firefox):
     """
     C1365108, Test SAP Google adclick - URL bar - US


### PR DESCRIPTION
QoL - increase test rerun delay, apparently re-running after all other tests is not part of pytest-rerunfailures. We could force this by running `pytest --lf` but this would require significant refactor of the pipeline, so I'm attempting to fix this a little by adding longer delays to reruns.