### PR TITLE
Anca/ Dev Edition - lang-pack from about:pref test stabilization

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -3058,6 +3058,13 @@ Description: Refresh Firefox dialog window
 Location: Dialog window
 Path to .json: modules/data/navigation.components.json
 ```
+```
+Selector Name: developer-tool-button
+Selector Data: developer-button
+Description: Developer tool icon
+Location: Navigation bar
+Path to .json: modules/data/navigation.components.json
+```
 #### panel_ui
 ```
 Selector name: panel-ui-button

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -588,5 +588,11 @@
         "selectorData": "window-modal-dialog",
         "strategy": "id",
         "groups": []
+    },
+
+    "developer-tool-button": {
+        "selectorData": "developer-button",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/preferences/test_lang_pack_changed_from_about_prefs.py
+++ b/tests/preferences/test_lang_pack_changed_from_about_prefs.py
@@ -1,4 +1,5 @@
 import pytest
+from selenium.common import TimeoutException
 from selenium.webdriver import Firefox
 
 from modules.browser_object import ContextMenu, PanelUi, TabBar
@@ -30,6 +31,18 @@ def test_lang_pack_changed_from_about_prefs(driver: Firefox):
     C1771617 - The language can be changed in about:preferences.
     We choose to set a pref rather than use a non-US local build.
     """
+    # Skip Developer Edition since modifying menus, messages, and notifications language is blocked and defaults to
+    # English
+    nav = Navigation(driver)
+    try:
+        if nav.element_exists("developer-tool-button"):
+            pytest.skip(
+                "Skipping test: Developer Edition detected dev tools button presence."
+            )
+    except TimeoutException:
+        pass  # If the element doesn't exist run the test
+
+    # Set the alternative language
     about_prefs = AboutPrefs(driver, category="general")
     about_prefs.open()
     about_prefs.set_alternative_language("pt-BR")
@@ -53,7 +66,6 @@ def test_lang_pack_changed_from_about_prefs(driver: Firefox):
     screen_cap = GenericPage(driver, url=SCREEN_CAP_URL)
     screen_cap.open()
     screen_cap.find_element("id", "start").click()
-    nav = Navigation(driver)
     nav.element_visible("popup-notification")
     nav.element_attribute_contains(
         "popup-notification", "label", SCREEN_CAP_LABEL_FRONT_PT


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1954095](https://bugzilla.mozilla.org/show_bug.cgi?id=1954095)
TestRail: [1771617](https://mozilla.testrail.io/index.php?/cases/view/1771617)

### Description of Code / Doc Changes

- Skip dev edition testing since, modifying menus, messages, and notifications language is blocked and defaults to English. Forcing an explicit pref in about:config doesn't unblock  this functionality.

### Comments or Future Work

- Waiting confirmation from Engineering regarding this behavior. Nevertheless this test will be skipped for now, whether the behavior is expected or a bug.

