### PR TITLE
Anca/ CM - l10n structure

### DIFF
--- a/tests/form_autofill/l10n_CM/CA/conftest.py
+++ b/tests/form_autofill/l10n_CM/CA/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture()
+def set_prefs():
+    return [("browser.search.region", "CA")]

--- a/tests/form_autofill/l10n_CM/DE/conftest.py
+++ b/tests/form_autofill/l10n_CM/DE/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture()
+def set_prefs():
+    return [("browser.search.region", "DE")]

--- a/tests/form_autofill/l10n_CM/FR/conftest.py
+++ b/tests/form_autofill/l10n_CM/FR/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture()
+def set_prefs():
+    return [("browser.search.region", "FR")]

--- a/tests/form_autofill/l10n_CM/US/conftest.py
+++ b/tests/form_autofill/l10n_CM/US/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture()
+def set_prefs():
+    return [("browser.search.region", "US")]

--- a/tests/form_autofill/l10n_CM/conftest.py
+++ b/tests/form_autofill/l10n_CM/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture()
+def set_prefs():
+    """Set prefs"""
+    return []


### PR DESCRIPTION
### Description

- Create a localization (l10n) subfolder under form-autofill, containing directories for 4 different regions (CA, DE, FR and US).

### Bugzilla bug ID

**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943153**

### Type of change

- [x] Other Changes (Add a l10-CM subfolder)

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A
### Comments / Concerns

- N/A