### PR TITLE
Anca / Test stabilization for open bookmarks from context menu (new and private window)

### DIFF
--- a/tests/bookmarks_and_history/test_open_bookmark_in_new_window_via_toolbar_context_menu.py
+++ b/tests/bookmarks_and_history/test_open_bookmark_in_new_window_via_toolbar_context_menu.py
@@ -30,21 +30,21 @@ def test_open_bookmark_in_new_window_via_toolbar_context_menu(driver: Firefox):
     panel = PanelUi(driver)
     tabs = TabBar(driver)
     context_menu = ContextMenu(driver)
-    page = GenericPage(driver, url=URL_TO_BOOKMARK).open()
+    page = GenericPage(driver, url=URL_TO_BOOKMARK)
 
     # Bookmark the test page via star button
+    page.open()
     nav.add_bookmark_via_star()
 
     # In a new tab, right-click the bookmarked page in the toolbar and select 'Open in New Window' from the context menu
     with driver.context(driver.CONTEXT_CHROME):
         tabs.new_tab_by_button()
-        bookmarked_page = panel.get_element(
-            "bookmark-by-title", labels=["Internet for people"]
-        )
-        context_menu.context_click(bookmarked_page)
+        panel.element_clickable("bookmark-by-title", labels=["Internet for people"])
+        panel.context_click("bookmark-by-title", labels=["Internet for people"])
         context_menu.click_and_hide_menu("context-menu-toolbar-open-in-new-window")
 
     # Verify that the test page is opened in a new normal window
+    tabs.wait_for_num_tabs(3)
     driver.switch_to.window(driver.window_handles[-1])
     assert not nav.is_private()
 

--- a/tests/bookmarks_and_history/test_open_bookmark_in_private_window_via_toolbar_context_menu.py
+++ b/tests/bookmarks_and_history/test_open_bookmark_in_private_window_via_toolbar_context_menu.py
@@ -30,24 +30,24 @@ def test_open_bookmark_in_new_private_window_via_toolbar_context_menu(driver: Fi
     panel = PanelUi(driver)
     tabs = TabBar(driver)
     context_menu = ContextMenu(driver)
-    page = GenericPage(driver, url=URL_TO_BOOKMARK).open()
+    page = GenericPage(driver, url=URL_TO_BOOKMARK)
 
     # Bookmark the test page via star button
+    page.open()
     nav.add_bookmark_via_star()
 
     # In a new tab, right-click the bookmarked page in the toolbar and select 'Open in New Private Window' from the
     # context menu
     with driver.context(driver.CONTEXT_CHROME):
         tabs.new_tab_by_button()
-        bookmarked_page = panel.get_element(
-            "bookmark-by-title", labels=["Internet for people"]
-        )
-        context_menu.context_click(bookmarked_page)
+        panel.element_clickable("bookmark-by-title", labels=["Internet for people"])
+        panel.context_click("bookmark-by-title", labels=["Internet for people"])
         context_menu.click_and_hide_menu(
             "context-menu-toolbar-open-in-new-private-window"
         )
 
     # Verify that the test page is opened in a new private window
+    tabs.wait_for_num_tabs(3)
     driver.switch_to.window(driver.window_handles[-1])
     assert nav.is_private()
 


### PR DESCRIPTION
### Description

- Attempt to stabilize test_open_bookmark_in_new_window_via_toolbar_context_menu and test_open_bookmark_in_new_private_window_via_toolbar_context_menu tests, which intermittently fail on macOS.

### Bugzilla bug ID

**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1936292**

### Type of change

- [x ] Other Changes (ensure element is clickable before context-click, add an explicit tab count check)

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
