### PR TITLE
Hani/Remove the unstable mark for blocking fingerprinters

### DIFF
--- a/tests/security_and_privacy/test_blocking_fingerprinters.py
+++ b/tests/security_and_privacy/test_blocking_fingerprinters.py
@@ -17,7 +17,6 @@ FINGERPRINTERS_URL = (
 )
 
 
-@pytest.mark.unstable
 def test_blocking_fingerprinter(driver: Firefox):
     """
     C446404: Blocking Fingerprinters


### PR DESCRIPTION
### Description

I forgot to remove the unstable mark after stabilizing test blocking fingerprinters.

### Bugzilla bug ID

**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1935374**

### Type of change

- [x] Other Changes (Stabilize tests)

### How does this resolve / make progress on that bug?

Completed.

### Screenshots / Explanations

N/A.

### Comments / Concerns

N/A.
