### PR TITLE
Hani/fix phone not matching DE and FR

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
@@ -42,15 +42,11 @@ def test_demo_ad_email_phone_captured_in_doorhanger_and_stored(
     if expected_phone:
         with driver.context(driver.CONTEXT_CHROME):
             actual_phone = autofill_popup.get_element("address-doorhanger-phone").text
-
         normalize_expected = util.normalize_regional_phone_numbers(expected_phone, region)
         normalized_actual = util.normalize_regional_phone_numbers(actual_phone, region)
-
         assert normalized_actual == normalize_expected, (
             f"Phone number mismatch for {region} | Expected: {normalize_expected}, Got: {normalized_actual}"
         )
-
-        print(f"DEBUG: {region} | Input: {normalized_actual} | Output: {normalize_expected}")  # Debugging print
 
     # Click the "Save" button
     autofill_popup.click_doorhanger_button("save")

--- a/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
@@ -38,7 +38,7 @@ def test_demo_ad_email_phone_captured_in_doorhanger_and_stored(
 
     # containing phone field
     expected_phone = address_autofill_data.telephone
-    # Skip verification if no phone number isn't provided
+    # Skip verification if phone number isn't provided
     if expected_phone:
         with driver.context(driver.CONTEXT_CHROME):
             actual_phone = autofill_popup.get_element("address-doorhanger-phone").text

--- a/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
@@ -38,11 +38,19 @@ def test_demo_ad_email_phone_captured_in_doorhanger_and_stored(
 
     # containing phone field
     expected_phone = address_autofill_data.telephone
-    with driver.context(driver.CONTEXT_CHROME):
-        actual_phone = autofill_popup.get_element("address-doorhanger-phone").text
-    normalize_expected = util.normalize_phone_number(expected_phone)
-    normalized_actual = util.normalize_phone_number(actual_phone)
-    assert normalized_actual == normalize_expected
+    # Skip verification if no phone number isn't provided
+    if expected_phone:
+        with driver.context(driver.CONTEXT_CHROME):
+            actual_phone = autofill_popup.get_element("address-doorhanger-phone").text
+
+        normalize_expected = util.normalize_regional_phone_numbers(expected_phone, region)
+        normalized_actual = util.normalize_regional_phone_numbers(actual_phone, region)
+
+        assert normalized_actual == normalize_expected, (
+            f"Phone number mismatch for {region} | Expected: {normalize_expected}, Got: {normalized_actual}"
+        )
+
+        print(f"DEBUG: {region} | Input: {normalized_actual} | Output: {normalize_expected}")  # Debugging print
 
     # Click the "Save" button
     autofill_popup.click_doorhanger_button("save")

--- a/modules/util.py
+++ b/modules/util.py
@@ -32,10 +32,6 @@ class Utilities:
     Methods that may be useful, that have nothing to do with Selenium.
     """
 
-    # COUNTRY_CODES = {
-    #     "US": "1", "CA": "1", "FR": "33", "DE": "49", "UK": "44", "JP": "81"
-    # }
-
     def __init__(self):
         self.state_province_abbr = {
             # US States
@@ -497,10 +493,9 @@ class Utilities:
             "DE": "49",
         }
 
-        # Remove phone number extensions (e.g., "x555" or "ext 555")
+        # Sub out anything that matches this regex statement with an empty string to get rid of extensions in generated phone numbers
         phone = re.sub(r"\s*(?:x|ext)\s*\d*$", "", phone, flags=re.IGNORECASE)
-
-        # Remove all non-numeric characters
+        # Sub out anything that is not a digit with the empty string to ensure the phone number is formatted with no spaces or special characters
         digits = re.sub(r"\D", "", phone)
 
         # Determine country code
@@ -511,12 +506,14 @@ class Utilities:
         for code in country_codes.values():
             if digits.startswith(code):
                 country_code = code
-                local_number = digits[len(code):]  # Remove country code from local number
+                # Remove country code from local number
+                local_number = digits[len(code):]
                 break
 
         # Handle leading zero in local numbers (France & Germany)
         if region in ["FR", "DE"] and local_number.startswith("0"):
-            local_number = local_number[1:]  # Remove the leading zero
+            # Remove the leading zero
+            local_number = local_number[1:]
 
         # Validate local number length
         if len(local_number) < 6:  # Too short to be valid


### PR DESCRIPTION
### Description

For DE and FR sometime tests were failing because actual and expected phone numbers are not matching ('33276733508' == '330276733508') there was a zero sometime added after country prefix for expected results.

### Bugzilla bug ID

**Testrail:**
**Link:**

### Type of change

- [x] Other Changes (Fix an issue)

### How does this resolve / make progress on that bug?

Fix an issue.

### Screenshots / Explanations

N/A

### Comments / Concerns

N/A
