### PR TITLE
Anca/l10n demo - addresses yellow highlight on name and organization fields

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_yellow_highlight.py
+++ b/l10n_CM/Unified/test_demo_ad_yellow_highlight.py
@@ -8,13 +8,16 @@ from modules.util import Utilities
 
 @pytest.fixture()
 def test_case():
-    return "2888569"
+    return "2888559"
 
 
-def test_address_yellow_highlight_on_name_org_fields(driver: Firefox, region: str):
+def test_address_yellow_highlight_on_name_organization_fields(
+    driver: Firefox, region: str
+):
     """
-    C2888569 - Verify Autofill functionality when selecting an entry from the dropdown for tele/email fields
+    C2888559 - Verify the yellow highlight appears on autofilled fields for name and organization.
     """
+
     # Instantiate objects
     address_autofill = AddressFill(driver)
     address_autofill_popup = AutofillPopup(driver)
@@ -28,15 +31,15 @@ def test_address_yellow_highlight_on_name_org_fields(driver: Firefox, region: st
     # Click the "Save" button
     address_autofill_popup.click_doorhanger_button("save")
 
-    # Double inside phone field and select a saved address entry from the dropdown
+    # Double click inside phone field and select a saved address entry from the dropdown
     address_autofill.double_click("form-field", labels=["name"])
 
     # Click on the first element from the autocomplete dropdown
     first_item = address_autofill_popup.get_nth_element(1)
     address_autofill_popup.click_on(first_item)
 
-    # Verify highlighted fields
+    # Verify the name and organization fields are highlighted
     address_autofill.verify_field_yellow_highlights(
-        fields_to_test=["name", "organization"],  # Only test name & org
+        fields_to_test=["name", "organization"],
         expected_highlighted_fields=["name", "organization"],
     )

--- a/l10n_CM/Unified/test_demo_ad_yellow_highlight.py
+++ b/l10n_CM/Unified/test_demo_ad_yellow_highlight.py
@@ -1,0 +1,42 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import AddressFill
+from modules.util import Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2888569"
+
+
+def test_address_yellow_highlight_on_name_org_fields(driver: Firefox, region: str):
+    """
+    C2888569 - Verify Autofill functionality when selecting an entry from the dropdown for tele/email fields
+    """
+    # Instantiate objects
+    address_autofill = AddressFill(driver)
+    address_autofill_popup = AutofillPopup(driver)
+    util = Utilities()
+
+    # Create fake data and fill it in
+    address_autofill.open()
+    address_autofill_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(address_autofill_data)
+
+    # Click the "Save" button
+    address_autofill_popup.click_doorhanger_button("save")
+
+    # Double inside phone field and select a saved address entry from the dropdown
+    address_autofill.double_click("form-field", labels=["name"])
+
+    # Click on the first element from the autocomplete dropdown
+    first_item = address_autofill_popup.get_nth_element(1)
+    address_autofill_popup.click_on(first_item)
+
+    # Verify highlighted fields
+    address_autofill.verify_field_yellow_highlights(
+        fields_to_test=["name", "organization"],  # Only test name & org
+        expected_highlighted_fields=["name", "organization"],
+    )

--- a/l10n_CM/region/Unified.json
+++ b/l10n_CM/region/Unified.json
@@ -12,6 +12,7 @@
         "test_demo_cc_doorhanger_data_is_stored_in_about_prefs.py",
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_dropdown-presence.py",
-        "test_demo_cc_yellow_highlight.py"
+        "test_demo_cc_yellow_highlight.py",
+        "test_demo_ad_yellow_highlight.py"
   ]
 }

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -39,18 +39,19 @@ class Autofill(BasePage):
         """Clicks submit on the form"""
         self.click_on("submit-button", labels=[field_name])
 
