### PR TITLE
Philimon/Create test for Verify that a new Address can be added

### DIFF
--- a/l10n_CM/Unified/conftest.py
+++ b/l10n_CM/Unified/conftest.py
@@ -2,6 +2,11 @@ import os
 
 import pytest
 
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import AddressFill, CreditCardFill
+from modules.page_object_prefs import AboutPrefs
+from modules.util import Utilities
+
 
 @pytest.fixture()
 def region():
@@ -19,8 +24,38 @@ def add_prefs(region: str):
 
 
 @pytest.fixture()
-def set_prefs(add_prefs: dict):
+def set_prefs(add_prefs: dict, region: str):
     """Set prefs"""
     prefs = []
     prefs.extend(add_prefs)
     return prefs
+
+
+@pytest.fixture()
+def address_autofill(driver):
+    yield AddressFill(driver)
+
+
+@pytest.fixture()
+def address_autofill_popup(driver):
+    yield AutofillPopup(driver)
+
+
+@pytest.fixture()
+def util():
+    yield Utilities()
+
+
+@pytest.fixture()
+def about_prefs(driver):
+    yield AboutPrefs(driver, category="privacy")
+
+
+@pytest.fixture()
+def about_prefs_cc_popup(driver):
+    yield AboutPrefs(driver)
+
+
+@pytest.fixture()
+def credit_card_fill_obj(driver):
+    yield CreditCardFill(driver)

--- a/l10n_CM/Unified/test_demo_ad_address_data_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_address_data_captured_in_doorhanger_and_stored.py
@@ -4,8 +4,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.page_object_prefs import AboutPrefs
-from modules.util import Utilities, BrowserActions
-
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -13,16 +12,17 @@ def test_case():
     return "2888703"
 
 
-def test_demo_ad_address_data_captured_in_doorhanger_and_stored(driver: Firefox, region: str):
+def test_demo_ad_address_data_captured_in_doorhanger_and_stored(
+    driver: Firefox,
+    region: str,
+    address_autofill: AddressFill,
+    util: Utilities,
+    address_autofill_popup: AutofillPopup,
+    about_prefs: AboutPrefs,
+):
     """
     C2888703 - Verify Address data are captured in the Capture Doorhanger and stored in about:preferences
     """
-    # instantiate objects
-    address_autofill = AddressFill(driver)
-    address_autofill_popup = AutofillPopup(driver)
-    util = Utilities()
-    browser_action_obj = BrowserActions(driver)
-
     # create fake data and fill it in
     address_autofill.open()
     address_autofill_data = util.fake_autofill_data(region)
