### PR TITLE
fix chooser script model checker

### DIFF
--- a/choose_ci_set.py
+++ b/choose_ci_set.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
         "suite_conftest_re_string": r".*/.*/conftest\.py",
         "selectors_json_re_string": r"modules/data/.*\.components\.json",
         "object_model_re_string": r"modules/.*.object.*\.py",
-        "class_re_string": r"\s*class (\w+):",
+        "class_re_string": r"\s*class (\w+)[(A-Za-z0-9_)]*:",
     }
     for k in list(re_obj.keys()):
         if slash == "\\":

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -74,6 +74,7 @@ class GenericPdf(BasePage):
         return self
 
     def add_image(self, image_path: str, sys_platform: str) -> BasePage:
+        """Add an image to a pdf file"""
         self.get_element("toolbar-add-image").click()
         self.get_element("toolbar-add-image-confirm").click()
         sleep(3)


### PR DESCRIPTION
### Relevant Links

no ticket

### Description of Code / Doc Changes

Previous iterations of `choose_ci_set.py` failed to consider that POM/BOM classes may (and usually do) extend another class (the BasePage).

* Updates regex for class declarations in `choose_ci_set.py`
* Doc for `GenericPdf.add_image()`

### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [x] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

When we change a model file, we want to re-run all the tests that import any of the models in that file. The failing regex made it so these tests were not run.


### Workflow Checklist

- [x] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
