### PR TITLE
Anca/ Clean the open bookmark from context menu tests, no fails since stabilization

### DIFF
--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -152,7 +152,7 @@ class Navigation(BasePage):
         """Open search settings from the awesome bar"""
         self.click_on("search-settings")
         return self
-    
+
     def click_on_change_search_settings_button(self) -> BasePage:
         with self.driver.context(self.driver.CONTEXT_CHROME):
             self.search_bar = self.find_element(By.CLASS_NAME, "searchbar-textbox")

--- a/tests/address_bar_and_search/test_default_search_provider_change_awesome_bar.py
+++ b/tests/address_bar_and_search/test_default_search_provider_change_awesome_bar.py
@@ -4,6 +4,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object import Navigation
 from modules.page_object import AboutPrefs
 
+
 @pytest.fixture()
 def test_case():
     return "2860208"
@@ -25,9 +26,7 @@ def test_default_search_provider_change_awesome_bar(driver: Firefox):
     nav.open_awesome_bar_settings()
 
     # Check that the current URL is about:preferences#search
-    nav.expect_in_content(
-        lambda _: driver.current_url == "about:preferences#search"
-        )
+    nav.expect_in_content(lambda _: driver.current_url == "about:preferences#search")
 
     # Open a site, open search settings again and check if it's opened in a different tab
     nav.set_content_context()
@@ -37,9 +36,7 @@ def test_default_search_provider_change_awesome_bar(driver: Firefox):
     nav.set_content_context()
 
     driver.switch_to.window(driver.window_handles[1])
-    nav.expect_in_content(
-        lambda _: driver.current_url == "about:preferences#search"
-        )
+    nav.expect_in_content(lambda _: driver.current_url == "about:preferences#search")
     driver.switch_to.window(driver.window_handles[0])
     assert driver.current_url == "https://9gag.com/"
 
@@ -49,7 +46,5 @@ def test_default_search_provider_change_awesome_bar(driver: Firefox):
 
     # Open the search bar and type in a keyword and check if it's with the right provider
     nav.search(search_term)
-    nav.expect_in_content(
-        lambda _: driver.current_url == "about:preferences#search"
-        )
+    nav.expect_in_content(lambda _: driver.current_url == "about:preferences#search")
     driver.quit()

--- a/tests/bookmarks_and_history/test_open_bookmark_in_new_window_via_toolbar_context_menu.py
+++ b/tests/bookmarks_and_history/test_open_bookmark_in_new_window_via_toolbar_context_menu.py
@@ -1,6 +1,3 @@
-import platform
-from os import environ
-
 import pytest
 from selenium.webdriver import Firefox
 
@@ -16,10 +13,6 @@ def test_case():
 URL_TO_BOOKMARK = "https://www.mozilla.org/"
 
 
-# @pytest.mark.xfail(
-#     platform.system() == "Darwin" and environ.get("GITHUB_ACTIONS") == "true",
-#     reason="Test failing in Mac GHA",
-# )
 def test_open_bookmark_in_new_window_via_toolbar_context_menu(driver: Firefox):
     """
     C2084552: Verify that a bookmarked page can be open in a New Window from Toolbar context menu.

--- a/tests/bookmarks_and_history/test_open_bookmark_in_private_window_via_toolbar_context_menu.py
+++ b/tests/bookmarks_and_history/test_open_bookmark_in_private_window_via_toolbar_context_menu.py
@@ -1,6 +1,3 @@
-import platform
-from os import environ
-
 import pytest
 from selenium.webdriver import Firefox
 
@@ -16,10 +13,6 @@ def test_case():
 URL_TO_BOOKMARK = "https://www.mozilla.org/"
 
 
-# @pytest.mark.xfail(
-#     platform.system() == "Darwin" and environ.get("GITHUB_ACTIONS") == "true",
-#     reason="Test failing in Mac GHA",
-# )
 def test_open_bookmark_in_new_private_window_via_toolbar_context_menu(driver: Firefox):
     """
     C2084553: Verify that a bookmarked page can be open in a New Private Window from Toolbar context menu.


### PR DESCRIPTION
### Description
- After some code intervention, these two test seams to be stable (both passed in the last two beta runs). Therefore I removed the unnecessary comments and imports.

### Bugzilla bug ID

**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1936292**

### Type of change

- [x ] Other Changes (delete unnecessary comments and imports)

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
