### PR TITLE
Philimon/ccfill_verify_autofill_refactor

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1389,6 +1389,13 @@ Location: Appears as part of the dropdown under the autofill panel, within any e
 Path to .json: modules/data/autofill_popup.components.json
 ```
 ```
+Selector Name: select-form-option-by-index
+Selector Data: ".autocomplete-richlistbox .autocomplete-richlistitem:nth:child({index})"
+Description: Select n individual entry within the autofill dropdown, using the index of the child.
+Location: Appears as part of the dropdown under the autofill panel, within any eligible form field when suggestions are available.
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
 Selector Name: clear-form-option
 Selector Data: ".autocomplete-richlistbox .autocomplete-richlistitem[ac-value='Clear Autofill Form']"
 Description: The "Clear Autofill Form" option in the dropdown that appears when interacting with an autofill-enabled input field

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -80,6 +80,20 @@ class AutofillPopup(BasePage):
                 )
             )
 
+    def select_nth_element(self, index: int):
+        """
+        Select the nth element from the autocomplete list
+        Arguments:
+            index (int): The index of the element to retrieve (1-based)
+        """
+        with self.driver.context(self.driver.CONTEXT_CHROME):
+            self.expect(
+                EC.visibility_of(
+                    self.get_element("select-form-option-by-index", labels=[str(index)])
+                )
+            )
+            self.get_element("select-form-option-by-index", labels=[str(index)]).click()
+
     def get_primary_value(self, element: WebElement) -> str:
         """
         Get the primary value from the autocomplete element

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -61,6 +61,12 @@
          "groups": []
     },
 
+    "select-form-option-by-index": {
+        "selectorData": ".autocomplete-richlistbox .autocomplete-richlistitem:nth-child({index})",
+        "strategy":"css",
+        "groups": []
+    },
+
     "update-card-info-popup-button": {
         "selectorData": "button[label='Update existing card']",
         "strategy": "css",

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -145,35 +145,19 @@ class CreditCardFill(Autofill):
         self.double_click("form-field", labels=["cc-csc"])
         ccp.ensure_autofill_dropdown_not_visible()
 
-    def verify_four_fields(
-        self, ccp: AutofillPopup, credit_card_sample_data: CreditCardBase
+    def verify_credit_card_form_data(
+        self, credit_card_sample_data: CreditCardBase
     ) -> Autofill:
         """
-        Verifies that after clicking the autofill panel the information is filled correctly.
+        Verifies that the information is filled correctly.
 
         Attributes
         ----------
 
-        ccp: CreditCardPopup
-            The credit card popup object
-
         credit_card_sample_data: CreditCardBase
             The object that contains all the relevant information about the credit card autofill
         """
-        self.double_click("form-field", labels=["cc-name"])
         info_list = self.extract_credit_card_obj_into_list(credit_card_sample_data)
-        # Click on popup form value with name only
-        if self.sys_platform() == "Linux":
-            with self.driver.context(self.driver.CONTEXT_CHROME):
-                ccp.custom_wait(timeout=30, poll_frequency=0.5).until(
-                    EC.element_to_be_clickable(
-                        ccp.get_selector(
-                            "select-form-option-by-value", labels=[info_list[0]]
-                        )
-                    )
-                )
-        ccp.click_on("select-form-option-by-value", labels=[info_list[0]])
-
         for i in range(len(info_list)):
             self.element_attribute_contains(
                 "form-field", "value", info_list[i], labels=[self.fields[i]]
@@ -225,13 +209,19 @@ class CreditCardFill(Autofill):
         self.fill_input_element(ba, field, field_data)
         self.click_form_button("submit")
 
-    def press_autofill_panel(self, credit_card_popoup_obj: AutofillPopup):
+    def press_autofill_panel(
+        self, autofill_popup: AutofillPopup, field: str = "cc-name"
+    ):
         """
         Presses the autofill panel that pops up after you double-click an input field
