### PR TITLE
always run all ci marked tests, to avoid unnecessary ci failures

### DIFF
--- a/choose_ci_set.py
+++ b/choose_ci_set.py
@@ -1,7 +1,7 @@
 import os
 import re
 import sys
-from subprocess import CalledProcessError, check_output
+from subprocess import check_output
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 CI_MARK = "@pytest.mark.ci"
@@ -114,12 +114,9 @@ if __name__ == "__main__":
                     test_paths_and_contents[this_file] = "".join(lines)
 
     ci_paths = []
-    ci_headed_paths = []
     for path, content in test_paths_and_contents.items():
         if CI_MARK in content:
             ci_paths.append(localify(path))
-            if HEADED_MARK in content:
-                ci_headed_paths.append(localify(path))
 
     # Dedupe just in case
     ci_paths = list(set(ci_paths))
@@ -172,8 +169,8 @@ if __name__ == "__main__":
     if not run_list:
         print("\n".join(ci_paths))
     else:
-        run_list = list(set(run_list))
-        # Dedupe just in case
+        run_list.extend(ci_paths)
 
-        run_list.extend(ci_headed_paths)
+        # Dedupe just in case
+        run_list = list(set(run_list))
         print("\n".join(run_list))

--- a/tests/bookmarks_and_history/test_delete_bookmarks_from_toolbar.py
+++ b/tests/bookmarks_and_history/test_delete_bookmarks_from_toolbar.py
@@ -14,7 +14,6 @@ def test_case():
 URL_TO_BOOKMARK = "https://www.mozilla.org/"
 
 
-@pytest.mark.ci
 @pytest.mark.headed
 def test_delete_bookmarks_from_toolbar(driver: Firefox):
     """

--- a/tests/form_autofill/test_telephone_autofill_attribute.py
+++ b/tests/form_autofill/test_telephone_autofill_attribute.py
@@ -13,16 +13,14 @@ def test_case():
     return "122361"
 
 
-countries = ["CA", "US"]
-
-
 @pytest.mark.ci
-@pytest.mark.parametrize("country_code", countries)
-def test_telephone_attribute_autofill(driver: Firefox, country_code: str):
+def test_telephone_attribute_autofill(driver: Firefox):
     """
     C122361, ensures that telephone numbers are autofilled
     """
     # instantiate objects
+    # removed CA support to make test cycle faster
+    country_code = "US"
     address_fill_obj = AddressFill(driver).open()
     autofill_popup_obj = AutofillPopup(driver)
     util = Utilities()

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -52,6 +52,7 @@ def test_open_image_in_new_tab(driver: Firefox):
     wiki_image_page.verify_opened_image_url("wikimedia", LOADED_IMAGE_URL)
 
 
+@pytest.mark.ci
 @pytest.mark.headed
 def test_save_image_as(driver: Firefox, sys_platform, delete_files):
     """


### PR DESCRIPTION
The CI subsuite isn't that long, we should just always run it, no matter what else is on the docket--this will prevent CI failures when there are changes to tests that don't get run in CI.