### PR TITLE
Hani/Demo address data captured in doorhanger and stored

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1353,6 +1353,48 @@ Description: Save address doorhanger
 Location: Address bar
 Path to .json: modules/data/autofill_popup.components.json
 ```
+```
+Selector Name: address-doorhanger-street
+Selector Data: "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(3) span"
+Description: Save address doorhanger street address section
+Location: Address bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector Name: address-doorhanger-city
+Selector Data: "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(4) span:nth-of-type(1)"
+Description: Save address doorhanger city section
+Location: Address bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector Name: address-doorhanger-state
+Selector Data: "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(4) span:nth-of-type(3)"
+Description: Save address doorhanger state section
+Location: Address bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector Name: address-doorhanger-zip
+Selector Data: "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(4) span:nth-of-type(5)"
+Description: Save address doorhanger zip section for US and CA
+Location: Address bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector Name: address-doorhanger-zip-other
+Selector Data: "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(4) span:nth-of-type(3)",
+Description: Save address doorhanger zip section for other regions
+Location: Address bar
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
+Selector Name: address-doorhanger-country
+Selector Data: "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(5) span"
+Description: Save address doorhanger country section
+Location: Address bar
+Path to .json: modules/data/autofill_popup.components.json
+```
 #### context_menu
 ```
 Selector Name: context-menu-search-selected-text

--- a/l10n_CM/Unified/test_demo_ad_address_data_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_address_data_captured_in_doorhanger_and_stored.py
@@ -1,0 +1,76 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_about_pages import AboutConfig
+from modules.page_object_autofill import AddressFill
+from modules.page_object_prefs import AboutPrefs
+from modules.util import Utilities, BrowserActions
+
+
+
+@pytest.fixture()
+def test_case():
+    return "2888701"
+
+
+def test_demo_ad_address_data_captured_in_doorhanger_and_stored(driver: Firefox, region: str):
+    """
+    C2888703 - Verify Address data are captured in the Capture Doorhanger and stored in about:preferences
+    """
+    # instantiate objects
+    address_autofill = AddressFill(driver)
+    address_autofill_popup = AutofillPopup(driver)
+    util = Utilities()
+    about_config = AboutConfig(driver)
+    browser_action_obj = BrowserActions(driver)
+
+    # Change pref value of region
+    about_config.change_config_value("browser.search.region", region)
+
+    # create fake data and fill it in
+    address_autofill.open()
+    address_autofill_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(address_autofill_data)
+
+    # The "Save address?" doorhanger is displayed
+    address_autofill_popup.element_visible("address-save-doorhanger")
+
+    # containing Street Address field
+    expected_street_add = address_autofill_data.street_address
+    address_autofill_popup.element_has_text("address-doorhanger-street", expected_street_add)
+
+    # containing City field
+    expected_city = address_autofill_data.address_level_2
+    address_autofill_popup.element_has_text("address-doorhanger-city", expected_city)
+
+    # containing State/Province field
+    expected_state = address_autofill_data.address_level_1
+    address_autofill_popup.element_has_text("address-doorhanger-state", expected_state)
+
+    # containing Zip code field
+    expected_zip = address_autofill_data.postal_code
+    address_autofill_popup.element_has_text("address-doorhanger-zip", expected_zip)
+
+    # containing Country field
+    expected_country = address_autofill_data.country
+    address_autofill_popup.element_has_text("address-doorhanger-country", expected_country)
+
+    # Click the "Save" button
+    address_autofill_popup.click_doorhanger_button("save")
+
+    # Navigate to about:preferences#privacy => "Autofill" section
+    about_prefs = AboutPrefs(driver, category="privacy").open()
+    iframe = about_prefs.get_save_addresses_popup_iframe()
+    browser_action_obj.switch_to_iframe_context(iframe)
+
+    # The address saved in step 2 is listed in the "Saved addresses" modal: Street, city, state, zip and country
+    elements = about_prefs.get_elements("saved-addresses-values")
+    expected_values = [expected_street_add, expected_city, expected_zip, expected_country]
+    found_name_org = any(
+        all(value in element.text for value in expected_values)
+        for element in elements
+    )
+    assert (
+        found_name_org
+    ), "Street, city, state, zip or country were not found in any of the address entries!"

--- a/l10n_CM/Unified/test_demo_ad_address_data_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_address_data_captured_in_doorhanger_and_stored.py
@@ -10,7 +10,7 @@ from modules.util import Utilities, BrowserActions
 
 @pytest.fixture()
 def test_case():
-    return "2888701"
+    return "2888703"
 
 
 def test_demo_ad_address_data_captured_in_doorhanger_and_stored(driver: Firefox, region: str):