+
+        Argument:
+            field:  field to click to show autofill option.
         """
-        self.double_click("form-field", labels=["cc-name"])
+        self.double_click("form-field", labels=[field])
+        autofill_popup.ensure_autofill_dropdown_visible()
         with self.driver.context(self.driver.CONTEXT_CHROME):
-            credit_card_popoup_obj.get_element("select-form-option").click()
+            autofill_popup.get_element("select-form-option").click()
 
     def update_credit_card_information(
         self,
@@ -303,7 +293,7 @@ class CreditCardFill(Autofill):
         self.update_credit_card_information(autofill_popup_obj, field_name, new_data)
 
         # verifying the correct data
-        self.verify_four_fields(autofill_popup_obj, credit_card_sample_data)
+        self.verify_credit_card_form_data(autofill_popup_obj, credit_card_sample_data)
         return self
 
     def update_cc_name(
@@ -382,6 +372,21 @@ class CreditCardFill(Autofill):
             # Verify that the 'cc-csc' field does not trigger an autofill dropdown
             self.double_click("form-field", labels=["cc-csc"])
             autofill_popup_obj.ensure_autofill_dropdown_not_visible()
+
+    def autofill_and_clear_all_fields(
+        self, autofill_popup: AutofillPopup, credit_card_data: CreditCardBase
+    ):
+        """
+        For each field select autofill option and clear.
+        """
+        for field in self.fields:
+            # press autofill panel for a field.
+            self.press_autofill_panel(autofill_popup, field)
+            # verify cc data in form.
+            self.verify_credit_card_form_data(credit_card_data)
+            # Clear the fields after verification
+            self.click_on("form-field", labels=[field])
+            autofill_popup.click_clear_form_option()
 
     def verify_field_yellow_highlights(self, expected_highlighted_fields=None):
         """

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -234,7 +234,6 @@ class CreditCardFill(Autofill):
         Updates the credit card based on field that is to be changed by first autofilling everything then updating
         the field of choice then pressing submit and handling the popup.
         """
-        self.press_autofill_panel(autofill_popup_obj)
         self.update_field(field_name, field_data, autofill_popup_obj)
         self.click_form_button("submit")
 
@@ -292,67 +291,39 @@ class CreditCardFill(Autofill):
         # updating the profile accordingly
         self.update_credit_card_information(autofill_popup_obj, field_name, new_data)
 
+        # autofill data
+        self.press_autofill_panel(autofill_popup_obj)
+
         # verifying the correct data
-        self.verify_credit_card_form_data(autofill_popup_obj, credit_card_sample_data)
+        self.verify_credit_card_form_data(credit_card_sample_data)
         return self
 
-    def update_cc_name(
+    def update_cc(
         self,
         util: Utilities,
         credit_card_sample_data: CreditCardBase,
         autofill_popup_obj: AutofillPopup,
+        field: str,
     ) -> Autofill:
         """