@@ -33,7 +33,9 @@ def test_demo_ad_address_data_captured_in_doorhanger_and_stored(driver: Firefox,
 
     # containing Street Address field
     expected_street_add = address_autofill_data.street_address
-    address_autofill_popup.element_has_text("address-doorhanger-street", expected_street_add)
+    address_autofill_popup.element_has_text(
+        "address-doorhanger-street", expected_street_add
+    )
 
     # containing City field
     expected_city = address_autofill_data.address_level_2
@@ -42,36 +44,47 @@ def test_demo_ad_address_data_captured_in_doorhanger_and_stored(driver: Firefox,
     expected_state = address_autofill_data.address_level_1
     if region not in ["FR", "DE"]:
         state_abbreviation = util.get_state_province_abbreviation(expected_state)
-        address_autofill_popup.element_has_text("address-doorhanger-state", state_abbreviation)
+        address_autofill_popup.element_has_text(
+            "address-doorhanger-state", state_abbreviation
+        )
 
     # Verify Zip Code field (Different selector for DE/FR)
     expected_zip = address_autofill_data.postal_code
-    zip_selector = "address-doorhanger-zip-other" if region in ["FR", "DE"] else "address-doorhanger-zip"
+    zip_selector = (
+        "address-doorhanger-zip-other"
+        if region in ["FR", "DE"]
+        else "address-doorhanger-zip"
+    )
     address_autofill_popup.element_has_text(zip_selector, expected_zip)
 
     # containing Country field
     expected_country = address_autofill_data.country
-    address_autofill_popup.element_has_text("address-doorhanger-country", expected_country)
+    address_autofill_popup.element_has_text(
+        "address-doorhanger-country", expected_country
+    )
 
     # Click the "Save" button
     address_autofill_popup.click_doorhanger_button("save")
 
     # Navigate to about:preferences#privacy => "Autofill" section
-    about_prefs = AboutPrefs(driver, category="privacy").open()
-    iframe = about_prefs.get_save_addresses_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs.open()
+    about_prefs.switch_to_saved_addresses_popup_iframe()
 
     # Verify saved addresses
     elements = about_prefs.get_elements("saved-addresses-values")
 
     # Expected values for verification
-    expected_values = [expected_street_add, expected_city, expected_zip, expected_country]
+    expected_values = [
+        expected_street_add,
+        expected_city,
+        expected_zip,
+        expected_country,
+    ]
     if region not in ["FR", "DE"]:
         expected_values.insert(2, expected_state)
 
     # Check if all expected values exist in any saved address
     found_address_data = any(
-        all(value in element.text for value in expected_values)
-        for element in elements
+        all(value in element.text for value in expected_values) for element in elements
     )
     assert found_address_data, "Street, city, state (if applicable), zip, or country were not found in any of the address entries!"

--- a/l10n_CM/Unified/test_demo_ad_doorhanger_shown_on_valid_address_submission.py
+++ b/l10n_CM/Unified/test_demo_ad_doorhanger_shown_on_valid_address_submission.py
@@ -2,7 +2,6 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutConfig
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
@@ -13,21 +12,15 @@ def test_case():
 
 
 def test_address_doorhanger_displayed_after_entering_valid_address(
-    driver: Firefox, region: str
+    driver: Firefox,
+    region: str,
+    address_autofill: AddressFill,
+    util: Utilities,
+    address_autofill_popup: AutofillPopup,
 ):
     """
     C2886581 - Verify the Capture Doorhanger is displayed after entering valid Address data
     """
-
-    # Instantiate objects
-    address_autofill = AddressFill(driver)
-    address_autofill_popup = AutofillPopup(driver)
-    util = Utilities()
-    about_config = AboutConfig(driver)
-
-    # Change pref value of region
-    about_config.change_config_value("browser.search.region", region)
-
     # Create fake data and fill it in
     address_autofill.open()
     address_autofill_data = util.fake_autofill_data(region)

--- a/l10n_CM/Unified/test_demo_ad_name_org_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_name_org_captured_in_doorhanger_and_stored.py
@@ -2,10 +2,9 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object_about_pages import AboutConfig
 from modules.page_object_autofill import AddressFill
 from modules.page_object_prefs import AboutPrefs
-from modules.util import BrowserActions, Utilities
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -14,21 +13,15 @@ def test_case():
 
 
 def test_demo_ad_name_org_captured_in_doorhanger_and_stored(
-    driver: Firefox, region: str
+    driver: Firefox,
+    region: str,
+    address_autofill: AddressFill,
+    util: Utilities,
+    address_autofill_popup: AutofillPopup,
 ):
     """
     C2888701 - Verify name/org fields are captured in the Capture Doorhanger and stored in about:preferences
     """
-    # instantiate objects
-    address_autofill = AddressFill(driver)
-    address_autofill_popup = AutofillPopup(driver)
-    util = Utilities()
-    about_config = AboutConfig(driver)
-    browser_action_obj = BrowserActions(driver)
-
-    # Change pref value of region
-    about_config.change_config_value("browser.search.region", region)
-
     # create fake data and fill it in
     address_autofill.open()
     address_autofill_data = util.fake_autofill_data(region)
@@ -50,8 +43,7 @@ def test_demo_ad_name_org_captured_in_doorhanger_and_stored(
 
     # Navigate to about:preferences#privacy => "Autofill" section
     about_prefs = AboutPrefs(driver, category="privacy").open()
-    iframe = about_prefs.get_save_addresses_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs.switch_to_saved_addresses_popup_iframe()
 
     # The address saved in step 2 is listed in the "Saved addresses" modal: name and organization
     elements = about_prefs.get_elements("saved-addresses-values")

--- a/l10n_CM/Unified/test_demo_cc_add_new_credit_card.py
+++ b/l10n_CM/Unified/test_demo_cc_add_new_credit_card.py
@@ -3,8 +3,8 @@ import json
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.page_object import AboutConfig, AboutPrefs
-from modules.util import BrowserActions, Utilities
+from modules.page_object import AboutPrefs
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -12,25 +12,20 @@ def test_case():
     return "2886595"
 
 
-def test_create_new_cc_profile(driver: Firefox, region: str):
+def test_create_new_cc_profile(
+    driver: Firefox,
+    region: str,
+    util: Utilities,
+    about_prefs: AboutPrefs,
+    about_prefs_cc_popup: AboutPrefs,
+):
     """
     C2886595 - Tests you can create and save a new Credit Card profile
     """
 
-    # Instantiate objects
-    util = Utilities()
-    browser_action_obj = BrowserActions(driver)
-    about_prefs = AboutPrefs(driver, category="privacy")
-    about_prefs_cc_popup = AboutPrefs(driver)
-    about_config = AboutConfig(driver)
-
-    # Change pref value of region
-    about_config.change_config_value("browser.search.region", region)
-
     # Go to about:preferences#privacy and open Saved Payment Methods
     about_prefs.open()
-    iframe = about_prefs.get_saved_payments_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs.switch_to_saved_payments_popup_iframe()
 
     # Save CC information using fake data
     credit_card_sample_data = util.fake_credit_card_data()

--- a/l10n_CM/Unified/test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py
+++ b/l10n_CM/Unified/test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py
@@ -2,7 +2,6 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutConfig
 from modules.page_object_autofill import CreditCardFill
 from modules.util import Utilities
 
@@ -12,20 +11,16 @@ def test_case():
     return "2889441"
 
 
-def test_cc_check_door_hanger_is_displayed(driver: Firefox, region: str):
+def test_cc_check_door_hanger_is_displayed(
+    driver: Firefox,
+    region: str,
+    util: Utilities,
+    address_autofill_popup: AutofillPopup,
+    credit_card_fill_obj: CreditCardFill,
+):
     """
     C2889441 - Ensures that the door hanger is displayed after filling credit card info
     """
-
-    # Instantiate objects
-    autofill_popup_obj = AutofillPopup(driver)
-    credit_card_fill_obj = CreditCardFill(driver)
-    util = Utilities()
-    about_config = AboutConfig(driver)
-
-    # Change pref value of region
-    about_config.change_config_value("browser.search.region", region)
-
     # Navigate to page
     credit_card_fill_obj.open()
 
@@ -34,4 +29,4 @@ def test_cc_check_door_hanger_is_displayed(driver: Firefox, region: str):
     credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
 
     # Check if an element from the door hanger is visible
-    autofill_popup_obj.element_visible("doorhanger-save-button")
+    address_autofill_popup.element_visible("doorhanger-save-button")

--- a/l10n_CM/Unified/test_demo_cc_dropdown-presence.py
+++ b/l10n_CM/Unified/test_demo_cc_dropdown-presence.py
@@ -3,7 +3,7 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object import AboutPrefs, CreditCardFill
-from modules.util import BrowserActions, Utilities
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -11,23 +11,22 @@ def test_case():
     return "2886598"
 
 
-def test_dropdown_presence_credit_card(driver: Firefox):
+def test_dropdown_presence_credit_card(
+    driver: Firefox,
+    util: Utilities,
+    address_autofill_popup: AutofillPopup,
+    about_prefs: AboutPrefs,
+    about_prefs_cc_popup: AboutPrefs,
+    credit_card_fill_obj: CreditCardFill,
+):
     """
     C2886598 - Verify autofill dropdown is displayed only for the eligible fields after a credit card is saved
     """
 
-    # Initialize objects
-    util = Utilities()
-    about_prefs = AboutPrefs(driver, category="privacy")
-    about_prefs_cc_popup = AboutPrefs(driver)
-    browser_action_obj = BrowserActions(driver)
-    credit_card_fill_obj = CreditCardFill(driver)
-    autofill_popup_obj = AutofillPopup(driver)
-
     # Save a credit card in about:preferences
     about_prefs.open()
-    iframe = about_prefs.get_saved_payments_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs.switch_to_saved_payments_popup_iframe()
+
     credit_card_sample_data = util.fake_credit_card_data()
     about_prefs_cc_popup.click_on(
         "panel-popup-button", labels=["autofill-manage-add-button"]
@@ -38,4 +37,4 @@ def test_dropdown_presence_credit_card(driver: Firefox):
     credit_card_fill_obj.open()
 
     # Verify autofill dropdown is displayed only for the eligible fields
-    credit_card_fill_obj.verify_autofill_dropdown_all_fields(autofill_popup_obj)
+    credit_card_fill_obj.verify_autofill_dropdown_all_fields(address_autofill_popup)

--- a/l10n_CM/Unified/test_us_demo_addy_verify_new_address_added.py
+++ b/l10n_CM/Unified/test_us_demo_addy_verify_new_address_added.py
@@ -1,0 +1,61 @@
+from typing import Dict
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object_prefs import AboutPrefs
+from modules.util import Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2886580"
+
+
+@pytest.fixture()
+def region():
+    return "US"
+
+
+@pytest.fixture()
+def add_prefs(region: str):
+    return [
+        ("browser.search.region", region),
+        ("extensions.formautofill.creditCards.supportedCountries", region),
+        ("extensions.formautofill.addresses.supported", "on"),
+    ]
+
+
+def test_verify_new_address_is_added(
+    driver: Firefox, region: str, about_prefs: AboutPrefs, util: Utilities
+):
+    """
+    C2886580: Verify that a new Address can be added
+    """
+    # invert state_province_abbr to help with verification
+    inverted_state_province_abbr = {v: k for k, v in util.state_province_abbr.items()}
+    # generate fake data for region
+    address_autofill_data = util.fake_autofill_data(region)
+
+    # open saved addresses and add entry
+    about_prefs.open()
+    about_prefs.add_entry_to_saved_addresses(address_autofill_data)
+
+    # verify that the address saved is the same.
+    # The address saved in step 2 is listed in the "Saved addresses" modal: name and organization
+    elements = about_prefs.get_element("saved-addresses-values").text.split(",")
+    address_match = all(
+        data_sanitizer(element, region, inverted_state_province_abbr)
+        in address_autofill_data.__dict__.values()
+        for element in elements
+    )
+    assert address_match, "Address found is not equal to address created!"
+
+
+def data_sanitizer(value: str, region: str, state_province: Dict):
+    value = value.strip()
+    if value[0] == "+":
+        return value[1:]
+    elif len(value) == 2 and value != region:
+        return state_province.get(value, value)
+    return value

--- a/l10n_CM/region/US.json
+++ b/l10n_CM/region/US.json
@@ -6,6 +6,7 @@
         "test_demo_ad_doorhanger_shown_on_valid_address_submission.py",
         "test_demo_ad_name_org_captured_in_doorhanger_and_stored.py",
         "test_demo_cc_dropdown-presence.py",
-        "test_demo_ad_address_data_captured_in_doorhanger_and_stored.py"
+        "test_demo_ad_address_data_captured_in_doorhanger_and_stored.py",
+        "test_verify_new_address_is_added.py"
     ]
 }

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -1,4 +1,9 @@
 {
+    "add-address": {
+        "selectorData": "add",
+        "strategy": "id",
+        "groups": []
+    },
     "search-engine-dropdown-root": {
         "selectorData": "defaultEngine",
         "strategy": "id",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -2,6 +2,7 @@ import re
 from time import sleep
 from typing import List
 
+from selenium.webdriver import Firefox
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
@@ -25,6 +26,10 @@ class AboutPrefs(BasePage):
 
     URL_TEMPLATE = "about:preferences#{category}"
     iframe = None
+
+    def __init__(self, driver: Firefox, **kwargs):
+        super().__init__(driver, **kwargs)
+        self.driver = driver
 
     # number of tabs to reach the country tab
     TABS_TO_COUNTRY = 6
@@ -237,6 +242,14 @@ class AboutPrefs(BasePage):
         iframe = self.get_element("browser-popup")
         return iframe
 
+    def switch_to_saved_payments_popup_iframe(self) -> BasePage:
+        """
+        Switch to saved payments popup frame.
+        """
+        saved_payments = self.get_saved_payments_popup_iframe()
+        self.driver.switch_to.frame(saved_payments)
+        return self
+
     def update_cc_field_panel(self, num_tabs: int, new_info: str) -> BasePage:
         """
         Updates a field in the credit card popup panel in about:prefs by pressing the number of tabs and sending the new information
@@ -256,14 +269,35 @@ class AboutPrefs(BasePage):
             self.actions.send_keys(Keys.TAB).perform()
 
         self.actions.send_keys(Keys.ENTER).perform()
+        return self
 
-    def get_save_addresses_popup_iframe(self) -> WebElement:
+    def get_saved_addresses_popup_iframe(self) -> WebElement:
         """
         Returns the iframe object for the dialog panel in the popup
         """
         self.get_element("prefs-button", labels=["Saved addresses"]).click()
         iframe = self.get_element("browser-popup")
         return iframe
+
+    def switch_to_saved_addresses_popup_iframe(self) -> BasePage:
+        """
+        switch to save addresses popup frame.
+        """
+        save_addresses = self.get_saved_addresses_popup_iframe()
+        self.driver.switch_to.frame(save_addresses)
+        return self
+
+    def add_entry_to_saved_addresses(self, address_data: AutofillAddressBase):
+        """
+        open saved addresses and add a new entry.
+
+        Arguments:
+            address_data: fake address data specific to region specified.
+        """
+        self.switch_to_saved_addresses_popup_iframe()
+        self.get_element("add-address").click()
+        self.fill_autofill_panel_information(address_data)
+        return self
 
     def get_password_exceptions_popup_iframe(self) -> WebElement:
         """

--- a/modules/util.py
+++ b/modules/util.py
@@ -33,7 +33,73 @@ class Utilities:
     """
 
     def __init__(self):
-        pass
+        self.state_province_abbr = {
+            # US States
+            "Alabama": "AL",
+            "Alaska": "AK",
+            "Arizona": "AZ",
+            "Arkansas": "AR",
+            "California": "CA",
+            "Colorado": "CO",
+            "Connecticut": "CT",
+            "Delaware": "DE",
+            "Florida": "FL",
+            "Georgia": "GA",
+            "Hawaii": "HI",
+            "Idaho": "ID",
+            "Illinois": "IL",
+            "Indiana": "IN",
+            "Iowa": "IA",
+            "Kansas": "KS",
+            "Kentucky": "KY",
+            "Louisiana": "LA",
+            "Maine": "ME",
+            "Maryland": "MD",
+            "Massachusetts": "MA",
+            "Michigan": "MI",
+            "Minnesota": "MN",
+            "Mississippi": "MS",
+            "Missouri": "MO",
+            "Montana": "MT",
+            "Nebraska": "NE",
+            "Nevada": "NV",
+            "New Hampshire": "NH",
+            "New Jersey": "NJ",
+            "New Mexico": "NM",
+            "New York": "NY",
+            "North Carolina": "NC",
+            "North Dakota": "ND",
+            "Ohio": "OH",
+            "Oklahoma": "OK",
+            "Oregon": "OR",
+            "Pennsylvania": "PA",
+            "Rhode Island": "RI",
+            "South Carolina": "SC",
+            "South Dakota": "SD",
+            "Tennessee": "TN",
+            "Texas": "TX",
+            "Utah": "UT",
+            "Vermont": "VT",
+            "Virginia": "VA",
+            "Washington": "WA",
+            "West Virginia": "WV",
+            "Wisconsin": "WI",
+            "Wyoming": "WY",
+            # Canadian Provinces
+            "Alberta": "AB",
+            "British Columbia": "BC",
+            "Manitoba": "MB",
+            "New Brunswick": "NB",
+            "Newfoundland and Labrador": "NL",
+            "Nova Scotia": "NS",
+            "Ontario": "ON",
+            "Prince Edward Island": "PE",
+            "Quebec": "QC",
+            "Saskatchewan": "SK",
+            "Northwest Territories": "NT",
+            "Nunavut": "NU",
+            "Yukon": "YT",
+        }
 
     def remove_file(self, path: str):
         try:
@@ -401,26 +467,8 @@ class Utilities:
         :param full_name: The full name of the state, province, or region.
         :return: The corresponding abbreviation or "Not Found" if not in the dictionary.
         """
-        state_province_abbr = {
-            # US States
-            "Alabama": "AL", "Alaska": "AK", "Arizona": "AZ", "Arkansas": "AR", "California": "CA",
-            "Colorado": "CO", "Connecticut": "CT", "Delaware": "DE", "Florida": "FL", "Georgia": "GA",
-            "Hawaii": "HI", "Idaho": "ID", "Illinois": "IL", "Indiana": "IN", "Iowa": "IA",
-            "Kansas": "KS", "Kentucky": "KY", "Louisiana": "LA", "Maine": "ME", "Maryland": "MD",
-            "Massachusetts": "MA", "Michigan": "MI", "Minnesota": "MN", "Mississippi": "MS", "Missouri": "MO",
-            "Montana": "MT", "Nebraska": "NE", "Nevada": "NV", "New Hampshire": "NH", "New Jersey": "NJ",
-            "New Mexico": "NM", "New York": "NY", "North Carolina": "NC", "North Dakota": "ND", "Ohio": "OH",
-            "Oklahoma": "OK", "Oregon": "OR", "Pennsylvania": "PA", "Rhode Island": "RI", "South Carolina": "SC",
-            "South Dakota": "SD", "Tennessee": "TN", "Texas": "TX", "Utah": "UT", "Vermont": "VT",
-            "Virginia": "VA", "Washington": "WA", "West Virginia": "WV", "Wisconsin": "WI", "Wyoming": "WY",
 
-            # Canadian Provinces
-            "Alberta": "AB", "British Columbia": "BC", "Manitoba": "MB", "New Brunswick": "NB",
-            "Newfoundland and Labrador": "NL", "Nova Scotia": "NS", "Ontario": "ON", "Prince Edward Island": "PE",
-            "Quebec": "QC", "Saskatchewan": "SK", "Northwest Territories": "NT", "Nunavut": "NU", "Yukon": "YT",
-        }
-
-        return state_province_abbr.get(full_name, "Not Found")
+        return self.state_province_abbr.get(full_name, "Not Found")
 
 
 class BrowserActions:


### PR DESCRIPTION
### Description

- Adds a new test to verify addition in saved addresses for US region.
- Minor changes in the other tests in the l10n test suite

### Bugzilla bug ID

**Testrail:** [2886580](https://mozilla.testrail.io/index.php?/cases/view/2886580&group_by=cases:section_id&group_order=asc&display_deleted_cases=0&group_id=579542)
**Link:**

### Type of change

Please delete options that are not relevant.

- [x] New Test
- [x] Other Changes (Please specify)

### Comments / Concerns

- Added a test that create a saved address entry and verifies the address for US region.
- move class instantiation in the other tests in l10n to the `contest`.
- removed any explicit region change in the test itself since the region was specified in the `conftest`. 
- added some additional methods in `AboutPrefs` to streamline the process of using the saved addresses.
