### PR TITLE
retry collect executables url on failure

### DIFF
--- a/collect_executables.py
+++ b/collect_executables.py
@@ -152,8 +152,17 @@ else:
     fx_download_dir_url = f"https://archive.mozilla.org/pub/firefox/candidates/{latest_beta_ver}-candidates/build{build}/{get_fx_platform()}/{language}/"
     response = requests.get(fx_download_dir_url)
     status = response.status_code
-    if status < 300:
-        response_text = response.text
+    response_text = None
+    for _ in range(3):
+        if status < 300:
+            response_text = response.text
+        else:
+            sleep(3)
+            response = requests.get(fx_download_dir_url)
+            status = response.status_code
+
+    if response_text is None:
+        exit(f"Could not find build at {fx_download_dir_url}.")
 
     # Parse the HTML content
     soup = BeautifulSoup(response_text, "html.parser")


### PR DESCRIPTION
Collect executables bombs out weirdly if the FTP site is not responsive. Retry and give an error.