### PR TITLE
expand BasePage.switch_to_iframe, eliminate switch_to_frame

### DIFF
--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -161,6 +161,12 @@
         "selectorData": "address-save-update-notification-content",
         "strategy": "class",
         "groups": []
+    },
+
+    "cc-preview-form-container": {
+        "selectorData": "credit-card-save-update-notification-content",
+        "strategy": "class",
+        "groups": []
     }
 }
 

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -715,7 +715,7 @@ class BasePage(Page):
         if isinstance(reference, int) or isinstance(reference, WebElement):
             self.driver.switch_to.frame(reference)
         elif isinstance(reference, str):
-            frame_selector = self.get_selector(reference, labels)
+            frame_selector = self.get_selector(reference, labels=labels)
             self.expect(EC.frame_to_be_available_and_switch_to_it(frame_selector))
         elif isinstance(reference, tuple):
             self.expect(EC.frame_to_be_available_and_switch_to_it(reference))

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -708,17 +708,9 @@ class BasePage(Page):
         self.driver.switch_to.default_content()
         return self
 
-    def switch_to_iframe(
-        self, reference: Union[str, tuple, WebElement, int], labels=[]
-    ):
-        """Switch to frame of given index, selector, selector name, or element."""
-        if isinstance(reference, int) or isinstance(reference, WebElement):
-            self.driver.switch_to.frame(reference)
-        elif isinstance(reference, str):
-            frame_selector = self.get_selector(reference, labels=labels)
-            self.expect(EC.frame_to_be_available_and_switch_to_it(frame_selector))
-        elif isinstance(reference, tuple):
-            self.expect(EC.frame_to_be_available_and_switch_to_it(reference))
+    def switch_to_iframe(self, index: int):
+        """Switch to frame of given index"""
+        self.driver.switch_to.frame(index)
         return self
 
     def switch_to_new_tab(self) -> Page:
@@ -772,6 +764,16 @@ class BasePage(Page):
             self.switch_to_new_window()
             self.title_contains("Private")
         self.driver.get("about:blank")
+        return self
+
+    def switch_to_frame(self, frame: str, labels=[]) -> Page:
+        """Switch to inline document frame"""
+        with self.driver.context(self.driver.CONTEXT_CHROME):
+            self.expect(
+                EC.frame_to_be_available_and_switch_to_it(
+                    self.get_selector(frame, labels=labels)
+                )
+            )
         return self
 
     def hide_popup(self, context_menu: str, chrome=True) -> Page:

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -711,7 +711,7 @@ class BasePage(Page):
     def switch_to_iframe(
         self, reference: Union[str, tuple, WebElement, int], labels=[]
     ):
-        """Switch to frame of given index, selector, selector name, or element"""
+        """Switch to frame of given index, selector, selector name, or element."""
         if isinstance(reference, int) or isinstance(reference, WebElement):
             self.driver.switch_to.frame(reference)
         elif isinstance(reference, str):

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -708,9 +708,17 @@ class BasePage(Page):
         self.driver.switch_to.default_content()
         return self
 
-    def switch_to_iframe(self, index: int):
+    def switch_to_iframe(
+        self, reference: Union[str, tuple, WebElement, int], labels=[]
+    ):
         """Switch to frame of given index"""
-        self.driver.switch_to.frame(index)
+        if isinstance(reference, int) or isinstance(reference, WebElement):
+            self.driver.switch_to.frame(reference)
+        elif isinstance(reference, str):
+            frame_selector = self.get_selector(reference, labels)
+            self.expect(EC.frame_to_be_available_and_switch_to_it(frame_selector))
+        elif isinstance(reference, tuple):
+            self.expect(EC.frame_to_be_available_and_switch_to_it(reference))
         return self
 
     def switch_to_new_tab(self) -> Page:
@@ -764,16 +772,6 @@ class BasePage(Page):
             self.switch_to_new_window()
             self.title_contains("Private")
         self.driver.get("about:blank")
-        return self
-
-    def switch_to_frame(self, frame: str, labels=[]) -> Page:
-        """Switch to inline document frame"""
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            self.expect(
-                EC.frame_to_be_available_and_switch_to_it(
-                    self.get_selector(frame, labels=labels)
-                )
-            )
         return self
 
     def hide_popup(self, context_menu: str, chrome=True) -> Page:

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -711,7 +711,7 @@ class BasePage(Page):
     def switch_to_iframe(
         self, reference: Union[str, tuple, WebElement, int], labels=[]
     ):
-        """Switch to frame of given index"""
+        """Switch to frame of given index, selector, selector name, or element"""
         if isinstance(reference, int) or isinstance(reference, WebElement):
             self.driver.switch_to.frame(reference)
         elif isinstance(reference, str):

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -93,6 +93,10 @@ class GenericPdf(BasePage):
         sleep(2)
         keyboard.press(Key.enter)
         keyboard.release(Key.enter)
+        sleep(2)
+        for _ in range(3):
+            keyboard.tap(Key.tab)
+        keyboard.tap(Key.enter)
         return self
 
     def fill_element(self, element: str, data: str) -> BasePage:


### PR DESCRIPTION
### Relevant Links

No ticket

### Description of Code / Doc Changes

* Removed `BasePage.switch_to_frame`
* Expanded `BasePage.switch_to_iframe` to handle all cases where we need to switch to an iframe.

### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [x] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

Currently we use a method in BrowserActions to switch iframes in almost all cases, but in #508 we added a method called `switch_to_iframe` on BasePage. That is where that method should live anyway, so it has been expanded to take a selector name, a selector tuple, a WebElement, or an index (int).

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_ **YES**

When we refactor any suite, we should eliminate calls to `BrowserActions.switch_to_iframe_context()` and `BrowserActions.switch_to_content_context()` and use `BasePage.switch_to_iframe()` and `BasePage.switch_to_default_frame()` instead. Then we should eliminate those methods from BrowserActions.

### Workflow Checklist

- [x] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