-    def verify_field_highlights_in_list(
+    def verify_field_highlight(
         self,
         fields_to_test: List[str],
         expected_highlighted_fields: Optional[List[str]] = None,
         extra_fields: Optional[List[str]] = None,
     ):
         """
-        A common method to check which fields have the "yellow highlight."
+        A common method to check which fields have the "yellow highlight". This is used in both CC and Address pages.
         - fields_to_test: The primary list of fields for this page (cc fields, address fields).
         - expected_highlighted_fields: Which ones are expected to be highlighted. Defaults to all in `fields_to_test`.
         - extra_fields: If some pages have extra fields to test (e.g. 'cc-csc'), pass them here.
         """
+
         if expected_highlighted_fields is None:
             # By default, everything in fields_to_test is expected to be highlighted
             expected_highlighted_fields = fields_to_test[:]
@@ -388,7 +389,7 @@ class CreditCardFill(Autofill):
         We also want to include the "cc-csc" field in the test, so we
         pass it via 'extra_fields'.
         """
-        return self.verify_field_highlights_in_list(
+        return self.verify_field_highlight(
             fields_to_test=self.fields,
             expected_highlighted_fields=expected_highlighted_fields,
             extra_fields=["cc-csc"],
@@ -563,7 +564,7 @@ class AddressFill(Autofill):
         if fields_to_test is None:
             fields_to_test = self.fields  # By default, test all address fields
 
-        return self.verify_field_highlights_in_list(
+        return self.verify_field_highlight(
             fields_to_test=fields_to_test,
             expected_highlighted_fields=expected_highlighted_fields,
         )

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -38,6 +38,67 @@ class Autofill(BasePage):
     def click_form_button(self, field_name):
         """Clicks submit on the form"""
         self.click_on("submit-button", labels=[field_name])
+
+    def verify_field_highlights_in_list(
+        self,
+        fields_to_test: List[str],
+        expected_highlighted_fields: Optional[List[str]] = None,
+        extra_fields: Optional[List[str]] = None,
+    ):
+        """
+        A common method to check which fields have the "yellow highlight."
+        - fields_to_test: The primary list of fields for this page (cc fields, address fields).
+        - expected_highlighted_fields: Which ones are expected to be highlighted. Defaults to all in `fields_to_test`.
+        - extra_fields: If some pages have extra fields to test (e.g. 'cc-csc'), pass them here.
+        """
+        if expected_highlighted_fields is None:
+            # By default, everything in fields_to_test is expected to be highlighted
+            expected_highlighted_fields = fields_to_test[:]
+
+        if extra_fields:
+            fields_to_actually_check = fields_to_test + extra_fields
+        else:
+            fields_to_actually_check = fields_to_test
+
+        browser_action_obj = BrowserActions(self.driver)
+
+        def is_yellow_highlight(rgb_tuple):
+            """
+            Returns True if the color tuple is bright yellow-ish.
+            """
+            if len(rgb_tuple) == 3:
+                r, g, b = rgb_tuple
+            else:
+                r, g, b, *_ = rgb_tuple
+
+            return (r >= 250) and (g >= 250) and (180 < b < 220)
+
+        for field_name in fields_to_actually_check:
+            # Focus the field so the highlight is visible
+            self.click_on("form-field", labels=[field_name])
+
+            # Get all colors in the field
+            selector = self.get_selector("form-field", labels=[field_name])
+            colors = browser_action_obj.get_all_colors_in_element(selector)
+            logging.info(f"Colors found in '{field_name}': {colors}")
+
+            # Check the highlight
+            is_field_highlighted = any(is_yellow_highlight(color) for color in colors)
+            should_be_highlighted = field_name in expected_highlighted_fields
+
+            # Assert based on expectation
+            if should_be_highlighted:
+                assert is_field_highlighted, (
+                    f"Expected yellow highlight on '{field_name}', but none found."
+                )
+                logging.info(f"Yellow highlight found in '{field_name}'.")
+            else:
+                assert not is_field_highlighted, (
+                    f"Expected NO yellow highlight on '{field_name}', but found one."
+                )
+                logging.info(f"No yellow highlight in '{field_name}', as expected.")
+
+        return self
 
 
 class CreditCardFill(Autofill):
@@ -323,50 +384,15 @@ class CreditCardFill(Autofill):
 
     def verify_field_yellow_highlights(self, expected_highlighted_fields=None):
         """
-        Verifies that specified form fields have the expected highlight state
+        Reuses the common highlight-check method from the base class.
+        We also want to include the "cc-csc" field in the test, so we
+        pass it via 'extra_fields'.
         """
-        if expected_highlighted_fields is None:
-            expected_highlighted_fields = self.fields
-
-        browser_action_obj = BrowserActions(self.driver)
-
-        # Check if a color is yellow-ish
-        def is_yellow_highlight(rgb_tuple):
-            if len(rgb_tuple) == 3:
-                r, g, b = rgb_tuple
-            elif len(rgb_tuple) >= 4:
-                r, g, b, *_ = rgb_tuple
-            else:
-                return False
-            # Uses a tolerance to detect a yellow highlight
-            return r >= 250 and g >= 250 and 180 < b < 220
-
-        all_fields = self.fields + ["cc-csc"]
-
-        for field_name in all_fields:
-            # Bring the fields into focus
-            self.click_on("form-field", labels=[field_name])
-
-            # Get the color of the fields
-            selector = self.get_selector("form-field", labels=[field_name])
-            colors = browser_action_obj.get_all_colors_in_element(selector)
-            logging.info(f"Colors found in {field_name}: {colors}")
-
-            is_field_highlighted = any(is_yellow_highlight(color) for color in colors)
-            should_be_highlighted = field_name in expected_highlighted_fields
-
-            if should_be_highlighted:
-                assert is_field_highlighted, (
-                    f"Expected yellow highlight on {field_name}, but none found."
-                )
-                logging.info(f"Yellow highlight correctly found in {field_name}.")
-            else:
-                assert not is_field_highlighted, (
-                    f"Expected no yellow highlight on {field_name}, but found one."
-                )
-                logging.info(f"No yellow highlight found in {field_name}, as expected.")
-
-        return self
+        return self.verify_field_highlights_in_list(
+            fields_to_test=self.fields,
+            expected_highlighted_fields=expected_highlighted_fields,
+            extra_fields=["cc-csc"],
+        )
 
 
 class LoginAutofill(Autofill):
@@ -413,6 +439,18 @@ class AddressFill(Autofill):
     """
 
     URL_TEMPLATE = "https://mozilla.github.io/form-fill-examples/basic.html"
+
+    fields = [
+        "name",
+        "organization",
+        "street-address",
+        "address-level2",  # city
+        "address-level1",  # state/province
+        "postal-code",
+        "country",
+        "email",
+        "tel",
+    ]
 
     def save_information_basic(self, autofill_info: AutofillAddressBase):
         """
@@ -518,6 +556,17 @@ class AddressFill(Autofill):
             assert actual == expected, (
                 f"Mismatch in {field}: Expected '{expected}', but got '{actual}'"
             )
+
+    def verify_field_yellow_highlights(
+        self, fields_to_test=None, expected_highlighted_fields=None
+    ):
+        if fields_to_test is None:
+            fields_to_test = self.fields  # By default, test all address fields
+
+        return self.verify_field_highlights_in_list(
+            fields_to_test=fields_to_test,
+            expected_highlighted_fields=expected_highlighted_fields,
+        )
 
 
 class TextAreaFormAutofill(Autofill):


### PR DESCRIPTION
### Description
- Verify that the fields inside the demo address form have the specific yellow highlight on name and organization fields, once an entry is selected from the autofill dropdown.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2888559**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943169**

### Type of change

Please delete options that are not relevant.

- [x ] New Test
- [x ] Other Changes (made a common method for both cc and addresses)

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations
- N/A

### Comments / Concerns

- N/A
