### PR TITLE
Fix https in PBM test

### DIFF
--- a/tests/networking/test_http_site.py
+++ b/tests/networking/test_http_site.py
@@ -17,7 +17,7 @@ def set_prefs():
         ("dom.security.https_only_mode_ever_enabled", True),
         ("dom.security.https_only_mode_ever_enabled_pbm", True),
         ("dom.security.https_first", False),
-        ("dom.security.https_first_add_exception_on_failiure", False),
+        ("dom.security.https_first_add_exception_on_failure", False),
         ("dom.security.https_first_pbm", False),
         ("dom.security.https_first_schemeless", False),
     ]

--- a/tests/security_and_privacy/test_https_enabled_private_browsing.py
+++ b/tests/security_and_privacy/test_https_enabled_private_browsing.py
@@ -2,21 +2,16 @@ import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.support.wait import WebDriverWait
 
+from modules.browser_object import Navigation, PanelUi
+from modules.page_object import AboutPrefs
+
 
 @pytest.fixture()
 def test_case():
     return "1362731"
 
 
-HTTP_URL = "http://example.com"
-
-
-@pytest.fixture()
-def add_prefs():
-    return [
-        ("browser.privatebrowsing.autostart", True),
-        ("dom.security.https_first_pbm", True),
-    ]
+HTTP_SITE = "http://example.com"
 
 
 def test_https_first_mode_in_private_browsing(driver: Firefox):
@@ -24,8 +19,15 @@ def test_https_first_mode_in_private_browsing(driver: Firefox):
     C1362731 Check that https First Mode is properly enabled and working in Private Browsing
     """
 
-    # Navigate to the HTTP URL
-    driver.get(HTTP_URL)
+    # Navigate to the HTTP Site in a Private Window
+    prefs = AboutPrefs(driver, category="privacy")
+    prefs.open()
+    prefs.select_https_only_setting(prefs.HTTPS_ONLY_STATUS.HTTPS_ONLY_PRIVATE)
+    hamburger = PanelUi(driver)
+    hamburger.open_private_window()
+    nav = Navigation(driver)
+    nav.switch_to_new_window()
+    driver.get(HTTP_SITE)
 
     # Wait for the URL to be redirected to HTTPS
     assert WebDriverWait(driver, 10).until(


### PR DESCRIPTION
### Description
fixes tests/security_and_privacy/test_https_enabled_private_browsing.py requiring addition pref to be set

#### Bugzilla bug ID
https://bugzilla.mozilla.org/show_bug.cgi?id=1946112
https://mozilla.testrail.io/index.php?/tests/view/6240228&group_by=cases:section_id&group_order=asc&group_id=222229&group_by=cases:section_id&group_order=asc&group_id=222229

#### Type of change
- [X] Test Fix

#### How does this resolve / make progress on that bug?
Completes

#### Comments / Concerns
Also fixed a typo in test_http_site.py
