### PR TITLE
Anca/l10n demo - yellow highlight on email and phone fields

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
@@ -42,7 +42,9 @@ def test_demo_ad_email_phone_captured_in_doorhanger_and_stored(
     if expected_phone:
         with driver.context(driver.CONTEXT_CHROME):
             actual_phone = autofill_popup.get_element("address-doorhanger-phone").text
-        normalize_expected = util.normalize_regional_phone_numbers(expected_phone, region)
+        normalize_expected = util.normalize_regional_phone_numbers(
+            expected_phone, region
+        )
         normalized_actual = util.normalize_regional_phone_numbers(actual_phone, region)
         assert normalized_actual == normalize_expected, (
             f"Phone number mismatch for {region} | Expected: {normalize_expected}, Got: {normalized_actual}"

--- a/l10n_CM/Unified/test_demo_ad_yellow_highlight_phone_email.py
+++ b/l10n_CM/Unified/test_demo_ad_yellow_highlight_phone_email.py
@@ -11,15 +11,16 @@ def test_case():
     return "2888570"
 
 
-def test_address_yellow_highlight_address_fields(driver: Firefox, region: str):
+def test_address_yellow_highlight_address_fields(
+    driver: Firefox,
+    region: str,
+    address_autofill: AddressFill,
+    util: Utilities,
+    autofill_popup: AutofillPopup,
+):
     """
     C2888570 - Verify the yellow highlight appears on autofilled fields for the email and phone fields.
     """
-
-    # Instantiate objects
-    address_autofill = AddressFill(driver)
-    address_autofill_popup = AutofillPopup(driver)
-    util = Utilities()
 
     # Create fake data and fill it in
     address_autofill.open()
@@ -27,14 +28,14 @@ def test_address_yellow_highlight_address_fields(driver: Firefox, region: str):
     address_autofill.save_information_basic(address_autofill_data)
 
     # Click the "Save" button
-    address_autofill_popup.click_doorhanger_button("save")
+    autofill_popup.click_doorhanger_button("save")
 
     # Double click inside email field and select a saved address entry from the dropdown
     address_autofill.double_click("form-field", labels=["email"])
 
     # Click on the first element from the autocomplete dropdown
-    first_item = address_autofill_popup.get_nth_element(1)
-    address_autofill_popup.click_on(first_item)
+    first_item = autofill_popup.get_nth_element(1)
+    autofill_popup.click_on(first_item)
 
     # Verify the email and phone fields are highlighted
     address_autofill.verify_field_yellow_highlights(

--- a/l10n_CM/Unified/test_demo_ad_yellow_highlight_phone_email.py
+++ b/l10n_CM/Unified/test_demo_ad_yellow_highlight_phone_email.py
@@ -1,0 +1,42 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import AddressFill
+from modules.util import Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2888570"
+
+
+def test_address_yellow_highlight_address_fields(driver: Firefox, region: str):
+    """
+    C2888570 - Verify the yellow highlight appears on autofilled fields for the email and phone fields.
+    """
+
+    # Instantiate objects
+    address_autofill = AddressFill(driver)
+    address_autofill_popup = AutofillPopup(driver)
+    util = Utilities()
+
+    # Create fake data and fill it in
+    address_autofill.open()
+    address_autofill_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(address_autofill_data)
+
+    # Click the "Save" button
+    address_autofill_popup.click_doorhanger_button("save")
+
+    # Double click inside email field and select a saved address entry from the dropdown
+    address_autofill.double_click("form-field", labels=["email"])
+
+    # Click on the first element from the autocomplete dropdown
+    first_item = address_autofill_popup.get_nth_element(1)
+    address_autofill_popup.click_on(first_item)
+
+    # Verify the email and phone fields are highlighted
+    address_autofill.verify_field_yellow_highlights(
+        fields_to_test=["email", "tel"], expected_highlighted_fields=["email", "tel"]
+    )

--- a/l10n_CM/region/Unified.json
+++ b/l10n_CM/region/Unified.json
@@ -13,6 +13,7 @@
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_dropdown-presence.py",
         "test_demo_cc_yellow_highlight.py",
-        "test_demo_ad_yellow_highlight.py"
+        "test_demo_ad_yellow_highlight.py",
+        "test_demo_ad_yellow_highlight_phone_email.py"
   ]
 }

--- a/modules/util.py
+++ b/modules/util.py
@@ -499,7 +499,9 @@ class Utilities:
         digits = re.sub(r"\D", "", phone)
 
         # Determine country code
-        country_code = country_codes.get(region, "1")  # Default to "1" (US/CA) if region is unknown
+        country_code = country_codes.get(
+            region, "1"
+        )  # Default to "1" (US/CA) if region is unknown
         local_number = digits
 
         # Check if phone already contains a valid country code
@@ -507,7 +509,7 @@ class Utilities:
             if digits.startswith(code):
                 country_code = code
                 # Remove country code from local number
-                local_number = digits[len(code):]
+                local_number = digits[len(code) :]
                 break
 
         # Handle leading zero in local numbers (France & Germany)


### PR DESCRIPTION
### Description
- Verify that the fields inside the demo form have the specific yellow highlight on email and phone  fields, once an entry is selected from the autofill dropdown.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2888570**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943183**

### Type of change

Please delete options that are not relevant.

- [x ] New Test

### How does this resolve / make progress on that bug?

- Completed

### Screenshots / Explanations
- N/A

### Comments / Concerns

- N/A
