### PR TITLE
Ben/fix dupe tests ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .tmp*
 .testrail_credential*
 .DS_Store
+selected_tests
 test*.txt
 fx_location
 test*txt

--- a/choose_ci_set.py
+++ b/choose_ci_set.py
@@ -72,25 +72,17 @@ def get_tests_by_model(
     return matching_tests
 
 
-def dedupe(run_list: list, slash: str) -> list:
+def dedupe(run_list: list) -> list:
     """For a run list, remove entries that are covered by more general entries."""
-    suites = []
     run_list = list(set(run_list))
-    run_list = [
-        f".{slash}{entry}"
-        for entry in run_list
-        if not (entry.startswith(".") or entry.startswith(slash))
-    ]
-    for entry in run_list:
-        pieces = entry.split(slash)
-        if len(pieces) < 4:
-            suites.append(pieces[-1])
-
     removes = []
-    for entry in run_list:
-        pieces = entry.split(slash)
-        if len(pieces) > 3 and pieces[2] in suites:
-            removes.append(run_list.index(entry))
+
+    for i, entry_a in enumerate(run_list):
+        for j, entry_b in enumerate(run_list):
+            if i == j:
+                continue
+            if entry_a in entry_b:
+                removes.append(j)
 
     for remove in removes:
         del run_list[remove]
@@ -219,7 +211,7 @@ if __name__ == "__main__":
         run_list.extend(ci_paths)
 
         # Dedupe just in case
-        run_list = dedupe(run_list, slash)
+        run_list = dedupe(run_list)
         run_list = [entry for entry in run_list if os.path.exists(entry.split("::")[0])]
         with open(OUTPUT_FILE, "w") as fh:
             fh.write("\n".join(run_list))

--- a/choose_ci_set.py
+++ b/choose_ci_set.py
@@ -76,6 +76,11 @@ def dedupe(run_list: list, slash: str) -> list:
     """For a run list, remove entries that are covered by more general entries."""
     suites = []
     run_list = list(set(run_list))
+    run_list = [
+        f".{slash}{entry}"
+        for entry in run_list
+        if not (entry.startswith(".") or entry.startswith(slash))
+    ]
     for entry in run_list:
         pieces = entry.split(slash)
         if len(pieces) < 4:

--- a/choose_ci_set.py
+++ b/choose_ci_set.py
@@ -72,10 +72,22 @@ def get_tests_by_model(
     return matching_tests
 
 
-def dedupe(run_list: list) -> list:
+def dedupe(run_list: list, slash: str) -> list:
     """For a run list, remove entries that are covered by more general entries."""
     run_list = list(set(run_list))
+    dotslashes = []
     removes = []
+
+    for i, entry in enumerate(run_list):
+        if (
+            not entry.startswith(".")
+            and not entry.startswith("\\")
+            and not entry.startswith("/")
+        ):
+            dotslashes.append(i)
+
+    for dotslash in dotslashes:
+        run_list[dotslash] = f".{slash}{run_list[dotslash]}"
 
     for i, entry_a in enumerate(run_list):
         for j, entry_b in enumerate(run_list):
@@ -211,7 +223,7 @@ if __name__ == "__main__":
         run_list.extend(ci_paths)
 
         # Dedupe just in case
-        run_list = dedupe(run_list)
+        run_list = dedupe(run_list, slash)
         run_list = [entry for entry in run_list if os.path.exists(entry.split("::")[0])]
         with open(OUTPUT_FILE, "w") as fh:
             fh.write("\n".join(run_list))

--- a/tests/bookmarks_and_history/test_delete_bookmarks_from_toolbar.py
+++ b/tests/bookmarks_and_history/test_delete_bookmarks_from_toolbar.py
@@ -14,7 +14,6 @@ def test_case():
 URL_TO_BOOKMARK = "https://www.mozilla.org/"
 
 
-@pytest.mark.unstable
 @pytest.mark.headed
 def test_delete_bookmarks_from_toolbar(driver: Firefox):
     """

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -52,7 +52,6 @@ def test_open_image_in_new_tab(driver: Firefox):
     wiki_image_page.verify_opened_image_url("wikimedia", LOADED_IMAGE_URL)
 
 
-@pytest.mark.unstable
 @pytest.mark.ci
 @pytest.mark.headed
 def test_save_image_as(driver: Firefox, sys_platform, delete_files):


### PR DESCRIPTION
The chooser script was put up against another unforeseen corner case and needed to be fixed. Tests that were made unstable by that change needed to be demarked.