### PR TITLE
Anca/l10n(demo) - cc autofill yellow highlight

### DIFF
--- a/l10n_CM/Unified/test_demo_cc_yellow_highlight.py
+++ b/l10n_CM/Unified/test_demo_cc_yellow_highlight.py
@@ -1,0 +1,43 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object import AboutPrefs, CreditCardFill
+from modules.util import BrowserActions, Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2886601"
+
+
+def test_cc_yellow_highlight(driver: Firefox):
+    """
+    C2886601 - Verify the yellow highlight appears on autofilled fields and make sure csv field is not highlighted
+    """
+
+    # Initialize objects
+    util = Utilities()
+    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs_cc_popup = AboutPrefs(driver)
+    browser_action_obj = BrowserActions(driver)
+    credit_card_fill_obj = CreditCardFill(driver)
+    autofill_popup = AutofillPopup(driver)
+
+    # Save a credit card in about:preferences
+    about_prefs.open()
+    iframe = about_prefs.get_saved_payments_popup_iframe()
+    browser_action_obj.switch_to_iframe_context(iframe)
+    credit_card_sample_data = util.fake_credit_card_data()
+    about_prefs_cc_popup.click_on(
+        "panel-popup-button", labels=["autofill-manage-add-button"]
+    )
+    about_prefs.fill_cc_panel_information(credit_card_sample_data)
+
+    # Open the credit card fill form and trigger the autofill option
+    credit_card_fill_obj.open()
+    credit_card_fill_obj.click_on("form-field", labels=["cc-name"])
+    autofill_popup.click_autofill_form_option()
+
+    # Verify that all fields have the yellow highlight, except for the cc-csv field
+    credit_card_fill_obj.verify_field_yellow_highlights()

--- a/l10n_CM/region/CA.json
+++ b/l10n_CM/region/CA.json
@@ -9,6 +9,7 @@
         "test_demo_cc_dropdown-presence.py",
         "test_demo_cc_clear_form.py",
         "test_demo_cc_dropdown-presence.py",
-        "test_demo_ad_autofill_name_org.py"
+        "test_demo_ad_autofill_name_org.py",
+        "test_demo_cc_yellow_highlight.py"
     ]
 }

--- a/l10n_CM/region/DE.json
+++ b/l10n_CM/region/DE.json
@@ -9,6 +9,7 @@
         "test_demo_ad_address_data_captured_in_doorhanger_and_stored.py",
         "test_demo_ad_autofill_name_org.py",
         "test_demo_ad_address_data_captured_in_doorhanger_and_stored.py",
-        "test_demo_cc_clear_form.py"
+        "test_demo_cc_clear_form.py",
+        "test_demo_cc_yellow_highlight.py"
     ]
 }

--- a/l10n_CM/region/FR.json
+++ b/l10n_CM/region/FR.json
@@ -10,6 +10,7 @@
         "test_demo_ad_autofill_name_org.py",
         "test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py",
         "test_demo_cc_dropdown-presence.py",
-        "test_demo_cc_clear_form.py"
+        "test_demo_cc_clear_form.py",
+        "test_demo_cc_yellow_highlight.py"
     ]
 }

--- a/l10n_CM/region/US.json
+++ b/l10n_CM/region/US.json
@@ -10,6 +10,7 @@
         "test_demo_ad_autofill_name_org.py",
         "test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py",
         "test_demo_cc_dropdown-presence.py",
-        "test_demo_cc_clear_form.py"
+        "test_demo_cc_clear_form.py",
+        "test_demo_cc_yellow_highlight.py"
     ]
 }

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 from selenium.webdriver.support import expected_conditions as EC
@@ -320,6 +321,53 @@ class CreditCardFill(Autofill):
             self.double_click("form-field", labels=["cc-csc"])
             autofill_popup_obj.ensure_autofill_dropdown_not_visible()
 
+    def verify_field_yellow_highlights(self, expected_highlighted_fields=None):
+        """
+        Verifies that specified form fields have the expected highlight state
+        """
+        if expected_highlighted_fields is None:
+            expected_highlighted_fields = (
+                self.fields
+            )  # Uses the default fields defined in the class
+
+        browser_action_obj = BrowserActions(self.driver)
+
+        def is_yellow_highlight(rgb_tuple):
+            if len(rgb_tuple) == 3:
+                r, g, b = rgb_tuple
+            elif len(rgb_tuple) >= 4:
+                r, g, b, *_ = rgb_tuple
+            else:
+                return False
+            return r >= 250 and g >= 250 and 180 < b < 220
+
+        all_fields = self.fields + ["cc-csc"]
+
+        for field_name in all_fields:
+            # Bring the field into focus
+            self.click_on("form-field", labels=[field_name])
+
+            # Get color of the fields
+            selector = self.get_selector("form-field", labels=[field_name])
+            colors = browser_action_obj.get_all_colors_in_element(selector)
+            logging.info(f"Colors found in {field_name}: {colors}")
+
+            is_field_highlighted = any(is_yellow_highlight(color) for color in colors)
+            should_be_highlighted = field_name in expected_highlighted_fields
+
+            if should_be_highlighted:
+                assert is_field_highlighted, (
+                    f"Expected yellow highlight on {field_name}, but none found."
+                )
+                logging.info(f"Yellow highlight correctly found in {field_name}.")
+            else:
+                assert not is_field_highlighted, (
+                    f"Expected no yellow highlight on {field_name}, but found one."
+                )
+                logging.info(f"No yellow highlight found in {field_name}, as expected.")
+
+        return self
+
 
 class LoginAutofill(Autofill):
     """
@@ -414,7 +462,9 @@ class AddressFill(Autofill):
         elem.clear()
         elem.send_keys(new_value)
 
-    def verify_autofill_data(self, autofill_data: AutofillAddressBase, region: str, util: Utilities):
+    def verify_autofill_data(
+        self, autofill_data: AutofillAddressBase, region: str, util: Utilities
+    ):
         """
         Verifies that the autofill data matches the expected values.
 
@@ -465,7 +515,9 @@ class AddressFill(Autofill):
             if field == "Phone":
                 actual = util.normalize_phone_number(actual)
 
-            assert actual == expected, f"Mismatch in {field}: Expected '{expected}', but got '{actual}'"
+            assert actual == expected, (
+                f"Mismatch in {field}: Expected '{expected}', but got '{actual}'"
+            )
 
 
 class TextAreaFormAutofill(Autofill):


### PR DESCRIPTION
### Description

- Verify that the fields inside the demo payment form have the specific yellow highlight  (except for the csv one) after an entry is selected from the autofill dropdown.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2886601**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943192**

### Type of change

Please delete options that are not relevant.

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A
