### PR TITLE
Hani/ Remove unstable mark for test intervention card refresh firefox

### DIFF
--- a/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
+++ b/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
@@ -17,7 +17,6 @@ ALLOWED_RGB_AFTER_VALUES = set(
 )
 
 
-@pytest.mark.unstable
 def test_intervention_card_refresh(driver: Firefox):
     """
     C1365204.1: regular firefox, check the intervention card


### PR DESCRIPTION
### Description

Remove unstable mark for test intervention card refresh firefox.

### Bugzilla bug ID

**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1936810**

### Type of change

- [x] Remove unstable mark

### How does this resolve / make progress on that bug?

Fixed

### Screenshots / Explanations

N/A

### Comments / Concerns

N/A
