### PR TITLE
Philimon/inital fix for test_zoom_text_only.py

### DIFF
--- a/tests/scrolling_panning_zooming/conftest.py
+++ b/tests/scrolling_panning_zooming/conftest.py
@@ -7,8 +7,15 @@ def suite_id():
 
 
 @pytest.fixture()
-def set_prefs():
+def add_prefs():
+    return []
+
+
+@pytest.fixture()
+def set_prefs(add_prefs: dict):
     """Set prefs"""
-    return [
+    prefs = [
         ("browser.aboutConfig.showWarning", False),
     ]
+    prefs.extend(add_prefs)
+    return prefs

--- a/tests/scrolling_panning_zooming/test_zoom_text_only.py
+++ b/tests/scrolling_panning_zooming/test_zoom_text_only.py
@@ -1,8 +1,9 @@
 import pytest
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation, PanelUi
-from modules.page_object import AboutConfig, AboutPrefs, GenericPage
+from modules.page_object import AboutPrefs, GenericPage
 
 
 @pytest.fixture()
@@ -74,10 +75,13 @@ def reject_consent_page(web_page: GenericPage):
     """
     reject consent page. scroll to rejection button if necessary.
     """
-    if web_page.element_clickable("yahoo-consent-page-scroll"):
-        web_page.click_on("yahoo-consent-page-scroll")
-    web_page.wait.until(lambda _: web_page.element_clickable("yahoo-reject-cookie"))
-    web_page.click_on("yahoo-reject-cookie")
+    try:
+        if web_page.element_clickable("yahoo-consent-page-scroll"):
+            web_page.click_on("yahoo-consent-page-scroll")
+        web_page.wait.until(lambda _: web_page.element_clickable("yahoo-reject-cookie"))
+        web_page.click_on("yahoo-reject-cookie")
+    except TimeoutException:
+        pass
 
 
 @pytest.mark.ci


### PR DESCRIPTION
### Description

Fixes the tests in `test_zoom_text_only.py`

### Bugzilla bug ID: [1947795](https://bugzilla.mozilla.org/show_bug.cgi?id=1947795)

**Testrail:**
**Link:**

### Type of change

Please delete options that are not relevant.

- [x] Other Changes (Please specify)

### How does this resolve / make progress on that bug?
- Changes the selectors for yahoo and duckduckgo to make the test work.
- breaks up tests into fixtures and moves pref setting to the conftests.

### Comments / Concerns

- Test should be refactored but currently only fixed due to priority.
