### PR TITLE
key on candidate builds; mark xfails as known

### DIFF
--- a/collect_executables.py
+++ b/collect_executables.py
@@ -7,9 +7,9 @@ from os import environ
 from platform import uname
 from sys import argv, exit
 from time import sleep
-from bs4 import BeautifulSoup
 
 import requests
+from bs4 import BeautifulSoup
 
 GECKO_API_URL = "https://api.github.com/repos/mozilla/geckodriver/releases/latest"
 
@@ -29,6 +29,7 @@ def get_fx_platform():
             return "win64"
         return "win32"
 
+
 def get_fx_executable_extension():
     u = uname()
     if u.system == "Darwin":
@@ -37,6 +38,7 @@ def get_fx_executable_extension():
         return "xz"
     if u.system == "Windows":
         return "exe"
+
 
 def get_gd_platform():
     u = uname()
@@ -102,14 +104,24 @@ else:
     if not language:
         language = "en-US"
 
-    fx_download_dir_url = f"https://archive.mozilla.org/pub/firefox/releases/{latest_beta_ver}/{get_fx_platform()}/{language}/"
+    status = 200
+    build = 0
+    while status < 400:
+        build += 1
+        fx_download_dir_url = f"https://archive.mozilla.org/pub/firefox/candidates/{latest_beta_ver}-candidates/build{build}/{get_fx_platform()}/{language}/"
 
-    # Fetch the page
-    response = requests.get(fx_download_dir_url)
-    response.raise_for_status()
+        # Fetch the page
+        response = requests.get(fx_download_dir_url)
+        status = response.status_code
+        if status < 300:
+            response_text = response.text
+
+    # Correct build is the last one that didn't 404
+    build -= 1
+    fx_download_dir_url = f"https://archive.mozilla.org/pub/firefox/candidates/{latest_beta_ver}-candidates/build{build}/{get_fx_platform()}/{language}/"
 
     # Parse the HTML content
-    soup = BeautifulSoup(response.text, "html.parser")
+    soup = BeautifulSoup(response_text, "html.parser")
 
     executable_name = ""
     # Extract the text of each line

--- a/modules/testrail.py
+++ b/modules/testrail.py
@@ -364,7 +364,7 @@ class TestRail:
     ):
         """Given a project id, a run id, and a suite id, for each case given a status,
         update the test objects with the correct status code"""
-        status_key = {"passed": 1, "failed": 5, "skipped": 3}
+        status_key = {"passed": 1, "skipped": 3, "xfailed": 4, "failed": 5}
         if not test_case_ids:
             test_case_ids = [
                 test_case.get("id")

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -133,7 +133,7 @@ def merge_results(*result_sets) -> dict:
             if not output.get(key):
                 output[key] = results[key]
                 continue
-            if key in ["passed", "failed", "skipped"]:
+            if key in ["passed", "skipped", "xfailed", "failed"]:
                 for run_id in results.get(key):
                     if not output.get(key).get(run_id):
                         output[key][run_id] = results[key][run_id]
@@ -146,7 +146,7 @@ def mark_results(testrail_session: TestRail, test_results):
     """For each type of result, and per run, mark tests to status in batches"""
     logging.info(f"mark results: object\n{test_results}")
     existing_results = {}
-    for category in ["passed", "failed", "skipped"]:
+    for category in ["passed", "skipped", "xfailed", "failed"]:
         for run_id in test_results[category]:
             if not existing_results.get(run_id):
                 existing_results[run_id] = testrail_session.get_test_results(run_id)
@@ -277,13 +277,15 @@ def organize_entries(testrail_session: TestRail, expected_plan: dict, suite_info
     # Gather the test results by category of result
     passkey = {
         "passed": ["passed", "xpassed", "warnings"],
-        "failed": ["failed", "xfailed", "error"],
+        "failed": ["failed", "error"],
+        "xfailed": ["xfailed"],
         "skipped": ["skipped", "deselected"],
     }
     test_results = {
         "project_id": TESTRAIL_FX_DESK_PRJ,
         "passed": {},
         "failed": {},
+        "xfailed": {},
         "skipped": {},
     }
 


### PR DESCRIPTION
We need to key on the build candidates, not beta releases because beta 1 is always manually released. (This also gives us early warning on failures).

We also need to mark xfails as known failures rather than new failures.
