### PR TITLE
Anca / Extend Faker support for DE and FR (demo page only)

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_doorhanger_shown_on_valid_address_submission.py
+++ b/l10n_CM/Unified/test_demo_ad_doorhanger_shown_on_valid_address_submission.py
@@ -6,7 +6,7 @@ from modules.page_object import AboutConfig
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
-params = [("US", "US"), ("CA", "CA")]
+regions = ["US", "CA", "DE", "FR"]
 
 
 @pytest.fixture()
@@ -14,9 +14,9 @@ def test_case():
     return "2886581"
 
 
-@pytest.mark.parametrize("region, locale", params)
+@pytest.mark.parametrize("region", regions)
 def test_address_doorhanger_displayed_after_entering_valid_address(
-    driver: Firefox, region: str, locale: str
+    driver: Firefox, region: str
 ):
     """
     C2886581 - Verify the Capture Doorhanger is displayed after entering valid Address data
@@ -33,7 +33,7 @@ def test_address_doorhanger_displayed_after_entering_valid_address(
 
     # Create fake data and fill it in
     address_autofill.open()
-    address_autofill_data = util.fake_autofill_data(locale)
+    address_autofill_data = util.fake_autofill_data(region)
     address_autofill.save_information_basic(address_autofill_data)
 
     # Check "Save Address?" doorhanger appears in the Address bar

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from time import sleep
 from typing import List


### PR DESCRIPTION
### Description

- Adjust Faker for additional regions (DE and FR) when populating sample data in the demo page fields.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2886581**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943163**

### Type of change

- [ x] Other Changes 
   -  Make Faker work on additional regions (DE and FR) on demo page
   -  Update test 1943163 to cover DE and FR 

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- Note that the work on Faker is not yet complete. Directly populating the fields in Saved Addresses (about:preferences) is not working.  Further adjustments and refinements are needed, the fields dynamically adjust based on the selected country, leading to variations in both the number and order of fields across regions. Additionally, I encountered some unexpected alerts. For now, Faker is functioning on the demo page, and the correct data for each region is successfully saved in Saved Addresses through the capture doorhanger.
