### PR TITLE
change private window method, pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,37 @@
-### Description
+### Relevant Links
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Bugzilla: _
+TestRail: _
 
-### Bugzilla bug ID
+### Description of Code / Doc Changes
 
-**Testrail:**
-**Link:**
+_Leave a bullet-pointed list of changes you made._
 
-### Type of change
+### Process Changes Required
 
-Please delete options that are not relevant.
+_Mark the relevant boxes:_
 
-- [ ] New Test
-- [ ] New POM
-- [ ] Other Changes (Please specify)
+- [ ] Adds a dependency (rerun `pipenv install`)
+- [ ] Changes the BasePage
+- [ ] Changes or creates a BOM/POM (name the object model): _
+- [ ] Changes CI flow
+- [ ] Changes scheduled Beta or DevEdition
+- [ ] Changes Git hooks or Github settings
+- [ ] Changes L10n harness
 
-### How does this resolve / make progress on that bug?
+### Screenshots or Explanations
 
-Please describe the progress or significance with respect to the bug listed above.
+_If you need to explain your code, do it here._
 
-### Screenshots / Explanations
+### Comments or Future Work
 
-Please upload any relevant media or add a relevant description with respect to the bug listed above.
+_Do we need to start another PR soon to address something you saw while working on this?_
 
-### Comments / Concerns
+### Workflow Checklist
 
-Please add a short blurb about any comments or concerns that this change might cause.
+- [ ] Please request reviewers
+- [ ] If this is an unblocker, please post in Slack.
+- [ ] If asked to address comments, please resolve conversations.
+- [ ] If asked to change code, please re-request review from the person who wanted changes.
+
+Thank you!

--- a/choose_ci_set.py
+++ b/choose_ci_set.py
@@ -139,8 +139,8 @@ if __name__ == "__main__":
         .splitlines()
     )
 
-    main_conftest = os.path.join(SCRIPT_DIR, "conftest.py")
-    base_page = os.path.join(SCRIPT_DIR, "modules", "page_base.py")
+    main_conftest = "conftest.py"
+    base_page = os.path.join("modules", "page_base.py")
 
     if main_conftest in committed_files or base_page in committed_files:
         # Run all the tests (no files as arguments) if main conftest or basepage changed

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -674,7 +674,9 @@ class BasePage(Page):
         try:
             self.wait.until(lambda _: len(self.driver.window_handles) == num_tabs)
         except TimeoutException:
-            logging.warn("Timeout waiting for the number of windows to be:", num_tabs)
+            logging.warning(
+                "Timeout waiting for the number of windows to be:", num_tabs
+            )
         return self
 
     def switch_to_new_tab(self) -> Page:
@@ -723,9 +725,11 @@ class BasePage(Page):
             self.actions.send_keys("p")
             self.actions.key_up(Keys.SHIFT)
             self.actions.key_up(mod_key).perform()
-        expected_window_count = window_count + 1
-        self.wait_for_num_windows(expected_window_count)
-        self.switch_to_new_window()
+            expected_window_count = window_count + 1
+            self.wait_for_num_windows(expected_window_count)
+            self.switch_to_new_window()
+            self.title_contains("Private")
+        self.driver.get("about:blank")
         return self
 
     def switch_to_frame(self, frame: str, labels=[]) -> Page:


### PR DESCRIPTION
### Changes

* Update private window method in BasePage to `driver.get("about:blank")` before returning, I believe something in Selenium's switch_to isn't fully finishing up before returning, causing the window not to be able to navigate when we ask it to
* Update PR template, we're not just pumping out tests and POMs anymore
* Fix chooser script, it was missing running everything when BasePage changed.