### PR TITLE
Anca/Adjust blocking social media trackers test

### DIFF
--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -152,7 +152,7 @@ class Navigation(BasePage):
         """Open search settings from the awesome bar"""
         self.click_on("search-settings")
         return self
-    
+
     def click_on_change_search_settings_button(self) -> BasePage:
         with self.driver.context(self.driver.CONTEXT_CHROME):
             self.search_bar = self.find_element(By.CLASS_NAME, "searchbar-textbox")

--- a/tests/address_bar_and_search/test_default_search_provider_change_awesome_bar.py
+++ b/tests/address_bar_and_search/test_default_search_provider_change_awesome_bar.py
@@ -4,6 +4,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object import Navigation
 from modules.page_object import AboutPrefs
 
+
 @pytest.fixture()
 def test_case():
     return "2860208"
@@ -25,9 +26,7 @@ def test_default_search_provider_change_awesome_bar(driver: Firefox):
     nav.open_awesome_bar_settings()
 
     # Check that the current URL is about:preferences#search
-    nav.expect_in_content(
-        lambda _: driver.current_url == "about:preferences#search"
-        )
+    nav.expect_in_content(lambda _: driver.current_url == "about:preferences#search")
 
     # Open a site, open search settings again and check if it's opened in a different tab
     nav.set_content_context()
@@ -37,9 +36,7 @@ def test_default_search_provider_change_awesome_bar(driver: Firefox):
     nav.set_content_context()
 
     driver.switch_to.window(driver.window_handles[1])
-    nav.expect_in_content(
-        lambda _: driver.current_url == "about:preferences#search"
-        )
+    nav.expect_in_content(lambda _: driver.current_url == "about:preferences#search")
     driver.switch_to.window(driver.window_handles[0])
     assert driver.current_url == "https://9gag.com/"
 
@@ -49,7 +46,5 @@ def test_default_search_provider_change_awesome_bar(driver: Firefox):
 
     # Open the search bar and type in a keyword and check if it's with the right provider
     nav.search(search_term)
-    nav.expect_in_content(
-        lambda _: driver.current_url == "about:preferences#search"
-        )
+    nav.expect_in_content(lambda _: driver.current_url == "about:preferences#search")
     driver.quit()

--- a/tests/security_and_privacy/test_blocking_social_media_trackers.py
+++ b/tests/security_and_privacy/test_blocking_social_media_trackers.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import pytest
 from selenium.webdriver import Firefox
 
@@ -11,8 +13,7 @@ def test_case():
     return "446406"
 
 
-SOCIAL_MEDIA_TRACKERS_URL = "https://panopticlick.eff.org/"
-# SOCIAL_MEDIA_TRACKERS_URL = "https://www.facebook.com/"  # alternative site
+SOCIAL_MEDIA_TRACKERS_URL = "https://senglehardt.com/test/trackingprotection/test_pages/social_tracking_protection.html"
 
 
 @pytest.fixture()
@@ -38,13 +39,14 @@ def test_blocking_social_media_trackers(driver: Firefox):
 
     about_prefs.get_element("cookies-checkbox")
     about_prefs.get_element("cookies-isolate-social-media-option").click()
+    sleep(3)
 
     driver.get(SOCIAL_MEDIA_TRACKERS_URL)
     nav.open_tracker_panel()
 
     driver.set_context(driver.CONTEXT_CHROME)
 
-    tracker_panel.get_element("social-media-tracker-content").click()
+    tracker_panel.element_clickable("social-media-tracker-content")
     social_media_subview_title = tracker_panel.get_element("social-media-subview")
     assert (
         social_media_subview_title.get_attribute("title")


### PR DESCRIPTION
### Description
- This test is blocked by bug [1866005](https://bugzilla.mozilla.org/show_bug.cgi?id=1866005), which is still open. However, the test xpassed each time, despite the Firefox feature being broken. This resulted in a false positive outcome. The settings were not correctly applied, so I resolved this by making sure  the settings are enabled and also, I've modified a condition in the tracking panel.  While the test appears intermittent, the consistent expected result should be xfail until a fix is landed.

### Bugzilla bug ID

- **Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1938374**

### Type of change

- [x ] Other Changes (ensure the correct settings are enabled)

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- Completed

### Comments / Concerns

- I've tried numerous alternatives to replace the hard wait, including different condition waits and attribute checks, but none worked consistently. I'm uncertain about the root cause of this behavior, so for now, I've used a hard wait as a workaround.
