### PR TITLE
Hani/ Fix test intervention card refresh firefox

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -2834,6 +2834,20 @@ Description: Option by label in search mode list
 Location: Search mode of awesomebar
 Path to .json: modules/data/navigation.components.json
 ```
+```
+Selector Name: refresh-button-awesome-bar
+Selector Data: .urlbarView-action-btn[data-action=refresh]
+Description: Refresh button in the awesome bar
+Location: Address bar
+Path to .json: modules/data/navigation.components.json
+```
+```
+Selector Name: refresh-firefox-dialog
+Selector Data: window-modal-dialog
+Description: Refresh Firefox dialog window
+Location: Dialog window
+Path to .json: modules/data/navigation.components.json
+```
 #### panel_ui
 ```
 Selector name: panel-ui-button

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -571,5 +571,17 @@
         "selectorData": "searchmode-switcher-popup-search-settings-button",
         "strategy": "id",
          "groups": []
+    },
+
+    "refresh-button-awesome-bar": {
+        "selectorData": ".urlbarView-action-btn[data-action=refresh]",
+        "strategy": "css",
+         "groups": []
+    },
+
+    "refresh-firefox-dialog": {
+        "selectorData": "window-modal-dialog",
+        "strategy": "id",
+         "groups": []
     }
 }

--- a/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
+++ b/tests/address_bar_and_search/test_intervention_card_refresh_firefox.py
@@ -6,79 +6,21 @@ from modules.browser_object import Navigation
 
 @pytest.fixture()
 def test_case():
-    return "1365204"
-
-
-ALLOWED_RGB_BEFORE_VALUES = set(
-    ["rgba(207, 207, 216, 0.33)", "color(srgb 0 0 0 / 0.13)", "rgba(0, 0, 0, 0.33)"]
-)
-ALLOWED_RGB_AFTER_VALUES = set(
-    ["color(srgb 0 0 0 / 0.6)", "color(srgb 0.984314 0.984314 0.996078 / 0.6)"]
-)
+    return "2914620"
 
 
 @pytest.mark.skip("Scotch Bonnet")
 def test_intervention_card_refresh(driver: Firefox):
     """
-    C1365204.1: regular firefox, check the intervention card
+    C2914620: Refresh Firefox dialog
     """
     # instantiate objects and type in search bar
     nav = Navigation(driver)
     nav.set_awesome_bar()
     nav.type_in_awesome_bar("refresh firefox")
 
-    with driver.context(driver.CONTEXT_CHROME):
-        # ensure the text is correct
-        nav.wait.until(
-            lambda _: nav.get_element("fx-refresh-text").get_attribute("innerHTML")
-            == "Restore default settings and remove old add-ons for optimal performance."
-        )
-        # ensure the color before hover
-        nav.wait.until(
-            lambda _: nav.get_element("fx-refresh-button").value_of_css_property(
-                "background-color"
-            )
-            in ALLOWED_RGB_BEFORE_VALUES
-        )
-        nav.hover(nav.get_element("fx-refresh-button"))
-        # ensure there is a hover state
-        nav.wait.until(
-            lambda _: nav.get_element("fx-refresh-button").value_of_css_property(
-                "background-color"
-            )
-            in ALLOWED_RGB_AFTER_VALUES
-        )
+    # Click on the "Refresh Firefox" button
+    nav.click_on("refresh-button-awesome-bar")
 
-        # repeated from before but with the 3 dots menu button
-        nav.wait.until(
-            lambda _: nav.get_element("fx-refresh-menu").value_of_css_property(
-                "background-color"
-            )
-            in ALLOWED_RGB_BEFORE_VALUES
-        )
-        nav.wait.until(
-            lambda _: nav.get_element("fx-refresh-menu").get_attribute("open") is None
-        )
-        nav.hover(nav.get_element("fx-refresh-menu"))
-        nav.wait.until(
-            lambda _: nav.get_element("fx-refresh-menu").value_of_css_property(
-                "background-color"
-            )
-            in ALLOWED_RGB_AFTER_VALUES
-        )
-
-        # ensure the popup appears
-        nav.click_on("fx-refresh-menu")
-        nav.wait.until(
-            lambda _: nav.get_element("fx-refresh-menu").get_attribute("open") == "true"
-        )
-        nav.wait.until(
-            lambda _: nav.get_element("fx-refresh-menu-get-help-item-get-help")
-            is not None
-        )
-
-        # get the number of options (search results)
-        search_results_container = nav.get_element("search-results-container")
-        nav.wait.until(
-            lambda _: len(nav.get_all_children(search_results_container)) == 2
-        )
+    # Refresh Firefox dialog is correctly displayed
+    nav.element_visible("refresh-firefox-dialog")


### PR DESCRIPTION
### Description

Replace test [Intervention Card UI is correctly displayed - Refresh Firefox](https://mozilla.testrail.io/index.php?/cases/view/1365208) with test [Refresh Firefox dialog](https://mozilla.testrail.io/index.php?/cases/view/2914620).

### Bugzilla bug ID

Testrail: https://mozilla.testrail.io/index.php?/cases/view/2914620
Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1945154

### Type of change

- [ ] Other Changes (Replace test)

### How does this resolve / make progress on that bug?

Completed.

### Screenshots / Explanations

N/A

### Comments / Concerns

N/A
