### PR TITLE
Philimon[l10n-CM][Fix] Fix l10n test suite

### DIFF
--- a/l10n_CM/run_l10n.py
+++ b/l10n_CM/run_l10n.py
@@ -22,16 +22,13 @@ def get_region_tests(test_region: str) -> list[str]:
 if __name__ == "__main__":
     valid_region = {"US", "CA", "DE", "FR"}
     regions = sys.argv[1:] if len(sys.argv[1:]) > 0 else valid_region
-    headless = "--run-headless" if sys.argv[-1] == "f" else ""
     for region in regions:
-        if region == "f":
-            break
         if region not in valid_region:
             raise ValueError("Invalid Region.")
         tests = get_region_tests(region)
         try:
             os.environ["STARFOX_REGION"] = region
-            subprocess.run(["pytest", headless, *tests], check=True, text=True)
+            subprocess.run(["pytest", *tests], check=True, text=True)
         except subprocess.CalledProcessError as e:
             print(e)
             logging.warn(f"Test run failed. {e}")

--- a/l10n_CM/run_l10n.py
+++ b/l10n_CM/run_l10n.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 import sys
@@ -19,14 +20,18 @@ def get_region_tests(test_region: str) -> list[str]:
 
 
 if __name__ == "__main__":
-    regions = sys.argv[1:]
     valid_region = {"US", "CA", "DE", "FR"}
+    regions = sys.argv[1:] if len(sys.argv[1:]) > 0 else valid_region
+    headless = "--run-headless" if sys.argv[-1] == "f" else ""
     for region in regions:
+        if region == "f":
+            break
         if region not in valid_region:
             raise ValueError("Invalid Region.")
         tests = get_region_tests(region)
         try:
             os.environ["STARFOX_REGION"] = region
-            subprocess.run(["pytest", *tests], check=True, text=True)
+            subprocess.run(["pytest", headless, *tests], check=True, text=True)
         except subprocess.CalledProcessError as e:
-            print(f"test run failed with {e} error")
+            print(e)
+            logging.warn(f"Test run failed. {e}")


### PR DESCRIPTION
### Description
Minor fix to allow `run_l10n` to run all region tests when a region isn't specified.
Also adds a headless execution flag (add `f` as the last argument for the python script).

### Bugzilla bug ID

### Type of change

Please delete options that are not relevant.
- [x] Other Changes (Please specify)

### Comments / Concerns

Can run all region tests by not specifying region when running script and also adds headless execution.
Headless Exection: `python l10n_CM/run_l10n.py US f`
All Region Tests: `python l10n_CM/run_l10n.py`
