### PR TITLE
remove CA parametrization on autofill

### DIFF
--- a/tests/form_autofill/test_address_autofill_attribute.py
+++ b/tests/form_autofill/test_address_autofill_attribute.py
@@ -5,17 +5,15 @@ from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
+COUNTRY_CODE = "US"
+
 
 @pytest.fixture()
 def test_case():
     return "122359"
 
 
-countries = ["CA", "US"]
-
-
-@pytest.mark.parametrize("country_code", countries)
-def test_address_attribute_selection(driver: Firefox, country_code: str):
+def test_address_attribute_selection(driver: Firefox):
     """
     C122359 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
     item in the dropdown ensures that the actual value matches the expected value.
@@ -26,7 +24,7 @@ def test_address_attribute_selection(driver: Firefox, country_code: str):
     util = Utilities()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(country_code)
+    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
     address_form_fields.save_information_basic(autofill_sample_data)
     autofill_popup_panel.click_doorhanger_button("save")
 

--- a/tests/form_autofill/test_clear_form.py
+++ b/tests/form_autofill/test_clear_form.py
@@ -5,17 +5,15 @@ from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
+COUNTRY_CODE = "US"
+
 
 @pytest.fixture()
 def test_case():
     return "122574"
 
 
-countries = ["CA", "US"]
-
-
-@pytest.mark.parametrize("country_code", countries)
-def test_clear_form(driver: Firefox, country_code: str):
+def test_clear_form(driver: Firefox):
     """
     C122574, test clear autofill form
     """
@@ -25,7 +23,7 @@ def test_clear_form(driver: Firefox, country_code: str):
     util = Utilities()
 
     # create fake data, fill it in and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(country_code)
+    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
     address_autofill.save_information_basic(autofill_sample_data)
     address_autofill_popup.click_doorhanger_button("save")
 

--- a/tests/form_autofill/test_create_profile_autofill.py
+++ b/tests/form_autofill/test_create_profile_autofill.py
@@ -4,17 +4,15 @@ from selenium.webdriver import Firefox
 from modules.page_object import AboutPrefs
 from modules.util import BrowserActions, Utilities
 
+COUNTRY_CODE = "US"
+
 
 @pytest.fixture()
 def test_case():
     return "122348"
 
 
-countries = ["CA", "US"]
-
-
-@pytest.mark.parametrize("country_code", countries)
-def test_create_address_profile(driver: Firefox, country_code: str):
+def test_create_address_profile(driver: Firefox):
     """
     C122348, creating an address profile
     """
@@ -25,7 +23,7 @@ def test_create_address_profile(driver: Firefox, country_code: str):
     about_prefs_obj.open()
 
     # create sample data
-    autofill_sample_data = util.fake_autofill_data(country_code)
+    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
     iframe_address_popup = about_prefs_obj.press_button_get_popup_dialog_iframe(
         "Saved addresses"
     )

--- a/tests/form_autofill/test_enable_disable_autofill.py
+++ b/tests/form_autofill/test_enable_disable_autofill.py
@@ -7,17 +7,15 @@ from modules.page_object import AboutPrefs
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
+COUNTRY_CODE = "US"
+
 
 @pytest.fixture()
 def test_case():
     return "122347"
 
 
-countries = ["CA", "US"]
-
-
-@pytest.mark.parametrize("country_code", countries)
-def test_enable_disable_autofill(driver: Firefox, country_code: str):
+def test_enable_disable_autofill(driver: Firefox):
     """
     C122347, tests that after filling autofill and disabling it in settings that
     the autofill popups do not appear.
@@ -29,7 +27,7 @@ def test_enable_disable_autofill(driver: Firefox, country_code: str):
     util = Utilities()
 
     # create fake data, fill it in and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(country_code)
+    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
     af.save_information_basic(autofill_sample_data)
     afp.click_doorhanger_button("save")
     about_prefs = AboutPrefs(driver, category="privacy").open()

--- a/tests/form_autofill/test_name_autofill_attribute.py
+++ b/tests/form_autofill/test_name_autofill_attribute.py
@@ -5,17 +5,15 @@ from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
+COUNTRY_CODE = "US"
+
 
 @pytest.fixture()
 def test_case():
     return "122356"
 
 
-countries = ["CA", "US"]
-
-
-@pytest.mark.parametrize("country_code", countries)
-def test_name_attribute_selection(driver: Firefox, country_code: str):
+def test_name_attribute_selection(driver: Firefox):
     """
     C122356 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
     item in the dropdown ensures that the actual value matches the expected value.
@@ -26,7 +24,7 @@ def test_name_attribute_selection(driver: Firefox, country_code: str):
     util = Utilities()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(country_code)
+    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
     address_form_fields.save_information_basic(autofill_sample_data)
     autofill_popup_panel.click_doorhanger_button("save")
 

--- a/tests/form_autofill/test_private_mode_info_not_saved.py
+++ b/tests/form_autofill/test_private_mode_info_not_saved.py
@@ -6,6 +6,8 @@ from modules.page_object import AboutPrefs
 from modules.page_object_autofill import AddressFill
 from modules.util import BrowserActions, Utilities
 
+COUNTRY_CODE = "US"
+
 
 @pytest.fixture()
 def test_case():
@@ -22,11 +24,7 @@ def set_prefs():
     ]
 
 
-countries = ["CA", "US"]
-
-
-@pytest.mark.parametrize("country_code", countries)
-def test_private_mode_info_not_saved(driver: Firefox, country_code: str):
+def test_private_mode_info_not_saved(driver: Firefox):
     """
     C122587 - Autofill data not saved in private mode.
     This only tests the last part of the written TC - case should be divided
@@ -37,7 +35,7 @@ def test_private_mode_info_not_saved(driver: Firefox, country_code: str):
     ba = BrowserActions(driver)
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(country_code)
+    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
     address_form_fields.save_information_basic(autofill_sample_data)
     autofill_popup.verify_no_popup_panel()
 

--- a/tests/form_autofill/test_updating_address.py
+++ b/tests/form_autofill/test_updating_address.py
@@ -6,17 +6,15 @@ from modules.page_object import AboutPrefs
 from modules.page_object_autofill import AddressFill
 from modules.util import BrowserActions, Utilities
 
+COUNTRY_CODE = "US"
+
 
 @pytest.fixture()
 def test_case():
     return "122354"
 
 
-countries = ["CA", "US"]
-
-
-@pytest.mark.parametrize("country_code", countries)
-def test_update_address(driver: Firefox, country_code: str):
+def test_update_address(driver: Firefox):
     """
     C122354 - This test verifies that after updating and saving the autofill name field, the updated value appears in the Saved Addresses section.
     """
@@ -27,7 +25,7 @@ def test_update_address(driver: Firefox, country_code: str):
     browser_action_obj = BrowserActions(driver)
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(country_code)
+    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
     address_form_fields.save_information_basic(autofill_sample_data)
     autofill_popup_panel.click_doorhanger_button("save")
 


### PR DESCRIPTION
With the new l10n work, it doesn't make sense to double our coverage for autofill tests anymore
