### PR TITLE
remove unstable for tests where instability cannot be addressed atm

### DIFF
--- a/tests/meta/test_selectors.py
+++ b/tests/meta/test_selectors.py
@@ -6,7 +6,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object import PanelUi
 
 
-@pytest.mark.unstable
+@pytest.mark.skip(reason="This is a metatest.")
 def test_a_selector(driver: Firefox, version: str):
     logging.info(f"Fx version {version}")
     panel = PanelUi(driver)

--- a/tests/pocket/test_basic_de.py
+++ b/tests/pocket/test_basic_de.py
@@ -18,7 +18,7 @@ def add_prefs():
 
 
 # LOW PRIORITY
-@pytest.mark.unstable
+@pytest.mark.skip(reason="Pocket tests no longer belong to DTE.")
 @pytest.mark.locale_de
 def test_localized_pocket_layout_DE(driver: Firefox):
     """

--- a/tests/pocket/test_basic_fr.py
+++ b/tests/pocket/test_basic_fr.py
@@ -18,7 +18,7 @@ def add_prefs():
 
 
 # LOW PRIORITY
-@pytest.mark.unstable
+@pytest.mark.skip(reason="Pocket tests no longer belong to DTE.")
 @pytest.mark.locale_fr
 def test_localized_pocket_layout_FR(driver: Firefox):
     """

--- a/tests/pocket/test_basic_gb.py
+++ b/tests/pocket/test_basic_gb.py
@@ -18,7 +18,7 @@ def add_prefs():
 
 
 # LOW PRIORITY
-@pytest.mark.unstable
+@pytest.mark.skip(reason="Pocket tests no longer belong to DTE.")
 @pytest.mark.locale_gb
 def test_localized_pocket_layout_GB(driver: Firefox):
     """

--- a/tests/pocket/test_basic_us.py
+++ b/tests/pocket/test_basic_us.py
@@ -22,6 +22,7 @@ def add_prefs():
     ]
 
 
+@pytest.mark.skip(reason="Pocket tests no longer belong to DTE.")
 def test_new_tab_about_blank(driver: Firefox):
     """
     C408037: Test about:blank Pocket layout (US). First step only.
@@ -32,7 +33,7 @@ def test_new_tab_about_blank(driver: Firefox):
 
 
 # LOW PRIORITY
-@pytest.mark.unstable
+@pytest.mark.skip(reason="Pocket tests no longer belong to DTE.")
 def test_localized_pocket_layout_US(driver: Firefox, screenshot):
     """
     C408037: Test about:blank Pocket layout (US)

--- a/tests/sync_and_fxa/test_existing_fxa.py
+++ b/tests/sync_and_fxa/test_existing_fxa.py
@@ -26,7 +26,7 @@ def fxa_test_account():
 
 
 # Attempts to deflake this have not been entirely successful
-@pytest.mark.unstable
+@pytest.mark.skip("Revisit when PyFxA is updated")
 def test_sync_existing_fxa(
     driver: Firefox,
     fxa_test_account: Tuple[str, str],


### PR DESCRIPTION
### Description

QoL improvement where `unstable` is reserved for tests where:

* Test should not be run in CI (hang) / test likely to have negative effects
* Test should eventually work in our flow
* Test instability is not due to a failing dependency

These criteria eliminate the unstable mark in 6 test files.