### PR TITLE
Inital implementation of search mode selection test

### DIFF
--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -21,6 +21,14 @@ class Navigation(BasePage):
         "History": "^",
         "Actions": ">",
     }
+    VALID_SEARCH_MODES = {
+        "Google",
+        "eBay",
+        "Amazon.com",
+        "Bing",
+        "DuckDuckGo",
+        "Wikipedia (en)",
+    }
 
     def expect_in_content(self, condition) -> BasePage:
         """Like BasePage.expect, but guarantee we're looking at CONTEXT_CONTENT"""
@@ -169,6 +177,44 @@ class Navigation(BasePage):
         self.set_awesome_bar()
         self.awesome_bar.click()
         return self
+
+    def click_search_mode_switcher(self) -> BasePage:
+        """
+        click search mode switcher
+        """
+        with self.driver.context(self.driver.CONTEXT_CHROME):
+            self.search_mode_switcher = self.get_element("search_mode_switcher")
+            self.search_mode_switcher.click()
+        return self
+
+    def set_search_mode(self, search_mode: str) -> BasePage:
+        """
+        set new search location if search_mode in VALID_SEARCH_MODES
+
+        Parameter:
+            search_mode (str): search mode to be selected
+
+        Raises:
+            StopIteration: if a valid search mode is not found in the list of valid elements.
+        """
+        # check if search_mode is valid, otherwise raise error.
+        if search_mode not in self.VALID_SEARCH_MODES:
+            raise ValueError("search location is not valid.")
+        # switch to chrome context
+        with self.driver.context(self.driver.CONTEXT_CHROME):
+            # get list of all valid search modes and filter by label
+            try:
+                element = next(
+                    filter(
+                        lambda el: el.get_attribute("label") == search_mode,
+                        self.get_elements(f"search_modes"),
+                    )
+                )
+                element.click()
+            except StopIteration:
+                logging.warning("search option not part of the valid search modes")
+            finally:
+                return self
 
     def get_download_button(self) -> WebElement:
         """

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -323,6 +323,16 @@
         "strategy": "id",
         "groups": []
     },
+    "search_mode_switcher": {
+        "selectorData": "urlbar-searchmode-switcher",
+        "strategy": "id",
+        "groups": []
+    },
+    "search_modes": {
+        "selectorData": "toolbarbutton[class='subviewbutton subviewbutton-iconic']",
+        "strategy": "css",
+        "groups": []
+    },
 
     "bookmarks-type-dropdown": {
         "selectorData": "editBMPanel_folderMenuList",

--- a/tests/address_bar_and_search/test_search_engine_selector.py
+++ b/tests/address_bar_and_search/test_search_engine_selector.py
@@ -1,0 +1,34 @@
+from time import sleep
+
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.support import expected_conditions as EC
+
+from modules.browser_object import Navigation
+
+
+@pytest.fixture()
+def test_case():
+    return "2567890"
+
+
+@pytest.mark.parametrize(
+    "search_mode",
+    ["Google", "eBay", "Bing", "DuckDuckGo", "Wikipedia (en)", "Amazon.com"],
+)
+def test_search_engine_selector_and_validator(driver: Firefox, search_mode: str):
+    """
+    Select Appropriate search engine and go to site, asserting that the correct search engine was used.
+
+    Parameters:
+    driver (FireFox): webdriver used for communicating with the browser.
+    search_mode (str): search parameter selected from the awesome bar.
+    """
+    nav = Navigation(driver)
+    url_element_search_mode = search_mode.split()[0].lower()
+    nav.click_search_mode_switcher()
+    nav.set_search_mode(search_mode)
+    nav.search("soccer")
+    nav.expect_in_content(EC.url_contains(url_element_search_mode))
+    assert url_element_search_mode in driver.current_url
+    nav.clear_awesome_bar()


### PR DESCRIPTION
### Description
* Test available search modes and validate searches with valid modes.
* Uses parameterization to test all available default search modes. 

### Bugzilla bug ID: 2567890

**Testrail:**
**Link:**

### Type of change

Please delete options that are not relevant.

- [x] New Test
- [ ] New POM
- [x] Other Changes (Please specify)

### How does this resolve/make progress on that bug?
 * Implements required [UAT](https://docs.google.com/document/d/1_uhLyTmUrPrldKUigGR0zQetk4PxQZQD5i5sCBlhSyE/edit?tab=t.0).

### Screenshots / Explanations

### Comments / Concerns
* Made changes to the`Navigation` POM. Specifically, methods were added to `click` the search mode button and `switch` between different search modes.
* Added an additional selector to the `navigation.components.json` file to locate the search mode in the address bar.