### PR TITLE
Add code to wait for the test site to wake up

### DIFF
--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -27,9 +27,16 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     C1756722: Verify that the user can download mixed content via HTTPS
     """
 
-    web_page = GenericPage(driver, url=MIXED_CONTENT_DOWNLOAD_URL).open()
-    web_page.wait_for_page_to_load()
-    web_page.find_element(By.XPATH, "//button[@onclick='runtestSec()']").click()
+    web_page = GenericPage(driver, url=MIXED_CONTENT_DOWNLOAD_URL)
+
+    # Wait up to 30 seconds for test website to wake up and load the content
+    web_page.open()
+    with driver.context(driver.CONTEXT_CHROME):
+        WebDriverWait(driver, 30).until(EC.title_contains("Hello!"))
+
+    WebDriverWait(driver, 5).until(
+        EC.presence_of_element_located((By.XPATH, "//button[@onclick='runtestSec()']"))
+    ).click()
 
     with driver.context(driver.CONTEXT_CHROME):
         download_name = WebDriverWait(driver, 10).until(


### PR DESCRIPTION
### Description
This adds a check for the page title to appear in the Tab before attempting to interact with the page. This has to be done as it often occurs the the site is "asleep" and must be allowed time to wake up.

#### Bugzilla bug ID
https://bugzilla.mozilla.org/show_bug.cgi?id=1935227

### Type of change
- [X] Test stabilization

### How does this resolve / make progress on that bug?
Resolves the test stability issue
