### PR TITLE
vs/autofill-cc-test

### DIFF
--- a/l10n_CM/Unified/test_demo_cc_autofill_from_dropdown.py
+++ b/l10n_CM/Unified/test_demo_cc_autofill_from_dropdown.py
@@ -2,8 +2,9 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object_autofill import CreditCardFill
+from modules.page_object import AboutPrefs, CreditCardFill
 from modules.util import Utilities
+
 
 
 @pytest.fixture()
@@ -11,15 +12,17 @@ def test_case():
     return "2886600"
 
 
-def test_cc_autofill_from_dropdown(driver: Firefox):
+def test_cc_autofill_from_dropdown(
+    driver: Firefox,
+    util: Utilities,
+    autofill_popup: AutofillPopup,
+    credit_card_fill_obj: CreditCardFill,
+
+):
     """
     Verify that saved credit card information is autofilled correctly when selected from the dropdown,
     except for the CVV field.
     """
-    # Instantiate objects
-    credit_card_fill_obj = CreditCardFill(driver)
-    autofill_popup = AutofillPopup(driver)
-    util = Utilities()
 
     # Open credit card form page
     credit_card_fill_obj.open()

--- a/l10n_CM/Unified/test_demo_cc_autofill_from_dropdown.py
+++ b/l10n_CM/Unified/test_demo_cc_autofill_from_dropdown.py
@@ -1,0 +1,37 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import CreditCardFill
+from modules.util import Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2886600"
+
+
+def test_cc_autofill_from_dropdown(driver: Firefox):
+    """
+    Verify that saved credit card information is autofilled correctly when selected from the dropdown,
+    except for the CVV field.
+    """
+    # Instantiate objects
+    credit_card_fill_obj = CreditCardFill(driver)
+    autofill_popup = AutofillPopup(driver)
+    util = Utilities()
+
+    # Open credit card form page
+    credit_card_fill_obj.open()
+
+    # Create and save fake credit card data
+    credit_card_data = util.fake_credit_card_data()
+    credit_card_fill_obj.fill_credit_card_info(credit_card_data)
+    autofill_popup.click_doorhanger_button("save")
+
+    # Autocomplete and clear all fields
+    credit_card_fill_obj.autofill_and_clear_all_fields(autofill_popup, credit_card_data)
+
+    # Step 5: Click the csc field (cc-csc), ensure autofill popup is not present
+    credit_card_fill_obj.click_on("form-field", labels=["cc-csc"])  # Use single click
+    autofill_popup.ensure_autofill_dropdown_not_visible()

--- a/l10n_CM/region/Unified.json
+++ b/l10n_CM/region/Unified.json
@@ -11,7 +11,7 @@
         "test_demo_cc_clear_form.py",
         "test_demo_cc_doorhanger_data_is_stored_in_about_prefs.py",
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
-        "test_demo_cc_dropdown-presence.py",
+        "test_demo_cc_dropdown_presence.py",
         "test_demo_cc_autofill_from_dropdown.py",
         "test_demo_cc_yellow_highlight.py",
         "test_demo_ad_autofill_address_fields.py"

--- a/l10n_CM/region/Unified.json
+++ b/l10n_CM/region/Unified.json
@@ -12,6 +12,7 @@
         "test_demo_cc_doorhanger_data_is_stored_in_about_prefs.py",
         "test_demo_cc_doorhanger_shown_on_valid_credit_card_submission.py",
         "test_demo_cc_dropdown-presence.py",
+        "test_demo_cc_autofill_from_dropdown.py",
         "test_demo_cc_yellow_highlight.py",
         "test_demo_ad_yellow_highlight_name_org.py",
         "test_demo_ad_yellow_highlight_address.py",


### PR DESCRIPTION
### Description

Test that checks that the CC Autofill data is displayed for a saved CC. Checks that CSC data is never saved.

### Bugzilla bug ID

**Testrail:** https://mozilla.testrail.io/index.php?/cases/view/2886600
**Link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1943191

### Type of change

Please delete options that are not relevant.

- [x] New Test
- [ ] New POM
- [ ] Other Changes (Please specify)

### How does this resolve / make progress on that bug?

Adding a new test.