### PR TITLE
Figured out switch to new window consistently.

### DIFF
--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -681,23 +681,16 @@ class BasePage(Page):
         self.driver.switch_to.window(self.driver.window_handles[-1])
         return self
 
+    def switch_to_new_window(self) -> Page:
+        """Switch to the most recently opened window. Can be a standard or private window"""
+        all_window_handles = self.driver.window_handles
+        self.driver.switch_to.window(all_window_handles[-1])
+        return self
+
     def wait_for_num_windows(self, num: int) -> Page:
         """Wait for the number of open tabs + windows to equal given int"""
         with self.driver.context(self.driver.CONTEXT_CONTENT):
             return self.wait_for_num_tabs(num)
-
-    def switch_to_new_window(self) -> Page:
-        """Switch to newest window"""
-        with self.driver.context(self.driver.CONTEXT_CONTENT):
-            return self.switch_to_new_tab()
-
-    def switch_to_new_private_window(self) -> Page:
-        "Switch to new private window"
-        non_private_window = self.driver.current_window_handle
-        original_window_idx = self.driver.window_handles.index(non_private_window)
-        private_window = self.driver.window_handles[1 - original_window_idx]
-        self.driver.switch_to.window(private_window)
-        return self
 
     def switch_to_frame(self, frame: str, labels=[]) -> Page:
         """Switch to inline document frame"""

--- a/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
+++ b/tests/security_and_privacy/test_cookies_not_saved_private_browsing.py
@@ -24,7 +24,7 @@ def test_cookies_not_saved_private_browsing(driver: Firefox):
 
     # Open new private window
     panel_ui.open_private_window()
-    nav.switch_to_new_private_window()
+    nav.switch_to_new_window()
 
     # Open the Google page and perform a search
     google_search.open()

--- a/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
+++ b/tests/security_and_privacy/test_downloads_from_private_not_leaked.py
@@ -35,12 +35,12 @@ def test_downloads_from_private_not_leaked(driver: Firefox, delete_files, screen
 
     # We've deleted relevant downloads_file just to be safe
     non_private_window = driver.current_window_handle
-    panelui = PanelUi(driver).open_panel_menu()
+    panelui = PanelUi(driver)
+    panelui.open_panel_menu()
     panelui.select_panel_setting("new-private-window-option")
-    panelui.wait_for_num_windows(2)
 
     nav = Navigation(driver)
-    nav.switch_to_new_private_window()
+    nav.switch_to_new_window()
 
     about_downloads = AboutDownloads(driver)
     about_downloads.open()

--- a/tests/security_and_privacy/test_https_enabled_private_browsing.py
+++ b/tests/security_and_privacy/test_https_enabled_private_browsing.py
@@ -27,7 +27,7 @@ def test_https_first_mode_in_private_browsing(driver: Firefox):
     hamburger.open_private_window()
 
     nav = Navigation(driver)
-    nav.switch_to_new_private_window()
+    nav.switch_to_new_window()
     driver.get(HTTP_SITE)
 
     # Wait for the URL to be redirected to HTTPS

--- a/tests/security_and_privacy/test_open_link_in_private_window.py
+++ b/tests/security_and_privacy/test_open_link_in_private_window.py
@@ -24,8 +24,7 @@ def test_open_link_in_private_window(driver: Firefox):
     sleep(1)
     context_menu.click_and_hide_menu("context-menu-open-link-in-new-private-window")
 
-    nav.wait_for_num_windows(2)
-    nav.switch_to_new_private_window()
+    nav.switch_to_new_window()
     sleep(1)
     with driver.context(driver.CONTEXT_CHROME):
         nav.title_contains("Private Browsing")

--- a/tests/security_and_privacy/test_private_browser_password_doorhanger.py
+++ b/tests/security_and_privacy/test_private_browser_password_doorhanger.py
@@ -30,7 +30,7 @@ def test_no_password_doorhanger_private_browsing(driver: Firefox):
 
     # Open Private Window
     panel_ui.open_private_window()
-    nav.switch_to_new_private_window()
+    nav.switch_to_new_window()
 
     # Open the form, fill the user and password
     login_auto_fill.open()

--- a/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
+++ b/tests/security_and_privacy/test_private_session_awesome_bar_exclusion.py
@@ -30,7 +30,7 @@ def test_websites_visited_in_private_browser_not_displayed_in_awesome_bar(
     panel_ui = PanelUi(driver)
 
     panel_ui.open_private_window()
-    panel_ui.switch_to_new_private_window()
+    panel_ui.switch_to_new_window()
 
     for url in WEBSITES:
         driver.get(url)

--- a/tests/security_and_privacy/test_private_session_history_exclusion.py
+++ b/tests/security_and_privacy/test_private_session_history_exclusion.py
@@ -29,7 +29,7 @@ def test_websites_visited_in_private_browser_not_displayed_in_history(driver: Fi
 
     panel_ui = PanelUi(driver).open()
     panel_ui.open_private_window()
-    panel_ui.switch_to_new_private_window()
+    panel_ui.switch_to_new_window()
 
     driver.get(YOUTUBE_URL)
     driver.get(FACEBOOK_URL)

--- a/tests/security_and_privacy/test_private_window_from_panelui.py
+++ b/tests/security_and_privacy/test_private_window_from_panelui.py
@@ -12,8 +12,8 @@ def test_case():
 
 def test_private_window_from_panelui(driver: Firefox):
     """C101660 - Private Browsing can be successfully opened via the Hamburger menu"""
-    panelui = PanelUi(driver).open_panel_menu()
+    panelui = PanelUi(driver)
+    panelui.open_panel_menu()
     panelui.select_panel_setting("new-private-window-option")
-    panelui.wait_for_num_windows(2)
-    panelui.switch_to_new_private_window()
+    panelui.switch_to_new_window()
     AboutPrivatebrowsing(driver).wait_for_page_to_load()

--- a/tests/security_and_privacy/test_third_party_content_blocked_private_browsing.py
+++ b/tests/security_and_privacy/test_third_party_content_blocked_private_browsing.py
@@ -36,7 +36,7 @@ def test_third_party_content_blocked_private_browsing_cross_site(driver: Firefox
 
     # open the new window
     panel_ui.open_private_window()
-    nav.switch_to_new_private_window()
+    nav.switch_to_new_window()
 
     # open the website, ensure the blocking is taking place by continuously refreshing website until indicated
     tracker_website.open()

--- a/tests/security_and_privacy/test_undo_close_tab_private_browsing.py
+++ b/tests/security_and_privacy/test_undo_close_tab_private_browsing.py
@@ -27,7 +27,7 @@ def test_undo_close_tab_private_browsing(driver: Firefox, sys_platform: str):
 
     # open a new private window and open a new tab
     panel_ui.open_private_window()
-    tabs.switch_to_new_private_window()
+    tabs.switch_to_new_window()
 
     # open a new tab
     tabs.new_tab_by_button()


### PR DESCRIPTION
### Description
I wasn't quite doing this right in switch to new private window.  turns out, it's no different than switching to a new window (or new tab);  Get the handles of all windows, then switch to the last one.

#### Bugzilla bug ID
[Bug 1049884](https://bugzilla.mozilla.org/show_bug.cgi?id=1949884)

#### Type of change
- [X] Stability. (hopefully)

### How does this resolve / make progress on that bug?
resolves

### Comments

