### PR TITLE
Hani/ remove unstable from test cross site tracking cookies blocked

### DIFF
--- a/tests/security_and_privacy/test_cross_site_tracking_cookies_blocked.py
+++ b/tests/security_and_privacy/test_cross_site_tracking_cookies_blocked.py
@@ -30,7 +30,6 @@ def add_prefs():
     ]
 
 
-@pytest.mark.unstable
 def test_cross_site_tracking_cookies_blocked(driver: Firefox):
     """
     C446402: Ensures the cross tracking cookies are displayed in the tracker panel


### PR DESCRIPTION
### Description

Removed unstable mark since the test passed locally on all 3 OS's.

### Bugzilla bug ID

**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1935646**

### Type of change

- [x] Other Changes (Remove unstable mark)

### How does this resolve / make progress on that bug?

Please describe the progress or significance with respect to the bug listed above.

### Screenshots / Explanations

N/A.

### Comments / Concerns

N/A