### PR TITLE
Anca/ l10n demo - CC autofill dropdown activation across all payment form fields

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_name_org_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_name_org_captured_in_doorhanger_and_stored.py
@@ -5,7 +5,7 @@ from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_about_pages import AboutConfig
 from modules.page_object_autofill import AddressFill
 from modules.page_object_prefs import AboutPrefs
-from modules.util import Utilities, BrowserActions
+from modules.util import BrowserActions, Utilities
 
 
 @pytest.fixture()
@@ -13,7 +13,9 @@ def test_case():
     return "2888701"
 
 
-def test_demo_ad_name_org_captured_in_doorhanger_and_stored(driver: Firefox, region: str):
+def test_demo_ad_name_org_captured_in_doorhanger_and_stored(
+    driver: Firefox, region: str
+):
     """
     C2888701 - Verify name/org fields are captured in the Capture Doorhanger and stored in about:preferences
     """
@@ -55,8 +57,7 @@ def test_demo_ad_name_org_captured_in_doorhanger_and_stored(driver: Firefox, reg
     elements = about_prefs.get_elements("saved-addresses-values")
     expected_values = [expected_name, expected_org]
     found_name_org = any(
-        all(value in element.text for value in expected_values)
-        for element in elements
+        all(value in element.text for value in expected_values) for element in elements
     )
     assert (
         found_name_org

--- a/l10n_CM/Unified/test_demo_cc_dropdown-presence.py
+++ b/l10n_CM/Unified/test_demo_cc_dropdown-presence.py
@@ -17,7 +17,7 @@ def test_dropdown_presence_credit_card(driver: Firefox, region: str):
     C2886598 - Verify autofill dropdown is displayed only for the eligible fields after a credit card is saved
     """
 
-    # Initialize
+    # Initialize objects
     util = Utilities()
     about_prefs = AboutPrefs(driver, category="privacy")
     about_prefs_cc_popup = AboutPrefs(driver)

--- a/l10n_CM/Unified/test_demo_cc_dropdown-presence.py
+++ b/l10n_CM/Unified/test_demo_cc_dropdown-presence.py
@@ -1,0 +1,46 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object import AboutConfig, AboutPrefs
+from modules.page_object_autofill import CreditCardFill
+from modules.util import BrowserActions, Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2886598"
+
+
+def test_dropdown_presence_credit_card(driver: Firefox, region: str):
+    """
+    C2886598 - Verify autofill dropdown is displayed only for the eligible fields after a credit card is saved
+    """
+
+    # Initialize
+    util = Utilities()
+    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs_cc_popup = AboutPrefs(driver)
+    about_config = AboutConfig(driver)
+    browser_action_obj = BrowserActions(driver)
+    credit_card_fill_obj = CreditCardFill(driver)
+    autofill_popup_obj = AutofillPopup(driver)
+
+    # Change pref value of region
+    about_config.change_config_value("browser.search.region", region)
+
+    # Save a credit card in about:preferences
+    about_prefs.open()
+    iframe = about_prefs.get_saved_payments_popup_iframe()
+    browser_action_obj.switch_to_iframe_context(iframe)
+    credit_card_sample_data = util.fake_credit_card_data()
+    about_prefs_cc_popup.click_on(
+        "panel-popup-button", labels=["autofill-manage-add-button"]
+    )
+    about_prefs.fill_cc_panel_information(credit_card_sample_data)
+
+    # Open credit card form page
+    credit_card_fill_obj.open()
+
+    # Verify autofill dropdown is displayed only for the eligible fields
+    credit_card_fill_obj.verify_autofill_dropdown_all_fields(autofill_popup_obj)

--- a/l10n_CM/Unified/test_demo_cc_dropdown-presence.py
+++ b/l10n_CM/Unified/test_demo_cc_dropdown-presence.py
@@ -2,8 +2,7 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutConfig, AboutPrefs
-from modules.page_object_autofill import CreditCardFill
+from modules.page_object import AboutPrefs, CreditCardFill
 from modules.util import BrowserActions, Utilities
 
 
@@ -12,7 +11,7 @@ def test_case():
     return "2886598"
 
 
-def test_dropdown_presence_credit_card(driver: Firefox, region: str):
+def test_dropdown_presence_credit_card(driver: Firefox):
     """
     C2886598 - Verify autofill dropdown is displayed only for the eligible fields after a credit card is saved
     """
@@ -21,13 +20,9 @@ def test_dropdown_presence_credit_card(driver: Firefox, region: str):
     util = Utilities()
     about_prefs = AboutPrefs(driver, category="privacy")
     about_prefs_cc_popup = AboutPrefs(driver)
-    about_config = AboutConfig(driver)
     browser_action_obj = BrowserActions(driver)
     credit_card_fill_obj = CreditCardFill(driver)
     autofill_popup_obj = AutofillPopup(driver)
-
-    # Change pref value of region
-    about_config.change_config_value("browser.search.region", region)
 
     # Save a credit card in about:preferences
     about_prefs.open()

--- a/l10n_CM/region/CA.json
+++ b/l10n_CM/region/CA.json
@@ -4,6 +4,7 @@
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_add_new_credit_card.py",
         "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
-        "test_demo_ad_name_org_captured_in_doorhanger_and_stored"
+        "test_demo_ad_name_org_captured_in_doorhanger_and_stored.py",
+        "test_demo_cc_dropdown-presence.py"
     ]
 }

--- a/l10n_CM/region/DE.json
+++ b/l10n_CM/region/DE.json
@@ -4,6 +4,7 @@
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_add_new_credit_card.py",
         "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
-        "test_demo_ad_name_org_captured_in_doorhanger_and_stored"
+        "test_demo_ad_name_org_captured_in_doorhanger_and_stored.py",
+        "test_demo_cc_dropdown-presence.py"
     ]
 }

--- a/l10n_CM/region/FR.json
+++ b/l10n_CM/region/FR.json
@@ -4,6 +4,7 @@
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_add_new_credit_card.py",
         "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
-        "test_demo_ad_name_org_captured_in_doorhanger_and_stored"
+        "test_demo_ad_name_org_captured_in_doorhanger_and_stored.py",
+        "test_demo_cc_dropdown-presence.py"
     ]
 }

--- a/l10n_CM/region/US.json
+++ b/l10n_CM/region/US.json
@@ -4,6 +4,7 @@
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_add_new_credit_card.py",
         "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
-        "test_demo_ad_name_org_captured_in_doorhanger_and_stored"
+        "test_demo_ad_name_org_captured_in_doorhanger_and_stored.py",
+        "test_demo_cc_dropdown-presence.py"
     ]
 }

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -23,18 +23,15 @@ class AutofillPopup(BasePage):
         """Confirms that an element exists in popup"""
         self.element_clickable(reference)
 
-    def verify_no_popup_panel(self):
-        """Verifies that the autofill popup does NOT appear"""
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            element = self.get_element("autofill-panel")
-            self.expect_not(EC.element_to_be_clickable(element))
+    def ensure_autofill_dropdown_not_visible(self):
+        """Verifies that the autofill dropdown does NOT appear"""
+        self.element_not_visible("select-form-option")
+        return self
 
-    def verify_popup(self):
-        """Verifies that the autofill popup is clickable"""
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            self.expect(
-                EC.element_to_be_clickable(self.get_element("select-form-option"))
-            )
+    def ensure_autofill_dropdown_visible(self):
+        """Verifies that the autofill dropdown appears"""
+        self.element_visible("select-form-option")
+        return self
 
     # Interaction with popup elements
     def click_doorhanger_button(self, button_type: str) -> BasePage:

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -78,9 +78,9 @@ class CreditCardFill(Autofill):
         for field in self.fields:
             self.double_click("form-field", labels=[field])
             ccp.ensure_autofill_dropdown_visible()
-        # Ensure 'cc-csc' does NOT trigger the dropdown
+        # Ensure 'cc-csc' does NOT trigger the autofill dropdown
         self.double_click("form-field", labels=["cc-csc"])
-        ccp.ensure_autofill_dropdown_not_visible()  # Ensure popup does NOT appear
+        ccp.ensure_autofill_dropdown_not_visible()
 
     def verify_four_fields(
         self, ccp: AutofillPopup, credit_card_sample_data: CreditCardBase

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -73,11 +73,14 @@ class CreditCardFill(Autofill):
 
         self.click_form_button("submit")
 
-    def verify_all_fields(self, ccp: AutofillPopup):
+    def verify_autofill_dropdown_all_fields(self, ccp: AutofillPopup):
         """Given a CreditCardPopup object, verify all fields"""
         for field in self.fields:
             self.double_click("form-field", labels=[field])
-            ccp.verify_popup()
+            ccp.ensure_autofill_dropdown_visible()
+        # Ensure 'cc-csc' does NOT trigger the dropdown
+        self.double_click("form-field", labels=["cc-csc"])
+        ccp.ensure_autofill_dropdown_not_visible()  # Ensure popup does NOT appear
 
     def verify_four_fields(
         self, ccp: AutofillPopup, credit_card_sample_data: CreditCardBase

--- a/tests/form_autofill/test_autofill_credit_card.py
+++ b/tests/form_autofill/test_autofill_credit_card.py
@@ -24,4 +24,4 @@ def test_autofill_credit_card(driver: Firefox):
     credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
     autofill_popup_obj.click_doorhanger_button("save")
 
-    credit_card_fill_obj.verify_all_fields(autofill_popup_obj)
+    credit_card_fill_obj.verify_autofill_dropdown_all_fields(autofill_popup_obj)

--- a/tests/form_autofill/test_autofill_credit_card_enable.py
+++ b/tests/form_autofill/test_autofill_credit_card_enable.py
@@ -31,4 +31,4 @@ def test_enable_disable_form_autofill_cc(driver: Firefox):
     new_autofill_popup_obj = AutofillPopup(driver)
 
     new_credit_card_fill_obj.double_click("form-field", labels=["cc-name"])
-    new_autofill_popup_obj.verify_no_popup_panel()
+    new_autofill_popup_obj.ensure_autofill_dropdown_not_visible()

--- a/tests/form_autofill/test_enable_disable_autofill.py
+++ b/tests/form_autofill/test_enable_disable_autofill.py
@@ -39,4 +39,4 @@ def test_enable_disable_autofill(driver: Firefox):
 
     # verifying the popup panel does not appear
     new_af.double_click("form-field", labels=["name"])
-    new_afp.verify_no_popup_panel()
+    new_afp.ensure_autofill_dropdown_not_visible()

--- a/tests/form_autofill/test_private_mode_info_not_saved.py
+++ b/tests/form_autofill/test_private_mode_info_not_saved.py
@@ -37,7 +37,7 @@ def test_private_mode_info_not_saved(driver: Firefox):
     # Create fake data, fill in the form, and press submit and save on the doorhanger
     autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
     address_form_fields.save_information_basic(autofill_sample_data)
-    autofill_popup.verify_no_popup_panel()
+    autofill_popup.ensure_autofill_dropdown_not_visible()
 
     about_prefs = AboutPrefs(driver, category="privacy").open()
 


### PR DESCRIPTION
### Description
- Verify the autofill dropdown is displayed for all the fields except cvv in payment form on demo page after a credit card was saved in about:preferences.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2886598**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943189**

### Type of change

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed
### Screenshots / Explanations
- N/A

### Comments / Concerns
- N/A
