### PR TITLE
Hani/US demo - Verify the Capture Doorhanger is displayed after entering valid Address data

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1346,6 +1346,13 @@ Description: The password update doorhanger
 Location: In the Navigation bar, next to the url input field, after the key icon was pressed
 Path to .json: modules/data/autofill_popup.components.json
 ```
+```
+Selector Name: address-save-doorhanger
+Selector Data: "address-save-update-notification-content"
+Description: Save address doorhanger
+Location: Address bar
+Path to .json: modules/data/autofill_popup.components.json
+```
 #### context_menu
 ```
 Selector Name: context-menu-search-selected-text

--- a/l10n_CM/US/test_us_demo_address_doorhanger_displayed_after_entering_valid_address.py
+++ b/l10n_CM/US/test_us_demo_address_doorhanger_displayed_after_entering_valid_address.py
@@ -11,11 +11,10 @@ def test_case():
     return "2886581"
 
 
-country = ["US"]
+country_code = "US"
 
 
-@pytest.mark.parametrize("country_code", country)
-def test_us_demo_address_doorhanger_displayed_after_entering_valid_address(driver: Firefox, country_code: str):
+def test_us_demo_address_doorhanger_displayed_after_entering_valid_address(driver: Firefox):
     """
     C2886581, Verify the Capture Doorhanger is displayed after entering valid Address data
     """

--- a/l10n_CM/US/test_us_demo_address_doorhanger_displayed_after_entering_valid_address.py
+++ b/l10n_CM/US/test_us_demo_address_doorhanger_displayed_after_entering_valid_address.py
@@ -1,0 +1,32 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import AddressFill
+from modules.util import Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2886581"
+
+
+country = ["US"]
+
+
+@pytest.mark.parametrize("country_code", country)
+def test_us_demo_address_doorhanger_displayed_after_entering_valid_address(driver: Firefox, country_code: str):
+    """
+    C2886581, Verify the Capture Doorhanger is displayed after entering valid Address data
+    """
+    # instantiate objects
+    address_autofill = AddressFill(driver).open()
+    address_autofill_popup = AutofillPopup(driver)
+    util = Utilities()
+
+    # create fake data and fill it in
+    address_autofill_data = util.fake_autofill_data(country_code)
+    address_autofill.save_information_basic(address_autofill_data)
+
+    # check "Save Address?" doorhanger appears in the Address bar
+    address_autofill_popup.wait.until(lambda _: address_autofill_popup.element_visible("address-save-doorhanger"))

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -77,6 +77,12 @@
         "selectorData": "//*[contains(@class, 'popup-notification-description') and @popupid='password']",
         "strategy": "xpath",
         "groups": []
+    },
+
+    "address-save-doorhanger": {
+        "selectorData": "address-save-update-notification-content",
+        "strategy": "class",
+        "groups": []
     }
 }
 


### PR DESCRIPTION
### Description

Verify the Capture Doorhanger is displayed after entering valid Address data.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2886581**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943163**

### Type of change

Please delete options that are not relevant.

- [x] New Test

### How does this resolve / make progress on that bug?

Completed

### Screenshots / Explanations

N/A

### Comments / Concerns

N/A
