### PR TITLE
Anca/ l10n demo - Addresses fields autofill dropdown activation

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_dropdown_presence_address.py
+++ b/l10n_CM/Unified/test_demo_ad_dropdown_presence_address.py
@@ -1,0 +1,44 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import AddressFill
+from modules.util import Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2888561"
+
+
+def test_dropdown_presence_address_field(
+    driver: Firefox,
+    region: str,
+    address_autofill: AddressFill,
+    util: Utilities,
+    autofill_popup: AutofillPopup,
+):
+    """
+    C2888561 - Verify that the autofill dropdown is displayed  for the eligible address fields after an address was
+    previously saved
+    """
+
+    # Create fake data and fill it in
+    address_autofill.open()
+    address_autofill_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(address_autofill_data)
+
+    # Click the "Save" button
+    autofill_popup.click_doorhanger_button("save")
+
+    fields_to_test = [
+        "street-address",
+        "address-level2",
+        "address-level1",
+        "postal-code",
+        "country",
+    ]
+
+    address_autofill.verify_autofill_dropdown_addresses(
+        autofill_popup=autofill_popup, fields_to_test=fields_to_test, region=region
+    )

--- a/l10n_CM/Unified/test_demo_cc_dropdown_presence.py
+++ b/l10n_CM/Unified/test_demo_cc_dropdown_presence.py
@@ -36,4 +36,4 @@ def test_dropdown_presence_credit_card(
     credit_card_fill_obj.open()
 
     # Verify autofill dropdown is displayed only for the eligible fields
-    credit_card_fill_obj.verify_autofill_dropdown_all_fields(autofill_popup)
+    credit_card_fill_obj.verify_autofill_dropdown_credit_card(autofill_popup)

--- a/l10n_CM/region/Unified.json
+++ b/l10n_CM/region/Unified.json
@@ -15,7 +15,8 @@
         "test_demo_cc_yellow_highlight.py",
         "test_demo_ad_yellow_highlight_name_org.py",
         "test_demo_ad_yellow_highlight_address.py",
-        "test_demo_ad_yellow_highlight_phone_email.py"
+        "test_demo_ad_yellow_highlight_phone_email.py",
+        "test_demo_ad_dropdown_presence_address.py"
 
   ]
 }

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -39,6 +39,43 @@ class Autofill(BasePage):
         """Clicks submit on the form"""
         self.click_on("submit-button", labels=[field_name])
 
+    def verify_field_autofill_dropdown(
+        self,
+        autofill_popup: AutofillPopup,
+        fields_to_test: List[str],
+        excluded_fields: Optional[List[str]] = None,
+        region: Optional[str] = None,
+    ):
+        """
+        A common method to check which fields trigger the autofill dropdown. This is used in both CC and Address pages.
+        - fields_to_test: The primary list of fields for this page (cc fields, address fields).
+        - excluded_fields: Fields that should NOT trigger an autofill dropdown.
+        - region: If provided, handle region-specific behavior (e.g., skip address-level1 for DE/FR).
+        """
+        # Create a copy of fields_to_test to avoid modifying the original
+        fields_to_check = fields_to_test[:]
+
+        # Handle region-specific behavior
+        if region in ["DE", "FR"] and "address-level1" in fields_to_check:
+            fields_to_check.remove("address-level1")
+
+        # Check fields that SHOULD trigger the autofill dropdown
+        for field_name in fields_to_check:
+            self.double_click("form-field", labels=[field_name])
+            autofill_popup.ensure_autofill_dropdown_visible()
+            logging.info(f"Autofill dropdown appears for field '{field_name}'.")
+
+        # Check fields that should NOT trigger the autofill dropdown
+        if excluded_fields:
+            for field_name in excluded_fields:
+                self.double_click("form-field", labels=[field_name])
+                autofill_popup.ensure_autofill_dropdown_not_visible()
+                logging.info(
+                    f"No autofill dropdown appears for field '{field_name}', as expected."
+                )
+
+        return self
+
     def verify_field_highlight(
         self,
         fields_to_test: List[str],
@@ -136,14 +173,11 @@ class CreditCardFill(Autofill):
 
         self.click_form_button("submit")
 
-    def verify_autofill_dropdown_all_fields(self, ccp: AutofillPopup):
-        """Given a CreditCardPopup object, verify all fields"""
-        for field in self.fields:
-            self.double_click("form-field", labels=[field])
-            ccp.ensure_autofill_dropdown_visible()
-        # Ensure 'cc-csc' does NOT trigger the autofill dropdown
-        self.double_click("form-field", labels=["cc-csc"])
-        ccp.ensure_autofill_dropdown_not_visible()
+    def verify_autofill_dropdown_credit_card(self, autofill_popup: AutofillPopup):
+        """Verifies autofill dropdown for credit card fields."""
+        return self.verify_field_autofill_dropdown(
+            autofill_popup, fields_to_test=self.fields, excluded_fields=["cc-csc"]
+        )
 
     def verify_credit_card_form_data(
         self, credit_card_sample_data: CreditCardBase
@@ -547,6 +581,17 @@ class AddressFill(Autofill):
         return self.verify_field_highlight(
             fields_to_test=fields_to_test,
             expected_highlighted_fields=expected_highlighted_fields,
+        )
+
+    def verify_autofill_dropdown_addresses(
+        self, autofill_popup: AutofillPopup, region=None, fields_to_test=None
+    ):
+        """Verifies autofill dropdown for address fields."""
+        if fields_to_test is None:
+            fields_to_test = self.fields
+
+        return self.verify_field_autofill_dropdown(
+            autofill_popup=autofill_popup, fields_to_test=fields_to_test, region=region
         )
 
 


### PR DESCRIPTION
### Description
- Verify the autofill dropdown is displayed for all the addresses fields on demo page after an was saved in about:preferences.
- Made a common method for both CC and Addresses.

### Bugzilla bug ID

**Testrail: https://mozilla.testrail.io/index.php?/cases/view/2888561**
**Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1943172**

### Type of change

Please delete options that are not relevant.

- [x ] New Test
- [ x] Other Changes (added a common autofill dropdown method))

### How does this resolve / make progress on that bug?
- Completed 

### Screenshots / Explanations

- N/A

### Comments / Concerns

- N/A