### PR TITLE
Anca/ l10n demo - Name/Organization fields autofill dropdown activation

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_dropdown_presence_name_org.py
+++ b/l10n_CM/Unified/test_demo_ad_dropdown_presence_name_org.py
@@ -1,0 +1,39 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import AddressFill
+from modules.util import Utilities
+
+
+@pytest.fixture()
+def test_case():
+    return "2888556"
+
+
+def test_dropdown_presence_name_organization(
+    driver: Firefox,
+    region: str,
+    address_autofill: AddressFill,
+    util: Utilities,
+    autofill_popup: AutofillPopup,
+):
+    """
+    C2888556 - Verify that the autofill dropdown is displayed  for the name and organization fields after an address was
+    previously saved
+    """
+
+    # Create fake data and fill it in
+    address_autofill.open()
+    address_autofill_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(address_autofill_data)
+
+    # Click the "Save" button
+    autofill_popup.click_doorhanger_button("save")
+
+    # Verify that the name and organization fields have the autofill dropdown present
+    fields_to_test = ["name", "organization"]
+
+    address_autofill.verify_autofill_dropdown_addresses(
+        autofill_popup=autofill_popup, fields_to_test=fields_to_test, region=region
+    )

--- a/l10n_CM/region/Unified.json
+++ b/l10n_CM/region/Unified.json
@@ -19,6 +19,7 @@
     "test_demo_ad_yellow_highlight_address.py",
     "test_demo_ad_yellow_highlight_phone_email.py",
     "test_demo_ad_dropdown_presence_address.py",
+    "test_demo_ad_dropdown_presence_name_org.py",
     "test_demo_ad_clear_name_org.py",
     "test_demo_ad_clear_address_fields.py",
     "test_demo_ad_clear_tel_email.py",


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1943165](https://bugzilla.mozilla.org/show_bug.cgi?id=1943165)
TestRail: [2888556](https://mozilla.testrail.io/index.php?/cases/view/2888556)

### Description of Code / Doc Changes

- Verify the autofill dropdown is triggered for name and organization fields if an address was saved.

### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

- N/A

### Comments or Future Work

- N/A

### Workflow Checklist

- [x ] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