--- a/l10n_CM/region/CA.json
+++ b/l10n_CM/region/CA.json
@@ -3,6 +3,7 @@
     "tests": [
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_add_new_credit_card.py",
-        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py"
+        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
+        "test_demo_ad_address_data_captured_in_doorhanger_and_stored.py"
     ]
 }

--- a/l10n_CM/region/DE.json
+++ b/l10n_CM/region/DE.json
@@ -3,6 +3,7 @@
     "tests": [
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_add_new_credit_card.py",
-        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py"
+        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
+        "test_demo_ad_address_data_captured_in_doorhanger_and_stored.py"
     ]
 }

--- a/l10n_CM/region/FR.json
+++ b/l10n_CM/region/FR.json
@@ -3,6 +3,7 @@
     "tests": [
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_add_new_credit_card.py",
-        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py"
+        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
+        "test_demo_ad_address_data_captured_in_doorhanger_and_stored.py"
     ]
 }

--- a/l10n_CM/region/US.json
+++ b/l10n_CM/region/US.json
@@ -3,6 +3,7 @@
     "tests": [
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_add_new_credit_card.py",
-        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py"
+        "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
+        "test_demo_ad_address_data_captured_in_doorhanger_and_stored.py"
     ]
 }

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -109,6 +109,12 @@
         "groups": []
     },
 
+    "address-doorhanger-zip-other": {
+        "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(4) span:nth-of-type(3)",
+        "strategy": "css",
+        "groups": []
+    },
+
     "address-doorhanger-country": {
         "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(5) span",
         "strategy": "css",

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -83,6 +83,36 @@
         "selectorData": "address-save-update-notification-content",
         "strategy": "class",
         "groups": []
+    },
+
+    "address-doorhanger-street": {
+        "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(3) span",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "address-doorhanger-city": {
+        "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(4) span:nth-of-type(1)",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "address-doorhanger-state": {
+        "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(4) span:nth-of-type(3)",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "address-doorhanger-zip": {
+        "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(4) span:nth-of-type(5)",
+        "strategy": "css",
+        "groups": []
+    },
+
+    "address-doorhanger-country": {
+        "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(5) span",
+        "strategy": "css",
+        "groups": []
     }
 }
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -394,6 +394,34 @@ class Utilities:
             ret_val += f"{attribute}: {value}\n"
         return ret_val
 
+    def get_state_province_abbreviation(self, full_name: str) -> str:
+        """
+        Returns the abbreviation for a given state, province, or region full name.
+
+        :param full_name: The full name of the state, province, or region.
+        :return: The corresponding abbreviation or "Not Found" if not in the dictionary.
+        """
+        state_province_abbr = {
+            # US States
+            "Alabama": "AL", "Alaska": "AK", "Arizona": "AZ", "Arkansas": "AR", "California": "CA",
+            "Colorado": "CO", "Connecticut": "CT", "Delaware": "DE", "Florida": "FL", "Georgia": "GA",
+            "Hawaii": "HI", "Idaho": "ID", "Illinois": "IL", "Indiana": "IN", "Iowa": "IA",
+            "Kansas": "KS", "Kentucky": "KY", "Louisiana": "LA", "Maine": "ME", "Maryland": "MD",
+            "Massachusetts": "MA", "Michigan": "MI", "Minnesota": "MN", "Mississippi": "MS", "Missouri": "MO",
+            "Montana": "MT", "Nebraska": "NE", "Nevada": "NV", "New Hampshire": "NH", "New Jersey": "NJ",
+            "New Mexico": "NM", "New York": "NY", "North Carolina": "NC", "North Dakota": "ND", "Ohio": "OH",
+            "Oklahoma": "OK", "Oregon": "OR", "Pennsylvania": "PA", "Rhode Island": "RI", "South Carolina": "SC",
+            "South Dakota": "SD", "Tennessee": "TN", "Texas": "TX", "Utah": "UT", "Vermont": "VT",
+            "Virginia": "VA", "Washington": "WA", "West Virginia": "WV", "Wisconsin": "WI", "Wyoming": "WY",
+
+            # Canadian Provinces
+            "Alberta": "AB", "British Columbia": "BC", "Manitoba": "MB", "New Brunswick": "NB",
+            "Newfoundland and Labrador": "NL", "Nova Scotia": "NS", "Ontario": "ON", "Prince Edward Island": "PE",
+            "Quebec": "QC", "Saskatchewan": "SK", "Northwest Territories": "NT", "Nunavut": "NU", "Yukon": "YT",
+        }
+
+        return state_province_abbr.get(full_name, "Not Found")
+
 
 class BrowserActions:
     """


### PR DESCRIPTION
### Description

Verify Address data are captured in the Capture Doorhanger and stored in about:preferences

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2888703**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943171**

### Type of change

- [x] New Test

### How does this resolve / make progress on that bug?

Completed.

### Screenshots / Explanations

N/A

### Comments / Concerns

N/A