### PR TITLE
Remove xfail mark in passing test.

### DIFF
--- a/tests/drag_and_drop/test_paste_image_text.py
+++ b/tests/drag_and_drop/test_paste_image_text.py
@@ -1,5 +1,3 @@
-import platform
-
 import pytest
 from pynput.keyboard import Controller
 from selenium.webdriver import Firefox
@@ -56,10 +54,8 @@ COPY_URL = "https://1stwebdesigner.com/image-file-types/"
 
 
 @pytest.mark.headed
-@pytest.mark.xfail(
-    platform.system() == "Windows", reason="A pref needs to be set only on windows."
-)
 # Ref to Windows bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1857764
+# which may or may not be relevant
 def test_paste_image_text(driver: Firefox, sys_platform, temp_selectors):
     """
     C464474: Verify that pasting images and text from html works


### PR DESCRIPTION
### Description
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Bugzilla bug ID
https://bugzilla.mozilla.org/show_bug.cgi?id=1938373 - Test stabilization - drag_and_drop/test_paste_image_text.py

#### Type of change
- [X] Remove unneeded xfail mark

#### How does this resolve / make progress on that bug?
Completes

#### Comments / Concerns
The test case had been marked with an xfail on Windows with reason that a pref had to be set and notes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1857764.  
In the test, I left:
    `"""Set prefs"""`
   ` return [("clipboard.imageAsFile.enabled", False)]`
even though it doesn't seem to matter if it's True or False (at least on Mac). Best I can tell, in Fx code, this pref is always false.