### PR TITLE
remove xfail mark in l10n tests

### DIFF
--- a/l10n_CM/CA/test_ca_demo_cc_add_new_credit_card.py
+++ b/l10n_CM/CA/test_ca_demo_cc_add_new_credit_card.py
@@ -1,5 +1,4 @@
 import json
-import platform
 
 import pytest
 from selenium.webdriver import Firefox
@@ -14,7 +13,6 @@ def test_case():
     return "2886595"
 
 
-@pytest.mark.xfail(platform.system() == "Linux", reason="Autofill Linux instability")
 def test_create_new_cc_profile(driver: Firefox):
     """
     C122389 - tests you can create and save a new Credit Card profile

--- a/l10n_CM/DE/test_de_demo_cc_add_new_credit_card.py
+++ b/l10n_CM/DE/test_de_demo_cc_add_new_credit_card.py
@@ -1,5 +1,4 @@
 import json
-import platform
 
 import pytest
 from selenium.webdriver import Firefox
@@ -14,7 +13,6 @@ def test_case():
     return "2886595"
 
 
-@pytest.mark.xfail(platform.system() == "Linux", reason="Autofill Linux instability")
 def test_create_new_cc_profile(driver: Firefox):
     """
     C122389, tests you can create and save a new Credit Card profile

--- a/l10n_CM/FR/test_fr_demo_cc_add_new_credit_card.py
+++ b/l10n_CM/FR/test_fr_demo_cc_add_new_credit_card.py
@@ -1,5 +1,4 @@
 import json
-import platform
 
 import pytest
 from selenium.webdriver import Firefox
@@ -14,7 +13,6 @@ def test_case():
     return "2886595"
 
 
-@pytest.mark.xfail(platform.system() == "Linux", reason="Autofill Linux instability")
 def test_create_new_cc_profile(driver: Firefox):
     """
     C122389, tests you can create and save a new Credit Card profile

--- a/l10n_CM/US/test_us_demo_cc_add_new_credit_card.py
+++ b/l10n_CM/US/test_us_demo_cc_add_new_credit_card.py
@@ -1,5 +1,4 @@
 import json
-import platform
 
 import pytest
 from selenium.webdriver import Firefox
@@ -13,7 +12,6 @@ def test_case():
     return "2886595"
 
 
-@pytest.mark.xfail(platform.system() == "Linux", reason="Autofill Linux instability")
 def test_create_new_cc_profile(driver: Firefox):
     """
     C2886595 - tests you can create and save a new Credit Card profile


### PR DESCRIPTION
### Description
Since Ben fixed the Linux instability in CI form auto-fill tests, these marks can be removed from the test that got created in l10n_CM land.

#### Bugzilla bug ID
none

#### Type of change
- [X] Other Changes (remove xfail mark)



