### PR TITLE
vs/accept cookies banner

### DIFF
--- a/tests/tabs/test_mute_tabs.py
+++ b/tests/tabs/test_mute_tabs.py
@@ -3,26 +3,31 @@ from os import environ
 import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
-
+from selenium.common.exceptions import NoSuchElementException
 from modules.browser_object import TabBar
-
 
 @pytest.fixture()
 def test_case():
     return "134719"
 
-
 GHA = environ.get("GITHUB_ACTIONS") == "true"
 
-
-@pytest.mark.skipif(GHA, reason="Test unstable in Github Actions")
 @pytest.mark.audio
 def test_mute_unmute_tab(screenshot, driver: Firefox, video_url: str):
     """C134719, test that tabs can be muted and unmuted"""
     tabs = TabBar(driver)
     driver.get(video_url)
+
+    # Dismiss cookie banner if present
+    try:
+        consent_button = driver.find_element(By.CSS_SELECTOR, "button[aria-label^='Accept all'], button[aria-label^='Accept the use']")
+        consent_button.click()
+    except NoSuchElementException:
+        pass  # Banner was not displayed; proceed normally
+
     play_button = driver.find_element(By.CSS_SELECTOR, ".ytp-play-button")
     play_button.click()
+
     with driver.context(driver.CONTEXT_CHROME):
         tabs.expect_tab_sound_status(1, tabs.MEDIA_STATUS.PLAYING)
         tabs.click_tab_mute_button(1)

--- a/tests/tabs/test_mute_tabs.py
+++ b/tests/tabs/test_mute_tabs.py
@@ -15,6 +15,7 @@ def test_case():
 
 GHA = environ.get("GITHUB_ACTIONS") == "true"
 
+@pytest.mark.headed
 @pytest.mark.audio
 def test_mute_unmute_tab(screenshot, driver: Firefox, video_url: str):
     """C134719, test that tabs can be muted and unmuted"""
@@ -33,7 +34,6 @@ def test_mute_unmute_tab(screenshot, driver: Firefox, video_url: str):
     # Scroll the play button into view before clicking
     play_button = driver.find_element(By.CSS_SELECTOR, PLAY_BUTTON_SELECTOR)
     driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", play_button)
-    play_button.click()
 
     with driver.context(driver.CONTEXT_CHROME):
         tabs.expect_tab_sound_status(1, tabs.MEDIA_STATUS.PLAYING)

--- a/tests/tabs/test_mute_tabs.py
+++ b/tests/tabs/test_mute_tabs.py
@@ -3,8 +3,11 @@ from os import environ
 import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException, ElementNotInteractableException
 from modules.browser_object import TabBar
+
+PLAY_BUTTON_SELECTOR = ".ytp-play-button"
+COOKIE_CONSENT_SELECTOR = "button[aria-label^='Accept all'], button[aria-label^='Accept the use']"
 
 @pytest.fixture()
 def test_case():
@@ -20,12 +23,16 @@ def test_mute_unmute_tab(screenshot, driver: Firefox, video_url: str):
 
     # Dismiss cookie banner if present
     try:
-        consent_button = driver.find_element(By.CSS_SELECTOR, "button[aria-label^='Accept all'], button[aria-label^='Accept the use']")
+        consent_button = driver.find_element(By.CSS_SELECTOR, COOKIE_CONSENT_SELECTOR)
         consent_button.click()
     except NoSuchElementException:
-        pass  # Banner was not displayed; proceed normally
+        pass  # Banner not displayed; proceed normally
+    except ElementNotInteractableException:
+        driver.execute_script("arguments[0].click();", consent_button)
 
-    play_button = driver.find_element(By.CSS_SELECTOR, ".ytp-play-button")
+    # Scroll the play button into view before clicking
+    play_button = driver.find_element(By.CSS_SELECTOR, PLAY_BUTTON_SELECTOR)
+    driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", play_button)
     play_button.click()
 
     with driver.context(driver.CONTEXT_CHROME):

--- a/tests/tabs/test_mute_tabs.py
+++ b/tests/tabs/test_mute_tabs.py
@@ -4,6 +4,7 @@ import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException, ElementNotInteractableException
+
 from modules.browser_object import TabBar
 
 PLAY_BUTTON_SELECTOR = ".ytp-play-button"
@@ -15,7 +16,7 @@ def test_case():
 
 GHA = environ.get("GITHUB_ACTIONS") == "true"
 
-@pytest.mark.headed
+@pytest.mark.skipif(GHA, reason="Test unstable in Github Actions")
 @pytest.mark.audio
 def test_mute_unmute_tab(screenshot, driver: Firefox, video_url: str):
     """C134719, test that tabs can be muted and unmuted"""
@@ -26,14 +27,11 @@ def test_mute_unmute_tab(screenshot, driver: Firefox, video_url: str):
     try:
         consent_button = driver.find_element(By.CSS_SELECTOR, COOKIE_CONSENT_SELECTOR)
         consent_button.click()
-    except NoSuchElementException:
-        pass  # Banner not displayed; proceed normally
-    except ElementNotInteractableException:
-        driver.execute_script("arguments[0].click();", consent_button)
+    except (NoSuchElementException, ElementNotInteractableException):
+        pass  # Banner wasn't displayed or not interactable; proceed normally
 
-    # Scroll the play button into view before clicking
     play_button = driver.find_element(By.CSS_SELECTOR, PLAY_BUTTON_SELECTOR)
-    driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", play_button)
+    play_button.click()
 
     with driver.context(driver.CONTEXT_CHROME):
         tabs.expect_tab_sound_status(1, tabs.MEDIA_STATUS.PLAYING)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1954094](https://bugzilla.mozilla.org/show_bug.cgi?id=1954094)

### Description of Code / Doc Changes

The reason for the test failure is that the cookies banner sometimes appears before the video is started. 
I made sure that the cookies banner is dismissed before playing the video.


