### PR TITLE
Hani/Stabilize test private browser doorhanger

### DIFF
--- a/tests/security_and_privacy/test_private_browser_password_doorhanger.py
+++ b/tests/security_and_privacy/test_private_browser_password_doorhanger.py
@@ -19,7 +19,6 @@ def add_prefs():
     return [("signon.rememberSignons", True)]
 
 
-@pytest.mark.unstable
 def test_no_password_doorhanger_private_browsing(driver: Firefox):
     """
     C101670: Ensure no save password doorhanger shows up and settings are correct


### PR DESCRIPTION
### Description

Stabilize test private browser doorhanger

### Bugzilla bug ID

**Link: [1935407](https://bugzilla.mozilla.org/show_bug.cgi?id=1935407)**

### Type of change

- [x] Other Changes (Stabilize test)

### How does this resolve / make progress on that bug?

Fixed.

### Screenshots / Explanations

N/A.

### Comments / Concerns

N/A.
