### PR TITLE
clean up sponsored suggestion test & fails when no new beta

### DIFF
--- a/.github/workflows/check-beta.yml
+++ b/.github/workflows/check-beta.yml
@@ -29,5 +29,6 @@ jobs:
           echo test=$(pipenv run python -c 'from modules import testrail_integration as tri; print(tri.reportable())') >> "$GITHUB_OUTPUT"
   Run-Smoke-Tests:
     needs: Check-Beta-Version
+    if: ${{ needs.Check-Beta-Version.outputs.reportable == 'True' }}
     uses: ./.github/workflows/smoke.yml
     secrets: inherit

--- a/.github/workflows/check-beta.yml
+++ b/.github/workflows/check-beta.yml
@@ -11,10 +11,13 @@ permissions:
 jobs:
   Check-Beta-Version:
     runs-on: ubuntu-latest
+    outputs:
+      reportable: ${{ steps.reportable.outputs.test }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Check if the run is reportable
+        id: reportable
         env: 
           TESTRAIL_REPORT: true
           TESTRAIL_BASE_URL: ${{ secrets.TESTRAIL_BASE_URL }}
@@ -23,7 +26,7 @@ jobs:
         run: |
           pip3 install 'pipenv==2023.11.15';
           pipenv install
-          pipenv run python -c 'from modules import testrail_integration as tri; import sys; sys.exit(0) if tri.reportable() else sys.exit(100)'
+          echo test=$(pipenv run python -c 'from modules import testrail_integration as tri; print(tri.reportable())') >> "$GITHUB_OUTPUT"
   Run-Smoke-Tests:
     needs: Check-Beta-Version
     uses: ./.github/workflows/smoke.yml

--- a/taskcluster/kinds/new-beta-qa/kind.yml
+++ b/taskcluster/kinds/new-beta-qa/kind.yml
@@ -39,7 +39,7 @@ tasks:
         pipenv install;
         ./collect_executables.sh;
         export FX_EXECUTABLE=./firefox/firefox;
-        pipenv run python -c 'from modules import testrail_integration as tri; tri.tc_reportable()' || exit 100;
+        pipenv run python -c 'from modules import testrail_integration as tri; tri.tc_reportable()' || exit 0;
         $FX_EXECUTABLE --version;
         . ./keyring-unlock.sh
         pipenv run pytest --fx-executable $FX_EXECUTABLE -n 4 tests;

--- a/tests/address_bar_and_search/test_preferences_all_toggles_enabled.py
+++ b/tests/address_bar_and_search/test_preferences_all_toggles_enabled.py
@@ -49,10 +49,6 @@ def test_preferences_all_toggles_enabled(driver: Firefox):
                     for el in nav.get_elements("sponsored-suggestion")
                 ]
             )
-            logging.info(
-                "Label text:"
-                + nav.get_element("sponsored-suggestion").get_attribute("innerText")
-            )
         sleep(3)
         retries += 1
 


### PR DESCRIPTION
When we don't have a new scheduled beta, we get red badges in TC and GHA. Also the sponsored suggestion test is failing in Scheduled for Linux still. It appears to be the logging call, so I removed it.