### PR TITLE
always run ci headed tests

### DIFF
--- a/choose_ci_set.py
+++ b/choose_ci_set.py
@@ -5,6 +5,7 @@ from subprocess import CalledProcessError, check_output
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 CI_MARK = "@pytest.mark.ci"
+HEADED_MARK = "@pytest.mark.headed"
 
 
 def snakify(pascal: str) -> str:
@@ -107,11 +108,13 @@ if __name__ == "__main__":
                     lines = fh.readlines()
                     test_paths_and_contents[this_file] = "".join(lines)
 
-    ci_paths = [
-        localify(path)
-        for path, content in test_paths_and_contents.items()
-        if CI_MARK in content
-    ]
+    ci_paths = []
+    ci_headed_paths = []
+    for path, content in test_paths_and_contents.items():
+        if CI_MARK in content:
+            ci_paths.append(localify(path))
+            if HEADED_MARK in content:
+                ci_headed_paths.append(localify(path))
 
     changed_suite_conftests = [
         f for f in committed_files if re_obj.get("suite_conftest_re").match(f)
@@ -161,4 +164,5 @@ if __name__ == "__main__":
     if not run_list:
         print("\n".join(ci_paths))
     else:
+        run_list.extend(ci_headed_paths)
         print("\n".join(run_list))

--- a/choose_ci_set.py
+++ b/choose_ci_set.py
@@ -116,6 +116,9 @@ if __name__ == "__main__":
             if HEADED_MARK in content:
                 ci_headed_paths.append(localify(path))
 
+    # Dedupe just in case
+    ci_paths = list(set(ci_paths))
+
     changed_suite_conftests = [
         f for f in committed_files if re_obj.get("suite_conftest_re").match(f)
     ]
@@ -164,5 +167,8 @@ if __name__ == "__main__":
     if not run_list:
         print("\n".join(ci_paths))
     else:
+        run_list = list(set(run_list))
+        # Dedupe just in case
+
         run_list.extend(ci_headed_paths)
         print("\n".join(run_list))

--- a/tests/address_bar_and_search/test_glean_basic.py
+++ b/tests/address_bar_and_search/test_glean_basic.py
@@ -57,7 +57,7 @@ def glean_handler(rq: Request) -> Response:
     return Response("", status=200)
 
 
-@pytest.mark.ci
+@pytest.mark.skip
 def test_glean_ping(driver: Firefox, httpserver: HTTPServer):
     """C2234689: Test that Glean pings contain expected info"""
     global PINGS_WITH_ID


### PR DESCRIPTION
Reduced CI has a bug where if no headed tests are changed, CI always fails. This fixes that by always running headed tests with the ci mark.