### PR TITLE
Adds back Hani's test that got stomped by PR #428

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1346,6 +1346,13 @@ Description: The password update doorhanger
 Location: In the Navigation bar, next to the url input field, after the key icon was pressed
 Path to .json: modules/data/autofill_popup.components.json
 ```
+```
+Selector Name: address-save-doorhanger
+Selector Data: "address-save-update-notification-content"
+Description: Save address doorhanger
+Location: Address bar
+Path to .json: modules/data/autofill_popup.components.json
+```
 #### context_menu
 ```
 Selector Name: context-menu-search-selected-text

--- a/l10n_CM/Unified/test_demo_address_doorhanger_displayed_after_entering_valid_address.py
+++ b/l10n_CM/Unified/test_demo_address_doorhanger_displayed_after_entering_valid_address.py
@@ -1,0 +1,42 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object import AboutConfig
+from modules.page_object_autofill import AddressFill
+from modules.util import Utilities
+
+params = [("US", "US"), ("CA", "CA")]
+
+
+@pytest.fixture()
+def test_case():
+    return "2886581"
+
+
+@pytest.mark.parametrize("region, locale", params)
+def test_address_doorhanger_displayed_after_entering_valid_address(
+    driver: Firefox, region: str, locale: str
+):
+    """
+    C2886581, Verify the Capture Doorhanger is displayed after entering valid Address data
+    """
+
+    # Instantiate objects
+    address_autofill = AddressFill(driver)
+    address_autofill_popup = AutofillPopup(driver)
+    util = Utilities()
+    about_config = AboutConfig(driver)
+
+    # Change pref value of region
+    about_config.change_config_value("browser.search.region", region)
+
+    # Create fake data and fill it in
+    address_autofill.open()
+    address_autofill_data = util.fake_autofill_data(locale)
+    address_autofill.save_information_basic(address_autofill_data)
+
+    # Check "Save Address?" doorhanger appears in the Address bar
+    address_autofill_popup.wait.until(
+        lambda _: address_autofill_popup.element_visible("address-save-doorhanger")
+    )

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -77,6 +77,12 @@
         "selectorData": "//*[contains(@class, 'popup-notification-description') and @popupid='password']",
         "strategy": "xpath",
         "groups": []
+    },
+
+    "address-save-doorhanger": {
+        "selectorData": "address-save-update-notification-content",
+        "strategy": "class",
+        "groups": []
     }
 }
 


### PR DESCRIPTION
#### Description
Re-add test lost due to my PR 428. That PR removed the directory that this test was living.

#### Bugzilla bug ID
none

#### Type of change
- [X] New Test

#### How does this resolve / make progress on that bug?
Completes
