### PR TITLE
Philimon/hover verify

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1361,6 +1361,13 @@ Location: Inside any autofill-eligible form field, triggered by user interaction
 Path to .json: modules/data/autofill_popup.components.json
 ```
 ```
+Selector Name: address-preview-form-container
+Selector Data: "address-save-update-notification-content"
+Description: Form container that is hidden in chrome context. Used to verify hover preview data
+Location: Inside chrome context, holds the data that would be showed as a preview when autofill is hovered.
+Path to .json: modules/data/autofill_popup.components.json
+```
+```
 Selector Name: doorhanger-save-button
 Selector Data: button[label='Save'].popup-notification-primary-button
 Description: The "Save" button 

--- a/l10n_CM/Unified/test_demo_ad_address_data_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_address_data_captured_in_doorhanger_and_stored.py
@@ -66,6 +66,7 @@ def test_demo_ad_address_data_captured_in_doorhanger_and_stored(
 
     # Navigate to about:preferences#privacy => "Autofill" section
     about_prefs_privacy.open()
+    about_prefs_privacy.get_saved_addresses_popup().click()
     about_prefs_privacy.switch_to_saved_addresses_popup_iframe()
 
     # Verify saved addresses

--- a/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_email_phone_captured_in_doorhanger_and_stored.py
@@ -42,10 +42,8 @@ def test_demo_ad_email_phone_captured_in_doorhanger_and_stored(
     if expected_phone:
         with driver.context(driver.CONTEXT_CHROME):
             actual_phone = autofill_popup.get_element("address-doorhanger-phone").text
-        normalize_expected = util.normalize_regional_phone_numbers(
-            expected_phone, region
-        )
-        normalized_actual = util.normalize_regional_phone_numbers(actual_phone, region)
+        normalize_expected = util.normalize_phone_number(expected_phone, region)
+        normalized_actual = util.normalize_phone_number(actual_phone, region)
         assert normalized_actual == normalize_expected, (
             f"Phone number mismatch for {region} | Expected: {normalize_expected}, Got: {normalized_actual}"
         )
@@ -55,6 +53,7 @@ def test_demo_ad_email_phone_captured_in_doorhanger_and_stored(
 
     # Navigate to about:preferences#privacy => "Autofill" section
     about_prefs_privacy.open()
+    about_prefs_privacy.get_saved_addresses_popup().click()
     about_prefs_privacy.switch_to_saved_addresses_popup_iframe()
 
     # The address saved in step 2 is listed in the "Saved addresses" modal: Email and phone

--- a/l10n_CM/Unified/test_demo_ad_hover_verify_address.py
+++ b/l10n_CM/Unified/test_demo_ad_hover_verify_address.py
@@ -1,0 +1,60 @@
+import logging
+from time import sleep
+
+import pytest
+from selenium.webdriver import ActionChains, Firefox
+from selenium.webdriver.common.by import By
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import AddressFill
+from modules.page_object_prefs import AboutPrefs
+from modules.util import Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2888562"
+
+
+@pytest.fixture()
+def add_to_prefs_list(region: str):
+    return [
+        ("extensions.formautofill.creditCards.supportedCountries", region),
+        ("extensions.formautofill.addresses.supported", "on"),
+    ]
+
+
+def test_hover_address_is_previewed(
+    driver: Firefox,
+    region: str,
+    about_prefs_privacy: AboutPrefs,
+    address_autofill: AddressFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+):
+    """
+    C2888562: Verify that hovering over field will preview all fields
+    """
+    # Create fake data and fill it in
+    address_autofill.open()
+    address_autofill_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(address_autofill_data)
+
+    # Click the "Save" button
+    autofill_popup.click_doorhanger_button("save")
+
+    # Hover over each field and check data preview
+    # for field in AddressFill.fields:
+    address_autofill.double_click("form-field", labels=["name"])
+    autofill_popup.element_visible("select-form-option")
+    autofill_popup.hover("select-form-option")
+    with driver.context(driver.CONTEXT_CHROME):
+        element = autofill_popup.get_element("address-preview-form-container")
+        children = [
+            x.get_attribute("innerHTML")
+            for x in element.find_elements(By.TAG_NAME, "span")
+            if x.get_attribute("innerHTML").strip()
+        ]
+        logging.warning(children)
+        logging.warning(element.get_attribute("innerHTML"))
+        # address_autofill.verify_autofill_data(address_autofill_data, region, util)

--- a/l10n_CM/Unified/test_demo_ad_hover_verify_address.py
+++ b/l10n_CM/Unified/test_demo_ad_hover_verify_address.py
@@ -1,9 +1,7 @@
 import logging
-from time import sleep
 
 import pytest
 from selenium.webdriver import ActionChains, Firefox
-from selenium.webdriver.common.by import By
 
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
@@ -42,11 +40,13 @@ def test_hover_address_is_previewed(
 
     # Click the "Save" button
     autofill_popup.click_doorhanger_button("save")
-
     # Hover over each field and check data preview
     for field in AddressFill.fields:
+        # hack to pass over fields that don't show up in autofill dropdown
+        if field == "address-level1" and region in ["DE", "FR"]:
+            continue
         address_autofill.double_click("form-field", labels=[field])
-        autofill_popup.element_visible("select-form-option")
+        autofill_popup.ensure_autofill_dropdown_visible()
         autofill_popup.hover("select-form-option")
         address_autofill.verify_autofill_data_on_hover(
             address_autofill_data, autofill_popup, util

--- a/l10n_CM/Unified/test_demo_ad_hover_verify_address.py
+++ b/l10n_CM/Unified/test_demo_ad_hover_verify_address.py
@@ -44,17 +44,10 @@ def test_hover_address_is_previewed(
     autofill_popup.click_doorhanger_button("save")
 
     # Hover over each field and check data preview
-    # for field in AddressFill.fields:
-    address_autofill.double_click("form-field", labels=["name"])
-    autofill_popup.element_visible("select-form-option")
-    autofill_popup.hover("select-form-option")
-    with driver.context(driver.CONTEXT_CHROME):
-        element = autofill_popup.get_element("address-preview-form-container")
-        children = [
-            x.get_attribute("innerHTML")
-            for x in element.find_elements(By.TAG_NAME, "span")
-            if x.get_attribute("innerHTML").strip()
-        ]
-        logging.warning(children)
-        logging.warning(element.get_attribute("innerHTML"))
-        # address_autofill.verify_autofill_data(address_autofill_data, region, util)
+    for field in AddressFill.fields:
+        address_autofill.double_click("form-field", labels=[field])
+        autofill_popup.element_visible("select-form-option")
+        autofill_popup.hover("select-form-option")
+        address_autofill.verify_autofill_data_on_hover(
+            address_autofill_data, autofill_popup, util
+        )

--- a/l10n_CM/Unified/test_demo_ad_name_org_captured_in_doorhanger_and_stored.py
+++ b/l10n_CM/Unified/test_demo_ad_name_org_captured_in_doorhanger_and_stored.py
@@ -44,6 +44,7 @@ def test_demo_ad_name_org_captured_in_doorhanger_and_stored(
 
     # Navigate to about:preferences#privacy => "Autofill" section
     about_prefs_privacy.open()
+    about_prefs_privacy.get_saved_addresses_popup().click()
     about_prefs_privacy.switch_to_saved_addresses_popup_iframe()
 
     # The address saved in step 2 is listed in the "Saved addresses" modal: name and organization

--- a/l10n_CM/Unified/test_demo_ad_yellow_highlight_address.py
+++ b/l10n_CM/Unified/test_demo_ad_yellow_highlight_address.py
@@ -21,24 +21,20 @@ def test_address_yellow_highlight_address_fields(
     """
     C2888564 - Verify the yellow highlight appears on autofilled fields for the address fields.
     """
-
-    # Instantiate objects
-    address_autofill_popup = AutofillPopup(driver)
-
     # Create fake data and fill it in
     address_autofill.open()
     address_autofill_data = util.fake_autofill_data(region)
     address_autofill.save_information_basic(address_autofill_data)
 
     # Click the "Save" button
-    address_autofill_popup.click_doorhanger_button("save")
+    autofill_popup.click_doorhanger_button("save")
 
     # Double click inside street address field and select a saved address entry from the dropdown
     address_autofill.double_click("form-field", labels=["street-address"])
 
     # Click on the first element from the autocomplete dropdown
-    first_item = address_autofill_popup.get_nth_element(1)
-    address_autofill_popup.click_on(first_item)
+    first_item = autofill_popup.get_nth_element(1)
+    autofill_popup.click_on(first_item)
 
     # Verify the address fields are highlighted
     address_autofill.verify_field_yellow_highlights(

--- a/l10n_CM/region/Unified.json
+++ b/l10n_CM/region/Unified.json
@@ -22,6 +22,7 @@
     "test_demo_ad_clear_name_org.py",
     "test_demo_ad_clear_address_fields.py",
     "test_demo_ad_clear_tel_email.py",
-    "test_demo_ad_autofill_dropdown_present_for_email_and_phone.py"
+    "test_demo_ad_autofill_dropdown_present_for_email_and_phone.py",
+    "test_demo_ad_hover_verify_address.py"
   ]
 }

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -155,6 +155,13 @@
         "selectorData": "div.address-save-update-row-container:nth-of-type(1) div p:nth-of-type(5) span",
         "strategy": "css",
         "groups": []
+    },
+
+    "address-preview-form-container": {
+        "selectorData": "address-save-update-notification-content",
+        "strategy": "class",
+        "groups": []
+
     }
 }
 

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -161,7 +161,6 @@
         "selectorData": "address-save-update-notification-content",
         "strategy": "class",
         "groups": []
-
     }
 }
 

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -684,6 +684,11 @@ class BasePage(Page):
         self.driver.switch_to.default_content()
         return self
 
+    def switch_to_iframe(self, index: int):
+        """Switch to frame of given index"""
+        self.driver.switch_to.frame(index)
+        return self
+
     def switch_to_new_tab(self) -> Page:
         """Get list of all window handles, switch to the newly opened tab"""
         with self.driver.context(self.driver.CONTEXT_CONTENT):

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -1,4 +1,5 @@
 import logging
+from html import unescape
 from typing import List, Optional
 
 from selenium.webdriver.common.by import By
@@ -277,8 +278,9 @@ class CreditCardFill(Autofill):
         else:
             autofill_popup_obj.click_on("doorhanger-save-button")
 
+    @staticmethod
     def extract_credit_card_obj_into_list(
-        self, credit_card_sample_data: CreditCardBase
+        credit_card_sample_data: CreditCardBase,
     ) -> List[str]:
         """
         Extracts the credit card information from the object and returns it as a list.
@@ -590,15 +592,12 @@ class AddressFill(Autofill):
             autofill_data.telephone, autofill_data.country_code
         )
         for expected in children:
-            logging.warning(expected)
             if expected[0] == "+":
-                expected = util.normalize_regional_phone_numbers(
-                    expected, autofill_data.country_code
-                )
+                expected = util.normalize_phone_number(expected)
             if len(expected) == 2 and expected != autofill_data.country_code:
                 continue
-            assert expected in autofill_data.__dict__.values(), (
-                f"Mismatched data: {expected} not in actual data."
+            assert unescape(expected) in autofill_data.__dict__.values(), (
+                f"Mismatched data: {expected} not in {autofill_data}."
             )
 
     @staticmethod
@@ -614,9 +613,7 @@ class AddressFill(Autofill):
 
             # Normalize phone numbers before comparison
             if field == "Phone":
-                actual = util.normalize_regional_phone_numbers(
-                    actual, expected_values["Country"]
-                )
+                actual = util.normalize_phone_number(actual)
 
             assert actual == expected, (
                 f"Mismatch in {field}: Expected '{expected}', but got '{actual}'"

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -511,6 +511,11 @@ class AddressFill(Autofill):
         elem.clear()
         elem.send_keys(new_value)
 
+    def hover_over_field(self, field):
+        """Hover over a given field."""
+        self.hover(field)
+        return self
+
     def verify_autofill_data(
         self, autofill_data: AutofillAddressBase, region: str, util: Utilities
     ):

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -514,11 +514,6 @@ class AddressFill(Autofill):
         elem.clear()
         elem.send_keys(new_value)
 
-    def hover_over_field(self, field):
-        """Hover over a given field."""
-        self.hover(field)
-        return self
-
     def verify_autofill_data(self, autofill_data: AutofillAddressBase, util: Utilities):
         """
         Verifies that the autofill data matches the expected values.

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -287,7 +287,7 @@ class AboutPrefs(BasePage):
         switch to save addresses popup frame.
         """
         self.switch_to_default_frame()
-        self.driver.switch_to.frame(1)
+        self.switch_to_iframe(1)
         return self
 
     def switch_to_edit_saved_addresses_popup_iframe(self) -> BasePage:
@@ -295,7 +295,7 @@ class AboutPrefs(BasePage):
         Switch to form iframe to edit saved addresses.
         """
         self.switch_to_default_frame()
-        self.driver.switch_to.frame(2)
+        self.switch_to_iframe(2)
         return self
 
     def add_entry_to_saved_addresses(self, address_data: AutofillAddressBase):


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1943173](https://bugzilla.mozilla.org/show_bug.cgi?id=1943173)
TestRail: [2888562](https://mozilla.testrail.io/index.php?/cases/view/2888562)

### Description of Code / Doc Changes
Added ability to test previewed data on hovered fields and verify them.

### Process Changes Required

_Mark the relevant boxes:_

- [x] Changes or creates a BOM/POM (name the object model): AutoFill

### Screenshots or Explanations
To verify the previewed data that appeared when the autofill field is hovered, I had to pull the data from the chrome context as that is where the data for the preview is stored. I had problems with making it work for all regions but since DE and FR don't save address-line1 I had to add a small hack until a better solution is found.
### Comments or Future Work

Will find a way to remove the condition check for DE and FR and make it region agnostic.

### Workflow Checklist

- [x] Please request reviewers
- [x] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
