### PR TITLE
Philimon[l10n-CM] Modularize l10n test suite

### DIFF
--- a/l10n_CM/Unified/conftest.py
+++ b/l10n_CM/Unified/conftest.py
@@ -1,12 +1,26 @@
+import os
+
 import pytest
 
 
 @pytest.fixture()
-def set_prefs():
-    """Set prefs"""
+def region():
+    return os.environ.get("STARFOX_REGION", "US")
+
+
+@pytest.fixture()
+def add_prefs(region: str):
     return [
         ("extensions.formautofill.creditCards.reauth.optout", False),
         ("extensions.formautofill.reauth.enabled", False),
         ("browser.aboutConfig.showWarning", False),
-        ("browser.search.region", "US"),
+        ("browser.search.region", region),
     ]
+
+
+@pytest.fixture()
+def set_prefs(add_prefs: dict):
+    """Set prefs"""
+    prefs = []
+    prefs.extend(add_prefs)
+    return prefs

--- a/l10n_CM/Unified/test_demo_ad_doorhanger_shown_on_valid_address_submission.py
+++ b/l10n_CM/Unified/test_demo_ad_doorhanger_shown_on_valid_address_submission.py
@@ -6,17 +6,14 @@ from modules.page_object import AboutConfig
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
-params = [("US", "US"), ("CA", "CA")]
-
 
 @pytest.fixture()
 def test_case():
     return "2886581"
 
 
-@pytest.mark.parametrize("region, locale", params)
 def test_address_doorhanger_displayed_after_entering_valid_address(
-    driver: Firefox, region: str, locale: str
+    driver: Firefox, region: str
 ):
     """
     C2886581 - Verify the Capture Doorhanger is displayed after entering valid Address data
@@ -33,7 +30,7 @@ def test_address_doorhanger_displayed_after_entering_valid_address(
 
     # Create fake data and fill it in
     address_autofill.open()
-    address_autofill_data = util.fake_autofill_data(locale)
+    address_autofill_data = util.fake_autofill_data(region)
     address_autofill.save_information_basic(address_autofill_data)
 
     # Check "Save Address?" doorhanger appears in the Address bar

--- a/l10n_CM/Unified/test_demo_cc_add_new_credit_card.py
+++ b/l10n_CM/Unified/test_demo_cc_add_new_credit_card.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 from selenium.webdriver import Firefox
@@ -6,15 +7,12 @@ from selenium.webdriver import Firefox
 from modules.page_object import AboutConfig, AboutPrefs
 from modules.util import BrowserActions, Utilities
 
-regions = ["US", "CA", "DE", "FR"]
-
 
 @pytest.fixture()
 def test_case():
     return "2886595"
 
 
-@pytest.mark.parametrize("region", regions)
 def test_create_new_cc_profile(driver: Firefox, region: str):
     """
     C2886595 - Tests you can create and save a new Credit Card profile

--- a/l10n_CM/Unified/test_demo_cc_add_new_credit_card.py
+++ b/l10n_CM/Unified/test_demo_cc_add_new_credit_card.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import pytest
 from selenium.webdriver import Firefox

--- a/l10n_CM/Unified/test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py
+++ b/l10n_CM/Unified/test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py
@@ -6,15 +6,12 @@ from modules.page_object import AboutConfig
 from modules.page_object_autofill import CreditCardFill
 from modules.util import Utilities
 
-regions = ["US", "CA", "DE", "FR"]
-
 
 @pytest.fixture()
 def test_case():
     return "2889441"
 
 
-@pytest.mark.parametrize("region", regions)
 def test_cc_check_door_hanger_is_displayed(driver: Firefox, region: str):
     """
     C2889441 - Ensures that the door hanger is displayed after filling credit card info

--- a/l10n_CM/region/CA.json
+++ b/l10n_CM/region/CA.json
@@ -1,0 +1,8 @@
+{
+    "region": "CA",
+    "tests": [
+        "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
+        "test_demo_cc_add_new_credit_card.py",
+        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py"
+    ]
+}

--- a/l10n_CM/region/DE.json
+++ b/l10n_CM/region/DE.json
@@ -1,0 +1,8 @@
+{
+    "region": "DE",
+    "tests": [
+        "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
+        "test_demo_cc_add_new_credit_card.py",
+        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py"
+    ]
+}

--- a/l10n_CM/region/FR.json
+++ b/l10n_CM/region/FR.json
@@ -1,0 +1,8 @@
+{
+    "region": "FR",
+    "tests": [
+        "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
+        "test_demo_cc_add_new_credit_card.py",
+        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py"
+    ]
+}

--- a/l10n_CM/region/US.json
+++ b/l10n_CM/region/US.json
@@ -1,0 +1,8 @@
+{
+    "region": "US",
+    "tests": [
+        "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
+        "test_demo_cc_add_new_credit_card.py",
+        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py"
+    ]
+}

--- a/l10n_CM/run_l10n.py
+++ b/l10n_CM/run_l10n.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import sys
+from json import load
+
+current_dir = os.path.dirname(__file__)
+
+
+def get_region_tests(test_region: str) -> list[str]:
+    path_to_region = current_dir + "/region/"
+    with open(path_to_region + test_region + ".json", "r") as fp:
+        region_data = load(fp)
+        raw_tests = region_data.get("tests", [])
+        return (
+            list(map(lambda test: current_dir + "/Unified/" + test, raw_tests))
+            if len(raw_tests) > 0
+            else raw_tests
+        )
+
+
+if __name__ == "__main__":
+    regions = sys.argv[1:]
+    valid_region = {"US", "CA", "DE", "FR"}
+    for region in regions:
+        if region not in valid_region:
+            raise ValueError("Invalid Region.")
+        tests = get_region_tests(region)
+        try:
+            os.environ["STARFOX_REGION"] = region
+            subprocess.run(["pytest", *tests], check=True, text=True)
+        except subprocess.CalledProcessError as e:
+            print(f"test run failed with {e} error")


### PR DESCRIPTION
### Description

In order to avoid copy/pasting code and make the system as modular as possible, it is recommended that we create three folders under the L10n_CM folder in STARfox:

`unified`: which holds all the tests
`region`: which holds config files for the locales being tested
`constants`: which holds files that indicate selectors, text, and other test data that will not change

### Bugzilla bug ID: [1944613](https://bugzilla.mozilla.org/show_bug.cgi?id=1944613)

**Testrail:**
**Link:** [1Pager](https://docs.google.com/document/d/1-s-cDpXCZFYBJ9c0iwRgca3gM4nPhTL9gxTVd5Y_oto/edit?tab=t.0)

### Type of change

Please delete options that are not relevant.

- [x] Other Changes (Please specify)

### How does this resolve / make progress on that bug?
* This initially allows us to section the test suits more modularly. More work can be done though.
* Still need to find a way to allow reporting to and from test rails from the python script.
### Comments / Concerns
* Edited the tests in unified to allow them to run through `run_l10n.py`.
* User runs `python run_l10n.py US` to run all the US locale tests.
* Will return a `ValueError` if local is not listed in the `valid_locales` set. (could be moved from run_l10n to one of the constant file).
