### PR TITLE
prep workflow for differently-named Fx executables in Mac

### DIFF
--- a/.github/workflows/check-devedition.yml
+++ b/.github/workflows/check-devedition.yml
@@ -2,7 +2,7 @@ name: Check new devedition version
 
 on:
   schedule:
-    - cron: "38 * * * *"
+    - cron: "38 */12 * * *"
 env:
   LATEST: ""
 permissions:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -144,8 +144,6 @@ jobs:
           echo "Running report for most recent Beta on MacOS";
       - name: Install dependencies
         id: setup
-        outputs:
-          app_name: ${{ setup.outputs.app_name }}
         run: |
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
@@ -155,10 +153,9 @@ jobs:
           pipenv install;
           echo app_name=$(bash ./collect_executables.sh | xargs -0 ./parse_executables.sh) >> "$GITHUB_OUTPUT"
       - name: Run Smoke Tests in MacOS
-        needs: setup
         if: steps.setup.conclusion == 'success'
         env:
-          FX_EXECUTABLE: /Volumes/${{ needs.setup.outputs.app_name }}/${{ needs.setup.outputs.app_name }}.app/Contents/MacOS/firefox
+          FX_EXECUTABLE: /Volumes/${{ steps.setup.outputs.app_name }}/${{ steps.setup.outputs.app_name }}.app/Contents/MacOS/firefox
         run: |
           /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox --version
           pipenv run python choose_ci_set.py

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -144,6 +144,8 @@ jobs:
           echo "Running report for most recent Beta on MacOS";
       - name: Install dependencies
         id: setup
+        outputs:
+          app_name: ${{ setup.outputs.app_name }}
         run: |
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
@@ -151,11 +153,12 @@ jobs:
           rm ./pyproject.toml;
           mv ./ci_pyproject.toml ./pyproject.toml;
           pipenv install;
-          bash ./collect_executables.sh;
+          echo app_name=$(bash ./collect_executables.sh | xargs -0 ./parse_executables.sh) >> "$GITHUB_OUTPUT"
       - name: Run Smoke Tests in MacOS
+        needs: setup
         if: steps.setup.conclusion == 'success'
         env:
-          FX_EXECUTABLE: /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox
+          FX_EXECUTABLE: /Volumes/${{ needs.setup.outputs.app_name }}/${{ needs.setup.outputs.app_name }}.app/Contents/MacOS/firefox
         run: |
           /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox --version
           pipenv run python choose_ci_set.py

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -372,9 +372,8 @@ def collect_changes(testrail_session: TestRail, report):
     """
 
     # Find milestone to attach to
-    channel = os.environ.get("FX_CHANNEL").title()
-    if not channel:
-        channel = "Beta"
+    channel = os.environ.get("FX_CHANNEL") or "beta"
+    channel = channel.title()
     if channel == "Release":
         raise ValueError("Release reporting currently not supported")
 

--- a/parse_executables.sh
+++ b/parse_executables.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while read -r line; do
+    if [[ "${line}" == *"/Volumes/"* ]]; then
+        echo "${line}" | cut -f 3 | cut -d"/" -f 3
+    fi
+done <<< "$1"


### PR DESCRIPTION
When we test devedition, the MacOS executable is called "Firefox Developer Edition", which matters as `hdiutil` mounts the volume so we can tell Selenium where Fx lives. This change *should* allow that to happen while also preventing scheduled Beta from breaking.

* `parse_executables` parses the output of `hdiutil` mount to get the name of the package
* pipeline updated to use that script to construct `FX_EXECUTABLE`
* Change cron in devedition gha yaml
* Update testrail_integration.collect_changes() not to break on missing `FX_CHANNEL`