-        Generates a new name, updates the credit card information in the form.
+        Generates a new data for credit card according to field given, updates the credit card information in the form.
         """
-        new_cc_name = util.fake_credit_card_data().name
-        credit_card_sample_data.name = new_cc_name
+        cc_mapping = {
+            "cc-name": "name",
+            "cc-exp-month": "expiration_month",
+            "cc-exp-year": "expiration_year",
+            "cc-number": "card_number",
+        }
+        new_cc_data = getattr(util.fake_credit_card_data(), cc_mapping[field])
+        while new_cc_data == getattr(credit_card_sample_data, cc_mapping[field]):
+            new_cc_data = getattr(util.fake_credit_card_data(), cc_mapping[field])
+        setattr(credit_card_sample_data, cc_mapping[field], new_cc_data)
 
         self.verify_updated_information(
             autofill_popup_obj,
             credit_card_sample_data,
-            "cc-name",
-            credit_card_sample_data.name,
-        )
-        return self
-
-    def update_cc_exp_month(
-        self,
-        util: Utilities,
-        credit_card_sample_data: CreditCardBase,
-        autofill_popup_obj: AutofillPopup,
-    ) -> Autofill:
-        """
-        Generates a new expiry month, updates the credit card information in the form.
-        """
-        new_cc_exp_month = util.fake_credit_card_data().expiration_month
-        credit_card_sample_data.expiration_month = new_cc_exp_month
-
-        self.verify_updated_information(
-            autofill_popup_obj,
-            credit_card_sample_data,
-            "cc-exp-month",
-            credit_card_sample_data.expiration_month,
-        )
-        return self
-
-    def update_cc_exp_year(
-        self,
-        util: Utilities,
-        credit_card_sample_data: CreditCardBase,
-        autofill_popup_obj: AutofillPopup,
-    ) -> Autofill:
-        """
-        Generates a new expiry year, updates the credit card information in the form.
-        """
-        new_cc_exp_year = util.fake_credit_card_data().expiration_year
-        credit_card_sample_data.expiration_year = new_cc_exp_year
-
-        self.verify_updated_information(
-            autofill_popup_obj,
-            credit_card_sample_data,
-            "cc-exp-year",
-            credit_card_sample_data.expiration_year,
+            field,
+            new_cc_data,
         )
         return self
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -100,6 +100,8 @@ class Utilities:
             "Nunavut": "NU",
             "Yukon": "YT",
         }
+        self.fake = None
+        self.locale = None
 
     def remove_file(self, path: str):
         try:
@@ -215,8 +217,13 @@ class Utilities:
 
         try:
             # seed to get consistent data
-            Faker.seed(locale)
-            faker = Faker(locale)
+            if self.fake is None:
+                if locale != self.locale:
+                    Faker.seed(locale)
+                    self.locale = locale
+                self.fake = Faker(locale)
+            faker = self.fake
+            self.fake = faker
             faker.add_provider(internet)
             faker.add_provider(misc)
             return faker, True

--- a/tests/form_autofill/test_autofill_credit_card_four_fields.py
+++ b/tests/form_autofill/test_autofill_credit_card_four_fields.py
@@ -24,4 +24,5 @@ def test_autofill_four_fields(driver: Firefox):
     credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
     autofill_popup_obj.click_doorhanger_button("save")
 
-    credit_card_fill_obj.verify_four_fields(autofill_popup_obj, credit_card_sample_data)
+    credit_card_fill_obj.press_autofill_panel(autofill_popup_obj)
+    credit_card_fill_obj.verify_credit_card_form_data(credit_card_sample_data)

--- a/tests/form_autofill/test_form_autofill_suggestions.py
+++ b/tests/form_autofill/test_form_autofill_suggestions.py
@@ -11,11 +11,7 @@ def test_case():
     return "122401"
 
 
-indices = range(2)
-
-
-@pytest.mark.parametrize("index", indices)
-def test_form_autofill_suggestions(driver: Firefox, index: str):
+def test_form_autofill_suggestions(driver: Firefox):
     """
     C122401, checks that the corresponding autofill suggestion autofills the fields correctly
     """
@@ -29,13 +25,15 @@ def test_form_autofill_suggestions(driver: Firefox, index: str):
     sample_data = [
         credit_card_fill_obj.fake_and_fill(util, autofill_popup_obj) for _ in range(2)
     ]
+    # reverse data list to match form options
+    sample_data.reverse()
 
     # press the corresponding option (according to the parameter)
     credit_card_fill_obj.click_on("form-field", labels=["cc-name"])
 
-    # verify information based, verify based on second object if we are verifying first option (this is the newer option) and
-    # vice versa
-    check_index = 1 - index
-    credit_card_fill_obj.verify_four_fields(
-        autofill_popup_obj, sample_data[check_index]
-    )
+    # verify form data in reverse (newer options are at the top)
+    for idx in range(1, 3):
+        autofill_popup_obj.select_nth_element(idx)
+        credit_card_fill_obj.verify_credit_card_form_data(sample_data[idx - 1])
+        credit_card_fill_obj.click_on("form-field", labels=["cc-name"])
+        autofill_popup_obj.click_clear_form_option()

--- a/tests/form_autofill/test_updating_credit_card.py
+++ b/tests/form_autofill/test_updating_credit_card.py
@@ -35,18 +35,9 @@ def test_update_cc_no_dupe_name(driver: Firefox, field: str):
     credit_card_fill_obj.press_autofill_panel(autofill_popup_obj)
 
     # updating the name of the cc holder
-    if field == "cc-name":
-        credit_card_fill_obj.update_cc_name(
-            util, credit_card_sample_data, autofill_popup_obj
-        )
-    elif field == "cc-exp-month":
-        credit_card_fill_obj.update_cc_exp_month(
-            util, credit_card_sample_data, autofill_popup_obj
-        )
-    else:
-        credit_card_fill_obj.update_cc_exp_year(
-            util, credit_card_sample_data, autofill_popup_obj
-        )
+    credit_card_fill_obj.update_cc(
+        util, credit_card_sample_data, autofill_popup_obj, field
+    )
 
     # navigate to settings
     about_prefs = AboutPrefs(driver, category="privacy").open()


### PR DESCRIPTION
### Description

refactored verify method in creditcardfill to only verify.
added autofill and learn method.

### Bugzilla bug ID

**Testrail:**
**Link:**

### Type of change

Please delete options that are not relevant.

- [x] Other Changes (Please specify)

### Comments / Concerns

changed `verify_four_fields` to `verify_credit_card_form_data` so it only verifies data in the form instead of autofilling data.
added `autofill_and_clear_all_fields` method to autofill and clear the data for each field.
