### PR TITLE
Philimon/First set of refactors - Form Autofill

### DIFF
--- a/l10n_CM/Unified/test_demo_cc_add_new_credit_card.py
+++ b/l10n_CM/Unified/test_demo_cc_add_new_credit_card.py
@@ -25,7 +25,7 @@ def test_create_new_cc_profile(
 
     # Go to about:preferences#privacy and open Saved Payment Methods
     about_prefs_privacy.open()
-    about_prefs_privacy.switch_to_saved_payments_popup_iframe()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
     # Save CC information using fake data
     credit_card_sample_data = util.fake_credit_card_data(region)

--- a/l10n_CM/Unified/test_demo_cc_clear_form.py
+++ b/l10n_CM/Unified/test_demo_cc_clear_form.py
@@ -27,7 +27,7 @@ def test_cc_clear_form(
 
     # Save a credit card in about:preferences
     about_prefs_privacy.open()
-    about_prefs_privacy.switch_to_saved_payments_popup_iframe()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
     credit_card_sample_data = util.fake_credit_card_data(region)
     about_prefs.click_on("panel-popup-button", labels=["autofill-manage-add-button"])

--- a/l10n_CM/Unified/test_demo_cc_doorhanger_data_is_stored_in_about_prefs.py
+++ b/l10n_CM/Unified/test_demo_cc_doorhanger_data_is_stored_in_about_prefs.py
@@ -52,7 +52,7 @@ def test_demo_cc_data_captured_in_doorhanger_and_stored(
 
     # Navigate to about:preferences#privacy => "Autofill" section
     about_prefs_privacy.open()
-    about_prefs_privacy.switch_to_saved_payments_popup_iframe()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
     # Get stored values
     elements = [

--- a/l10n_CM/Unified/test_demo_cc_dropdown_presence.py
+++ b/l10n_CM/Unified/test_demo_cc_dropdown_presence.py
@@ -26,7 +26,7 @@ def test_dropdown_presence_credit_card(
 
     # Save a credit card in about:preferences
     about_prefs_privacy.open()
-    about_prefs_privacy.switch_to_saved_payments_popup_iframe()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
     credit_card_sample_data = util.fake_credit_card_data(region)
     about_prefs.click_on("panel-popup-button", labels=["autofill-manage-add-button"])

--- a/l10n_CM/Unified/test_demo_cc_yellow_highlight.py
+++ b/l10n_CM/Unified/test_demo_cc_yellow_highlight.py
@@ -26,7 +26,7 @@ def test_cc_yellow_highlight(
 
     # Save a credit card in about:preferences
     about_prefs_privacy.open()
-    about_prefs_privacy.switch_to_saved_payments_popup_iframe()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
     credit_card_sample_data = util.fake_credit_card_data(region)
     about_prefs.click_on("panel-popup-button", labels=["autofill-manage-add-button"])
     about_prefs.fill_cc_panel_information(credit_card_sample_data)

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -41,10 +41,10 @@ class AutofillPopup(BasePage):
         return self
 
     # Interaction with form options
+    @BasePage.context_chrome
     def click_autofill_form_option(self) -> BasePage:
         """Clicks the credit card or address selection in the autofill panel"""
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            self.get_element("select-form-option").click()
+        self.get_element("select-form-option").click()
         return self
 
     def click_clear_form_option(self) -> BasePage:
@@ -56,49 +56,49 @@ class AutofillPopup(BasePage):
         """Retrieves the last 4 digits of the credit card from the doorhanger popup"""
         return self.get_element("doorhanger-cc-number").text
 
+    @BasePage.context_chrome
     def get_cc_doorhanger_data(self, selector: str) -> str:
         """
         get text for the credit card doorhanger data.
         """
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            return self.get_element(selector).text
+        return self.get_element(selector).text
 
     # Interaction with autocomplete list elements
+    @BasePage.context_chrome
     def get_nth_element(self, index: str | int) -> WebElement:
         """
         Get the nth element from the autocomplete list
         Parameters: index (str): The index of the element to retrieve (1-based)
         Returns: WebElement: The nth element in the autocomplete list
         """
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            return self.wait.until(
-                EC.visibility_of_element_located(
-                    (
-                        "css selector",
-                        f".autocomplete-richlistbox .autocomplete-richlistitem:nth-child({index})",
-                    )
+        return self.wait.until(
+            EC.visibility_of_element_located(
+                (
+                    "css selector",
+                    f".autocomplete-richlistbox .autocomplete-richlistitem:nth-child({index})",
                 )
             )
+        )
 
+    @BasePage.context_chrome
     def select_nth_element(self, index: int):
         """
         Select the nth element from the autocomplete list
         Arguments:
             index (int): The index of the element to retrieve (1-based)
         """
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            self.expect(
-                EC.visibility_of(
-                    self.get_element("select-form-option-by-index", labels=[str(index)])
-                )
+        self.expect(
+            EC.visibility_of(
+                self.get_element("select-form-option-by-index", labels=[str(index)])
             )
-            self.get_element("select-form-option-by-index", labels=[str(index)]).click()
+        )
+        self.get_element("select-form-option-by-index", labels=[str(index)]).click()
 
+    @BasePage.context_chrome
     def get_primary_value(self, element: WebElement) -> str:
         """
         Get the primary value from the autocomplete element
         Parameters: element (WebElement): The autocomplete element from which to retrieve the primary value
         Returns: str: The primary value extracted from the element's attribute
         """
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            return element.get_attribute("ac-value")
+        return element.get_attribute("ac-value")

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -525,13 +525,13 @@ class AddressFill(Autofill):
 
         self.click_form_button("submit")
 
+    @BasePage.context_chrome
     def verify_autofill_displayed(self):
         """
         Verifies that the autofill suggestions are displayed.
         """
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            element = self.get_element("select-address")
-            self.expect(EC.visibility_of(element))
+        element = self.get_element("select-address")
+        self.expect(EC.visibility_of(element))
 
     def check_autofill_preview_for_field(
         self,

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -273,10 +273,10 @@ class CreditCardFill(Autofill):
         self.update_field(field_name, field_data, autofill_popup_obj)
         self.click_form_button("submit")
 
-        if not save_card:
-            autofill_popup_obj.click_on("update-card-info-popup-button")
-        else:
+        if save_card or field_name == "cc-number":
             autofill_popup_obj.click_on("doorhanger-save-button")
+        else:
+            autofill_popup_obj.click_on("update-card-info-popup-button")
 
     @BasePage.context_chrome
     def verify_autofill_cc_data_on_hover(

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -268,16 +268,15 @@ class AboutPrefs(BasePage):
         """
         Returns the iframe object for the dialog panel in the popup
         """
-        self.open_saved_payments_list()
+        self.get_saved_payments_popup().click()
         iframe = self.get_element("browser-popup")
         return iframe
 
-    def open_saved_payments_list(self):
+    def get_saved_payments_popup(self) -> WebElement:
         """
         Open saved payments dialog panel
         """
-        self.get_element("prefs-button", labels=["Saved payment methods"]).click()
-        return self
+        return self.get_element("prefs-button", labels=["Saved payment methods"])
 
     def click_edit_saved_payment(self):
         """
@@ -290,12 +289,12 @@ class AboutPrefs(BasePage):
         edit_button.click()
         return self
 
-    def switch_to_saved_payments_popup_iframe(self) -> BasePage:
+    def open_and_switch_to_saved_payments_popup(self) -> BasePage:
         """
-        Switch to saved payments popup frame.
+        Open and Switch to saved payments popup frame.
         """
-        saved_payments = self.get_saved_payments_popup_iframe()
-        self.driver.switch_to.frame(saved_payments)
+        saved_payments_iframe = self.get_saved_payments_popup_iframe()
+        self.driver.switch_to.frame(saved_payments_iframe)
         return self
 
     def switch_to_edit_saved_payments_popup_iframe(self) -> BasePage:
@@ -341,9 +340,25 @@ class AboutPrefs(BasePage):
         """
         return self.get_element("prefs-button", labels=["Saved addresses"])
 
+    def open_and_switch_to_saved_addresses_popup(self) -> BasePage:
+        """
+        Open and Switch to saved addresses popup frame.
+        """
+        saved_address_iframe = self.get_saved_addresses_popup_iframe()
+        self.driver.switch_to.frame(saved_address_iframe)
+        return self
+
     def switch_to_saved_addresses_popup_iframe(self) -> BasePage:
         """
         switch to save addresses popup frame.
+        """
+        self.switch_to_default_frame()
+        self.switch_to_iframe(1)
+        return self
+
+    def switch_to_saved_payments_popup_iframe(self) -> BasePage:
+        """
+        switch to save payments popup frame.
         """
         self.switch_to_default_frame()
         self.switch_to_iframe(1)

--- a/tests/form_autofill/conftest.py
+++ b/tests/form_autofill/conftest.py
@@ -1,5 +1,10 @@
 import pytest
 
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import AddressFill, CreditCardFill
+from modules.page_object_prefs import AboutPrefs
+from modules.util import Utilities
+
 
 @pytest.fixture()
 def suite_id():
@@ -20,3 +25,33 @@ def prefs_list(add_to_prefs_list: dict):
 @pytest.fixture()
 def add_to_prefs_list():
     return []
+
+
+@pytest.fixture()
+def address_autofill(driver):
+    yield AddressFill(driver)
+
+
+@pytest.fixture()
+def autofill_popup(driver):
+    yield AutofillPopup(driver)
+
+
+@pytest.fixture()
+def util():
+    yield Utilities()
+
+
+@pytest.fixture()
+def about_prefs_privacy(driver):
+    yield AboutPrefs(driver, category="privacy")
+
+
+@pytest.fixture()
+def about_prefs(driver):
+    yield AboutPrefs(driver)
+
+
+@pytest.fixture()
+def credit_card_autofill(driver):
+    yield CreditCardFill(driver)

--- a/tests/form_autofill/conftest.py
+++ b/tests/form_autofill/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from modules.browser_object_autofill_popup import AutofillPopup
@@ -20,6 +22,11 @@ def prefs_list(add_to_prefs_list: dict):
     ]
     prefs.extend(add_to_prefs_list)
     return prefs
+
+
+@pytest.fixture()
+def region():
+    return os.environ.get("FX_REGION", "US")
 
 
 @pytest.fixture()

--- a/tests/form_autofill/test_address_autofill_attribute.py
+++ b/tests/form_autofill/test_address_autofill_attribute.py
@@ -13,28 +13,35 @@ def test_case():
     return "122359"
 
 
-def test_address_attribute_selection(driver: Firefox):
+def test_address_attribute_selection(
+    driver: Firefox,
+    address_autofill: AddressFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+):
     """
     C122359 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
     item in the dropdown ensures that the actual value matches the expected value.
+
+    Arguments:
+        address_autofill: AddressFill instance
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
     """
-    # Instantiate objects and open the navigation page
-    address_form_fields = AddressFill(driver).open()
-    autofill_popup_panel = AutofillPopup(driver)
-    util = Utilities()
+    # open the navigation page
+    address_autofill.open()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
     autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
-    address_form_fields.save_information_basic(autofill_sample_data)
-    autofill_popup_panel.click_doorhanger_button("save")
+    address_autofill.save_information_basic(autofill_sample_data)
+    autofill_popup.click_doorhanger_button("save")
 
     # Double-click on the name field to trigger the autocomplete dropdown
-    address_form_fields.click_on("form-field", labels=["street-address"])
-    address_form_fields.click_on("form-field", labels=["street-address"])
+    address_autofill.double_click("form-field", labels=["street-address"])
 
     # Get the first element from the autocomplete dropdown
-    first_item = autofill_popup_panel.get_nth_element(1)
-    actual_value = autofill_popup_panel.hover(first_item).get_primary_value(first_item)
+    first_item = autofill_popup.get_nth_element(1)
+    actual_value = autofill_popup.hover(first_item).get_primary_value(first_item)
 
     # Get the primary value (street address) from the first item in the dropdown and assert that the actual value
     # matches the expected value

--- a/tests/form_autofill/test_address_autofill_attribute.py
+++ b/tests/form_autofill/test_address_autofill_attribute.py
@@ -5,8 +5,6 @@ from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
-COUNTRY_CODE = "US"
-
 
 @pytest.fixture()
 def test_case():
@@ -18,6 +16,7 @@ def test_address_attribute_selection(
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
     util: Utilities,
+    region: str,
 ):
     """
     C122359 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
@@ -27,12 +26,13 @@ def test_address_attribute_selection(
         address_autofill: AddressFill instance
         autofill_popup: AutofillPopup instance
         util: Utilities instance
+        region: country code in use
     """
     # open the navigation page
     address_autofill.open()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
+    autofill_sample_data = util.fake_autofill_data(region)
     address_autofill.save_information_basic(autofill_sample_data)
     autofill_popup.click_doorhanger_button("save")
 

--- a/tests/form_autofill/test_autofill_cc_cvv.py
+++ b/tests/form_autofill/test_autofill_cc_cvv.py
@@ -15,44 +15,46 @@ def test_case():
     return "122399"
 
 
-def test_autofill_cc_cvv(driver: Firefox):
+def test_autofill_cc_cvv(
+    driver: Firefox,
+    credit_card_autofill: CreditCardFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+    about_prefs_privacy: AboutPrefs,
+):
     """
     C122399, Test form autofill CC CVV number
-    """
-    # instantiate objects
-    credit_card_autofill = CreditCardFill(driver).open()
-    autofill_popup = AutofillPopup(driver)
-    util = Utilities()
-    about_prefs_obj = AboutPrefs(driver, category="privacy")
-    browser_action_obj = BrowserActions(driver)
 
-    # create fake data, fill it in and press submit and save on the doorhanger
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance
+        credit_card_autofill: CreditCardFill instance
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
+    """
+
+    # open credit card autofill page
+    credit_card_autofill.open()
+
+    # create fake data, fill it in and press submit and save on the door hanger
     credit_card_sample_data = util.fake_credit_card_data()
     credit_card_autofill.fill_credit_card_info(credit_card_sample_data)
     cvv = credit_card_sample_data.cvv
     autofill_popup.click_doorhanger_button("save")
 
     # navigate to prefs
+    about_prefs_privacy.open()
+    about_prefs_privacy.switch_to_saved_payments_popup_iframe()
 
-    about_prefs_obj.open()
-    iframe = about_prefs_obj.press_button_get_popup_dialog_iframe(
-        "Saved payment methods"
-    )
-    browser_action_obj.switch_to_iframe_context(iframe)
+    # Get the saved CC data (first entry)
+    cc_profile = about_prefs_privacy.get_all_saved_cc_profiles()[0]
+    cc_info_json = json.loads(cc_profile.get_dom_attribute("data-l10n-args"))
 
-    # Select the saved cc
-    saved_profile = about_prefs_obj.get_element("cc-saved-options")
-    info_string = saved_profile.get_attribute("data-l10n-args")
-    cc_info_json_original = json.loads(info_string)
-    logging.info(f"Extracted Original data: {cc_info_json_original}")
-    saved_profile.click()
+    # Compare input CC data with saved CC data
+    about_prefs_privacy.verify_cc_json(cc_info_json, credit_card_sample_data)
 
-    # Click on edit
-    about_prefs_obj.get_element(
-        "panel-popup-button", labels=["autofill-manage-edit-button"]
-    ).click()
+    # Click on saved address and edit
+    cc_profile.click()
+    about_prefs_privacy.click_edit_saved_payment()
 
-    # Verify that CVV number is not saved under CC profile
-    element = about_prefs_obj.get_element("cc-saved-options", multiple=True)
-    cvv_not_displayed = not any(cvv in element.text for element in element)
-    assert cvv_not_displayed, "CVV is displayed."
+    # Verify that CVV number is not saved under CC profile but the rest of the data is saved
+    about_prefs_privacy.verify_cc_edit_saved_payments_profile(credit_card_sample_data)

--- a/tests/form_autofill/test_autofill_cc_cvv.py
+++ b/tests/form_autofill/test_autofill_cc_cvv.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 import pytest
 from selenium.webdriver import Firefox
@@ -7,7 +6,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import CreditCardFill
 from modules.page_object_prefs import AboutPrefs
-from modules.util import BrowserActions, Utilities
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -26,7 +25,7 @@ def test_autofill_cc_cvv(
     C122399, Test form autofill CC CVV number
 
     Arguments:
-        about_prefs_privacy: AboutPrefs instance
+        about_prefs_privacy: AboutPrefs instance (privacy category)
         credit_card_autofill: CreditCardFill instance
         autofill_popup: AutofillPopup instance
         util: Utilities instance
@@ -43,7 +42,7 @@ def test_autofill_cc_cvv(
 
     # navigate to prefs
     about_prefs_privacy.open()
-    about_prefs_privacy.switch_to_saved_payments_popup_iframe()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
     # Get the saved CC data (first entry)
     cc_profile = about_prefs_privacy.get_all_saved_cc_profiles()[0]

--- a/tests/form_autofill/test_autofill_credit_card.py
+++ b/tests/form_autofill/test_autofill_credit_card.py
@@ -11,17 +11,25 @@ def test_case():
     return "122405"
 
 
-def test_autofill_credit_card(driver: Firefox):
+def test_autofill_credit_card(
+    driver: Firefox,
+    util: Utilities,
+    credit_card_autofill: CreditCardFill,
+    autofill_popup: AutofillPopup,
+):
     """
     C122405, tests that after filling autofill and disabling cc info it appears in panel
-    """
-    util = Utilities()
 
-    credit_card_fill_obj = CreditCardFill(driver).open()
-    autofill_popup = AutofillPopup(driver)
+    Arguments:
+        credit_card_autofill: CreditCardFill instance
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
+    """
+
+    credit_card_autofill.open()
 
     credit_card_data = util.fake_credit_card_data()
-    credit_card_fill_obj.fill_credit_card_info(credit_card_data)
+    credit_card_autofill.fill_credit_card_info(credit_card_data)
     autofill_popup.click_doorhanger_button("save")
 
-    credit_card_fill_obj.autofill_and_clear_all_fields(autofill_popup, credit_card_data)
+    credit_card_autofill.autofill_and_clear_all_fields(autofill_popup, credit_card_data)

--- a/tests/form_autofill/test_autofill_credit_card_doorhanger.py
+++ b/tests/form_autofill/test_autofill_credit_card_doorhanger.py
@@ -12,28 +12,35 @@ def test_case():
     return "122392"
 
 
-def test_autofill_credit_card_doorhanger(driver: Firefox):
+def test_autofill_credit_card_doorhanger(
+    driver: Firefox,
+    about_prefs_privacy: AboutPrefs,
+    autofill_popup: AutofillPopup,
+    credit_card_autofill: CreditCardFill,
+    util: Utilities,
+):
     """
     C122392, ensures that pressing not now > never save cards toggles off the setting
-    """
-    # instantiate objects
-    about_prefs_obj = AboutPrefs(driver, category="privacy")
-    autofill_popup_obj = AutofillPopup(driver)
-    util = Utilities()
 
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        autofill_popup: AutofillPopup instance
+        credit_card_autofill: CreditCardFill instance
+        util: Utilities instance
+    """
     # navigate to page
-    credit_card_fill_obj = CreditCardFill(driver).open()
+    credit_card_autofill.open()
 
     # fill data
     credit_card_sample_data = util.fake_credit_card_data()
-    credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
+    credit_card_autofill.fill_credit_card_info(credit_card_sample_data)
 
     # press the arrow
-    autofill_popup_obj.click_doorhanger_button("dropdown")
-    autofill_popup_obj.click_doorhanger_button("dropdown-never-save-cards")
+    autofill_popup.click_doorhanger_button("dropdown")
+    autofill_popup.click_doorhanger_button("dropdown-never-save-cards")
 
     # ensure that the checked attribute is off
-    about_prefs_obj.open()
-    payment_checkbox = about_prefs_obj.get_element("save-and-fill-payment-methods")
+    about_prefs_privacy.open()
+    payment_checkbox = about_prefs_privacy.get_element("save-and-fill-payment-methods")
     checked_attr = payment_checkbox.get_attribute("checked")
     assert checked_attr is None

--- a/tests/form_autofill/test_autofill_credit_card_enable.py
+++ b/tests/form_autofill/test_autofill_credit_card_enable.py
@@ -12,20 +12,30 @@ def test_case():
     return "122388"
 
 
-def test_enable_disable_form_autofill_cc(driver: Firefox):
+def test_enable_disable_form_autofill_cc(
+    driver: Firefox,
+    about_prefs_privacy: AboutPrefs,
+    autofill_popup: AutofillPopup,
+    credit_card_autofill: CreditCardFill,
+    util: Utilities,
+):
     """
     C122388, tests that after saving cc information and toggling the autofill credit
     cards box the dropdown does not appear.
+
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        autofill_popup: AutofillPopup instance
+        credit_card_autofill: CreditCardFill instance
+        util: Utilities instance
     """
-    util = Utilities()
 
-    credit_card_fill_obj = CreditCardFill(driver).open()
-    autofill_popup_obj = AutofillPopup(driver)
+    credit_card_autofill.open()
 
-    credit_card_fill_obj.fake_and_fill(util, autofill_popup_obj)
+    credit_card_autofill.fake_and_fill(util, autofill_popup)
 
-    about_prefs = AboutPrefs(driver, category="privacy").open()
-    about_prefs.get_element("save-and-fill-payment-methods").click()
+    about_prefs_privacy.open()
+    about_prefs_privacy.get_element("save-and-fill-payment-methods").click()
 
     new_credit_card_fill_obj = CreditCardFill(driver).open()
     new_autofill_popup_obj = AutofillPopup(driver)

--- a/tests/form_autofill/test_autofill_credit_card_four_fields.py
+++ b/tests/form_autofill/test_autofill_credit_card_four_fields.py
@@ -11,18 +11,25 @@ def test_case():
     return "122404"
 
 
-def test_autofill_four_fields(driver: Firefox):
+def test_autofill_four_fields(
+    driver: Firefox,
+    autofill_popup: AutofillPopup,
+    credit_card_autofill: CreditCardFill,
+    util: Utilities,
+):
     """
     C122404, tests that the form fields are filled corrected after saving a profile.
-    """
-    util = Utilities()
 
-    credit_card_fill_obj = CreditCardFill(driver).open()
-    autofill_popup_obj = AutofillPopup(driver)
+    Arguments:
+        autofill_popup: AutofillPopup instance
+        credit_card_autofill: CreditCardFill instance
+        util: Utilities instance
+    """
+    credit_card_autofill.open()
 
     credit_card_sample_data = util.fake_credit_card_data()
-    credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
-    autofill_popup_obj.click_doorhanger_button("save")
+    credit_card_autofill.fill_credit_card_info(credit_card_sample_data)
+    autofill_popup.click_doorhanger_button("save")
 
-    credit_card_fill_obj.press_autofill_panel(autofill_popup_obj)
-    credit_card_fill_obj.verify_credit_card_form_data(credit_card_sample_data)
+    credit_card_autofill.press_autofill_panel(autofill_popup)
+    credit_card_autofill.verify_credit_card_form_data(credit_card_sample_data)

--- a/tests/form_autofill/test_cc_clear_form.py
+++ b/tests/form_autofill/test_cc_clear_form.py
@@ -11,26 +11,30 @@ def test_case():
     return "122581"
 
 
-def test_clear_form_credit_card(driver: Firefox):
+def test_clear_form_credit_card(
+    driver: Firefox,
+    autofill_popup: AutofillPopup,
+    credit_card_autofill: CreditCardFill,
+    util: Utilities,
+):
     """
     C122581, Test clear form credit card
+
+    Arguments:
+        autofill_popup: AutofillPopup instance
+        credit_card_autofill: CreditCardFill instance
+        util: Utilities instance
     """
-    # instantiate objects
-    credit_card_autofill = CreditCardFill(driver).open()
-    autofill_popup = AutofillPopup(driver)
-    util = Utilities()
+    credit_card_autofill.open()
 
     # create fake data, fill it in and press submit and save on the doorhanger
     credit_card_sample_data = util.fake_credit_card_data()
     credit_card_autofill.fill_credit_card_info(credit_card_sample_data)
     autofill_popup.click_doorhanger_button("save")
 
-    # creating new objects to prevent stale webelements
-    new_credit_card_autofill = CreditCardFill(driver).open()
-
     # Open dropdown, select first option, clear autofill form and verify autofill is displayed
-    new_credit_card_autofill.get_element("form-field", labels=["cc-name"]).click()
+    credit_card_autofill.get_element("form-field", labels=["cc-name"]).click()
     autofill_popup.click_autofill_form_option()
-    new_credit_card_autofill.get_element("form-field", labels=["cc-name"]).click()
+    credit_card_autofill.get_element("form-field", labels=["cc-name"]).click()
     autofill_popup.click_clear_form_option()
     autofill_popup.verify_autofill_displayed()

--- a/tests/form_autofill/test_clear_form.py
+++ b/tests/form_autofill/test_clear_form.py
@@ -5,34 +5,38 @@ from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
-COUNTRY_CODE = "US"
-
 
 @pytest.fixture()
 def test_case():
     return "122574"
 
 
-def test_clear_form(driver: Firefox):
+def test_clear_form(
+    driver: Firefox,
+    address_autofill: AddressFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+    region: str,
+):
     """
     C122574, test clear autofill form
+
+    Arguments:
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
+        region: country code in use
     """
-    # instantiate objects
-    address_autofill = AddressFill(driver).open()
-    address_autofill_popup = AutofillPopup(driver)
-    util = Utilities()
+    # open address page
+    address_autofill.open()
 
     # create fake data, fill it in and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
+    autofill_sample_data = util.fake_autofill_data(region)
     address_autofill.save_information_basic(autofill_sample_data)
-    address_autofill_popup.click_doorhanger_button("save")
-
-    # creating new objects to prevent stale webelements
-    new_address_autofill = AddressFill(driver).open()
+    autofill_popup.click_doorhanger_button("save")
 
     # Open dropdown and select first option and clear autofill form
-    new_address_autofill.triple_click("form-field", labels=["name"])
-    address_autofill_popup.click_autofill_form_option()
-    new_address_autofill.click_on("form-field", labels=["name"])
+    address_autofill.triple_click("form-field", labels=["name"])
+    autofill_popup.click_autofill_form_option()
+    address_autofill.click_on("form-field", labels=["name"])
     # Verify that the form autofill suggestions are displayed.
-    address_autofill_popup.verify_element_displayed("select-form-option")
+    autofill_popup.verify_element_displayed("select-form-option")

--- a/tests/form_autofill/test_create_new_cc_profile.py
+++ b/tests/form_autofill/test_create_new_cc_profile.py
@@ -4,7 +4,7 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.page_object import AboutPrefs
-from modules.util import BrowserActions, Utilities
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -12,32 +12,36 @@ def test_case():
     return "122389"
 
 
-def test_create_new_cc_profile(driver: Firefox):
+def test_create_new_cc_profile(
+    driver: Firefox,
+    about_prefs_privacy: AboutPrefs,
+    about_prefs: AboutPrefs,
+    util: Utilities,
+):
     """
     C122389, tests you can create and save a new Credit Card profile
-    """
-    # instantiate objects
-    util = Utilities()
-    browser_action_obj = BrowserActions(driver)
 
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        about_prefs: AboutPrefs instance
+        util: Utilities instance
+    """
     # go to about:preferences#privacy and open Saved Payment Methods
-    about_prefs = AboutPrefs(driver, category="privacy").open()
-    iframe = about_prefs.get_saved_payments_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs_privacy.open()
+    about_prefs.open_and_switch_to_saved_payments_popup()
 
     # save CC data by using the fake data
     credit_card_sample_data = util.fake_credit_card_data()
-    about_prefs_cc_popup = AboutPrefs(driver)
 
     # add a new CC profile
-    about_prefs_cc_popup.get_element(
+    about_prefs.get_element(
         "panel-popup-button", labels=["autofill-manage-add-button"]
     ).click()
 
     about_prefs.fill_cc_panel_information(credit_card_sample_data)
 
     # get the saved CC data
-    cc_profiles = about_prefs_cc_popup.get_all_saved_cc_profiles()
+    cc_profiles = about_prefs.get_all_saved_cc_profiles()
     cc_info_json = json.loads(cc_profiles[0].get_dom_attribute("data-l10n-args"))
 
     # compare input CC data with saved CC data

--- a/tests/form_autofill/test_create_profile_autofill.py
+++ b/tests/form_autofill/test_create_profile_autofill.py
@@ -2,9 +2,7 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.page_object import AboutPrefs
-from modules.util import BrowserActions, Utilities
-
-COUNTRY_CODE = "US"
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -12,39 +10,34 @@ def test_case():
     return "122348"
 
 
-def test_create_address_profile(driver: Firefox):
+def test_create_address_profile(
+    driver: Firefox, about_prefs_privacy: AboutPrefs, util: Utilities, region: str
+):
     """
     C122348, creating an address profile
-    """
-    about_prefs_obj = AboutPrefs(driver, category="privacy")
-    util = Utilities()
-    browser_action_obj = BrowserActions(driver)
 
-    about_prefs_obj.open()
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        util: Utilities instance
+        region: country code in use
+    """
+    about_prefs_privacy.open()
 
     # create sample data
-    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
-    iframe_address_popup = about_prefs_obj.press_button_get_popup_dialog_iframe(
-        "Saved addresses"
-    )
-    browser_action_obj.switch_to_iframe_context(iframe_address_popup)
-    about_prefs_obj.get_element(
+    autofill_sample_data = util.fake_autofill_data(region)
+    about_prefs_privacy.open_and_switch_to_saved_addresses_popup()
+    about_prefs_privacy.get_element(
         "panel-popup-button", labels=["autofill-manage-add-button"]
     ).click()
 
     # fill in the data and clean it up
-    about_prefs_obj.add_entry_to_saved_addresses(autofill_sample_data)
-    about_prefs_obj.switch_to_saved_addresses_popup_iframe()
-    saved_address_option = about_prefs_obj.get_element("saved-addresses")
+    about_prefs_privacy.add_entry_to_saved_addresses(autofill_sample_data)
+    about_prefs_privacy.switch_to_saved_addresses_popup_iframe()
+    saved_address_option = about_prefs_privacy.get_element("saved-addresses")
     inner_content = saved_address_option.get_attribute("innerHTML")
-    cleaned_data = about_prefs_obj.extract_content_from_html(inner_content)
-    split_text = about_prefs_obj.extract_and_split_text(cleaned_data)
-    print(inner_content)
-    print(cleaned_data)
-    print(split_text)
-    observed_data = about_prefs_obj.organize_data_into_obj(split_text)
-    print(autofill_sample_data)
-    print(observed_data)
+    cleaned_data = about_prefs_privacy.extract_content_from_html(inner_content)
+    split_text = about_prefs_privacy.extract_and_split_text(cleaned_data)
+    observed_data = about_prefs_privacy.organize_data_into_obj(split_text)
 
     # currently ignoring the address level 1 field
     observed_data.telephone = util.normalize_phone_number(observed_data.telephone)

--- a/tests/form_autofill/test_delete_cc_profile.py
+++ b/tests/form_autofill/test_delete_cc_profile.py
@@ -4,7 +4,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object import AboutPrefs
 from modules.page_object_autofill import CreditCardFill
-from modules.util import BrowserActions, Utilities
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -12,38 +12,46 @@ def test_case():
     return "122391"
 
 
-def test_delete_cc_profile(driver: Firefox):
+def test_delete_cc_profile(
+    driver: Firefox,
+    about_prefs: AboutPrefs,
+    about_prefs_privacy: AboutPrefs,
+    autofill_popup: AutofillPopup,
+    credit_card_autofill: CreditCardFill,
+    util: Utilities,
+):
     """
     C122391, Ensuring that deleting cc profiles will make it so CC does not show up in the grid
+
+    Arguments:
+        about_prefs: AboutPrefs instance
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        autofill_popup: AutofillPopup instance
+        credit_card_autofill: CreditCardFill instance
+        util: Utilities instance
     """
     # instantiate objects
-    util = Utilities()
-
-    credit_card_fill_obj = CreditCardFill(driver).open()
-    autofill_popup_obj = AutofillPopup(driver)
-    browser_action_obj = BrowserActions(driver)
+    credit_card_autofill.open()
 
     # create two profiles
     credit_card_sample_data = util.fake_credit_card_data()
-    credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
-    autofill_popup_obj.click_doorhanger_button("save")
+    credit_card_autofill.fill_credit_card_info(credit_card_sample_data)
+    autofill_popup.click_doorhanger_button("save")
 
     credit_card_sample_data = util.fake_credit_card_data()
-    credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
-    autofill_popup_obj.click_doorhanger_button("save")
+    credit_card_autofill.fill_credit_card_info(credit_card_sample_data)
+    autofill_popup.click_doorhanger_button("save")
 
     # navigate to prefs
-    about_prefs = AboutPrefs(driver, category="privacy").open()
-    iframe = about_prefs.get_saved_payments_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs_privacy.open()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
     # verify there are 2 profiles at first
-    about_prefs_cc_popup = AboutPrefs(driver)
-    cc_profiles = about_prefs_cc_popup.get_all_saved_cc_profiles()
+    cc_profiles = about_prefs.get_all_saved_cc_profiles()
     assert len(cc_profiles) == 2
 
     # delete a profile and verify there is only 1 left
     cc_profiles[0].click()
-    about_prefs_cc_popup.click_popup_panel_button("autofill-manage-remove-button")
-    cc_profiles = about_prefs_cc_popup.get_all_saved_cc_profiles()
+    about_prefs.click_popup_panel_button("autofill-manage-remove-button")
+    cc_profiles = about_prefs.get_all_saved_cc_profiles()
     assert len(cc_profiles) == 1

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -22,47 +22,49 @@ def hard_quit():
     return True
 
 
-tabs = [i for i in range(4)]
-
-
-@pytest.mark.parametrize("num_tabs", tabs)
-def test_edit_credit_card_profile(driver: Firefox, num_tabs: int, hard_quit):
+@pytest.mark.parametrize("num_tabs", range(4))
+def test_edit_credit_card_profile(
+    driver: Firefox,
+    num_tabs: int,
+    hard_quit,
+    about_prefs_privacy: AboutPrefs,
+    util: Utilities,
+    credit_card_autofill: CreditCardFill,
+    autofill_popup: AutofillPopup,
+):
     """
     C122390, ensures that editing a credit card profile in the about:prefs
     has the correct behaviour
+
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        autofill_popup: AutofillPopup instance
+        credit_card_autofill: CreditCardFill instance
+        util: Utilities instance
     """
-    # instantiate objects
-    about_prefs_obj = AboutPrefs(driver, category="privacy")
-    util = Utilities()
-    browser_action_obj = BrowserActions(driver)
-    credit_card_fill_obj = CreditCardFill(driver)
-    autofill_popup_obj = AutofillPopup(driver)
 
     # fill in cc information
-    credit_card_fill_obj.open()
+    credit_card_autofill.open()
     credit_card_sample_data_original = util.fake_credit_card_data()
-    credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data_original)
-    autofill_popup_obj.click_doorhanger_button("save")
+    credit_card_autofill.fill_credit_card_info(credit_card_sample_data_original)
+    autofill_popup.click_doorhanger_button("save")
 
     # navigate to about:prefs and select the saved payment methods
-    about_prefs_obj.open()
-    iframe = about_prefs_obj.press_button_get_popup_dialog_iframe(
-        "Saved payment methods"
-    )
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs_privacy.open()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
     # fetch the saved cc profile and select edit
-    saved_profile = about_prefs_obj.get_element("cc-saved-options")
+    saved_profile = about_prefs_privacy.get_element("cc-saved-options")
     info_string = saved_profile.get_attribute("data-l10n-args")
     cc_info_json_original = json.loads(info_string)
     logging.info(f"Extracted Original data: {cc_info_json_original}")
     saved_profile.click()
 
     # assert that the edit button is clickable
-    panel_edit_button = about_prefs_obj.get_element(
+    panel_edit_button = about_prefs_privacy.get_element(
         "panel-popup-button", labels=["autofill-manage-edit-button"]
     )
-    about_prefs_obj.expect(EC.element_to_be_clickable(panel_edit_button))
+    about_prefs_privacy.expect(EC.element_to_be_clickable(panel_edit_button))
 
     # ensure the same year or month is not generated
     credit_card_sample_data_new = util.fake_credit_card_data()
@@ -92,26 +94,26 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int, hard_quit):
     # modify some values
     panel_edit_button.click()
 
-    about_prefs_obj.update_cc_field_panel(num_tabs, tab_num_to_data[num_tabs])
+    about_prefs_privacy.update_cc_field_panel(num_tabs, tab_num_to_data[num_tabs])
 
     # ensure that the information is updated using a trick with the dialog templates
-    browser_action_obj.switch_to_content_context()
-    dialog_stack = about_prefs_obj.get_element("panel-popup-stack")
-    about_prefs_obj.custom_wait(timeout=15).until_not(
+    about_prefs_privacy.switch_to_default_frame()
+    dialog_stack = about_prefs_privacy.get_element("panel-popup-stack")
+    about_prefs_privacy.custom_wait(timeout=15).until_not(
         lambda _: len(dialog_stack.find_elements(By.ID, "dialogTemplate")) >= 3,
         message="Timeout waiting for the number of dialogTemplate elements to drop below 3",
     )
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs_privacy.switch_to_saved_payments_popup_iframe()
 
     # fetch the edited profile, ensure that the attribute containing the data is new
-    about_prefs_obj.expect_not(
+    about_prefs_privacy.expect_not(
         EC.text_to_be_present_in_element_attribute(
-            about_prefs_obj.get_selector("cc-saved-options"),
+            about_prefs_privacy.get_selector("cc-saved-options"),
             "data-l10n-args",
             tab_num_to_original_data[num_tabs],
         )
     )
-    edited_profile = about_prefs_obj.get_element("cc-saved-options")
+    edited_profile = about_prefs_privacy.get_element("cc-saved-options")
 
     cc_info_json = json.loads(edited_profile.get_attribute("data-l10n-args"))
     logging.info(f"Extracted Edited data: {cc_info_json}")
@@ -135,9 +137,9 @@ def test_edit_credit_card_profile(driver: Firefox, num_tabs: int, hard_quit):
     else:
         credit_card_sample_data_original.name = credit_card_sample_data_new.name
 
-    about_prefs_obj.verify_cc_json(cc_info_json, credit_card_sample_data_original)
+    about_prefs_privacy.verify_cc_json(cc_info_json, credit_card_sample_data_original)
 
     # close the pop-up
-    browser_action_obj.switch_to_content_context()
-    about_prefs_obj.click_on("dialog-close-button")
+    about_prefs_privacy.switch_to_default_frame()
+    about_prefs_privacy.click_on("dialog-close-button")
     driver.quit()

--- a/tests/form_autofill/test_enable_disable_autofill.py
+++ b/tests/form_autofill/test_enable_disable_autofill.py
@@ -7,36 +7,41 @@ from modules.page_object import AboutPrefs
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
-COUNTRY_CODE = "US"
-
 
 @pytest.fixture()
 def test_case():
     return "122347"
 
 
-def test_enable_disable_autofill(driver: Firefox):
+def test_enable_disable_autofill(
+    driver: Firefox,
+    about_prefs_privacy: AboutPrefs,
+    address_autofill: AddressFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+    region: str,
+):
     """
     C122347, tests that after filling autofill and disabling it in settings that
     the autofill popups do not appear.
+
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
     """
-    # instantiate objects
-    Navigation(driver)
-    af = AddressFill(driver).open()
-    afp = AutofillPopup(driver)
-    util = Utilities()
+    address_autofill.open()
 
     # create fake data, fill it in and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
-    af.save_information_basic(autofill_sample_data)
-    afp.click_doorhanger_button("save")
-    about_prefs = AboutPrefs(driver, category="privacy").open()
-    about_prefs.get_element("save-and-fill-addresses").click()
+    autofill_sample_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(autofill_sample_data)
+    autofill_popup.click_doorhanger_button("save")
 
-    # creating new objects to prevent stale webelements
-    new_af = AddressFill(driver).open()
-    new_afp = AutofillPopup(driver)
+    about_prefs_privacy.open()
+    about_prefs_privacy.get_element("save-and-fill-addresses").click()
+
+    address_autofill.open()
 
     # verifying the popup panel does not appear
-    new_af.double_click("form-field", labels=["name"])
-    new_afp.ensure_autofill_dropdown_not_visible()
+    address_autofill.double_click("form-field", labels=["name"])
+    autofill_popup.ensure_autofill_dropdown_not_visible()

--- a/tests/form_autofill/test_form_autofill_suggestions.py
+++ b/tests/form_autofill/test_form_autofill_suggestions.py
@@ -11,29 +11,34 @@ def test_case():
     return "122401"
 
 
-def test_form_autofill_suggestions(driver: Firefox):
+def test_form_autofill_suggestions(
+    driver: Firefox,
+    autofill_popup: AutofillPopup,
+    credit_card_autofill: CreditCardFill,
+    util: Utilities,
+):
     """
     C122401, checks that the corresponding autofill suggestion autofills the fields correctly
+
+    Arguments:
+        autofill_popup: AutofillPopup instance
+        credit_card_autofill: CreditCardFill instance
+        util: Utilities instance
     """
-    # instantiate objects
-    util = Utilities()
-
-    credit_card_fill_obj = CreditCardFill(driver).open()
-    autofill_popup_obj = AutofillPopup(driver)
-
+    credit_card_autofill.open()
     # create fake data, two profiles
     sample_data = [
-        credit_card_fill_obj.fake_and_fill(util, autofill_popup_obj) for _ in range(2)
+        credit_card_autofill.fake_and_fill(util, autofill_popup) for _ in range(2)
     ]
     # reverse data list to match form options
     sample_data.reverse()
 
     # press the corresponding option (according to the parameter)
-    credit_card_fill_obj.click_on("form-field", labels=["cc-name"])
+    credit_card_autofill.click_on("form-field", labels=["cc-name"])
 
     # verify form data in reverse (newer options are at the top)
     for idx in range(1, 3):
-        autofill_popup_obj.select_nth_element(idx)
-        credit_card_fill_obj.verify_credit_card_form_data(sample_data[idx - 1])
-        credit_card_fill_obj.click_on("form-field", labels=["cc-name"])
-        autofill_popup_obj.click_clear_form_option()
+        autofill_popup.select_nth_element(idx)
+        credit_card_autofill.verify_credit_card_form_data(sample_data[idx - 1])
+        credit_card_autofill.click_on("form-field", labels=["cc-name"])
+        autofill_popup.click_clear_form_option()

--- a/tests/form_autofill/test_name_autofill_attribute.py
+++ b/tests/form_autofill/test_name_autofill_attribute.py
@@ -5,8 +5,6 @@ from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
-COUNTRY_CODE = "US"
-
 
 @pytest.fixture()
 def test_case():
@@ -18,6 +16,7 @@ def test_name_attribute_selection(
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
     util: Utilities,
+    region: str,
 ):
     """
     C122356 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
@@ -28,12 +27,13 @@ def test_name_attribute_selection(
         address_autofill: AddressFill instance
         autofill_popup: AutofillPopup instance
         util: Utilities instance
+        region: country code in use
     """
     # open the navigation page
     address_autofill.open()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
+    autofill_sample_data = util.fake_autofill_data(region)
     address_autofill.save_information_basic(autofill_sample_data)
     autofill_popup.click_doorhanger_button("save")
 

--- a/tests/form_autofill/test_name_autofill_attribute.py
+++ b/tests/form_autofill/test_name_autofill_attribute.py
@@ -13,28 +13,36 @@ def test_case():
     return "122356"
 
 
-def test_name_attribute_selection(driver: Firefox):
+def test_name_attribute_selection(
+    driver: Firefox,
+    address_autofill: AddressFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+):
     """
     C122356 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
     item in the dropdown ensures that the actual value matches the expected value.
+    Verifies name attribute.
+
+    Arguments:
+        address_autofill: AddressFill instance
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
     """
-    # Instantiate objects and open the navigation page
-    address_form_fields = AddressFill(driver).open()
-    autofill_popup_panel = AutofillPopup(driver)
-    util = Utilities()
+    # open the navigation page
+    address_autofill.open()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
     autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
-    address_form_fields.save_information_basic(autofill_sample_data)
-    autofill_popup_panel.click_doorhanger_button("save")
+    address_autofill.save_information_basic(autofill_sample_data)
+    autofill_popup.click_doorhanger_button("save")
 
     # Double-click on the name field to trigger the autocomplete dropdown
-    address_form_fields.click_on("form-field", labels=["name"])
-    address_form_fields.click_on("form-field", labels=["name"])
+    address_autofill.double_click("form-field", labels=["name"])
 
     # Get the first element from the autocomplete dropdown
-    first_item = autofill_popup_panel.get_nth_element(1)
-    actual_value = autofill_popup_panel.hover(first_item).get_primary_value(first_item)
+    first_item = autofill_popup.get_nth_element(1)
+    actual_value = autofill_popup.hover(first_item).get_primary_value(first_item)
 
     # Get the primary value (street address) from the first item in the dropdown and assert that the actual value
     # matches the expected value

--- a/tests/form_autofill/test_private_mode_info_not_saved.py
+++ b/tests/form_autofill/test_private_mode_info_not_saved.py
@@ -4,9 +4,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object import AutofillPopup
 from modules.page_object import AboutPrefs
 from modules.page_object_autofill import AddressFill
-from modules.util import BrowserActions, Utilities
-
-COUNTRY_CODE = "US"
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -24,25 +22,43 @@ def add_to_prefs_list():
     ]
 
 
-def test_private_mode_info_not_saved(driver: Firefox):
+def test_private_mode_info_not_saved(
+    driver: Firefox,
+    about_prefs_privacy: AboutPrefs,
+    address_autofill: AddressFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+    region: str,
+):
     """
     C122587 - Autofill data not saved in private mode.
     This only tests the last part of the written TC - case should be divided
+
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        address_autofill: AddressFill instance
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
+        region: country code in use
     """
-    address_form_fields = AddressFill(driver).open()
-    autofill_popup = AutofillPopup(driver)
-    util = Utilities()
-    ba = BrowserActions(driver)
+
+    address_autofill.open()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
-    address_form_fields.save_information_basic(autofill_sample_data)
+    autofill_sample_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(autofill_sample_data)
     autofill_popup.ensure_autofill_dropdown_not_visible()
 
-    about_prefs = AboutPrefs(driver, category="privacy").open()
+    about_prefs_privacy.open()
 
-    iframe_address_popup = about_prefs.press_button_get_popup_dialog_iframe(
-        "Saved addresses"
+    about_prefs_privacy.open_and_switch_to_saved_addresses_popup()
+    # Get all saved addresses items and filter out any false data.
+    element_list = list(
+        filter(
+            lambda d: len(d.get_attribute("innerHTML")) > 1,
+            about_prefs_privacy.get_elements("saved-addresses"),
+        )
     )
-    ba.switch_to_iframe_context(iframe_address_popup)
-    about_prefs.element_does_not_exist("saved-addresses-values")
+    assert len(element_list) == 0, (
+        f"Expected 0 saved address, but found {len(element_list)}."
+    )

--- a/tests/form_autofill/test_telephone_autofill_attribute.py
+++ b/tests/form_autofill/test_telephone_autofill_attribute.py
@@ -7,6 +7,8 @@ from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
 
+COUNTRY_CODE = "US"
+
 
 @pytest.fixture()
 def test_case():
@@ -14,38 +16,42 @@ def test_case():
 
 
 @pytest.mark.ci
-def test_telephone_attribute_autofill(driver: Firefox):
+def test_telephone_attribute_autofill(
+    driver: Firefox,
+    address_autofill: AddressFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+):
     """
-    C122361, ensures that telephone numbers are autofilled
+    C122356 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
+    item in the dropdown ensures that the actual value matches the expected value.
+    Verifies Telephone
+
+    Arguments:
+        address_autofill: AddressFill instance
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
     """
-    # instantiate objects
-    # removed CA support to make test cycle faster
-    country_code = "US"
-    address_fill_obj = AddressFill(driver).open()
-    autofill_popup_obj = AutofillPopup(driver)
-    util = Utilities()
+    # open the navigation page
+    address_autofill.open()
 
-    # create fake data, fill it in and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(country_code)
-    address_fill_obj.save_information_basic(autofill_sample_data)
-    autofill_popup_obj.click_doorhanger_button("save")
+    # Create fake data, fill in the form, and press submit and save on the doorhanger
+    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
+    address_autofill.save_information_basic(autofill_sample_data)
+    autofill_popup.click_doorhanger_button("save")
 
-    # double click telephone attribute
-    address_fill_obj.click_on("form-field", labels=["tel"])
-    address_fill_obj.click_on("form-field", labels=["tel"])
-    logging.info(f"The generated phone number: {autofill_sample_data.telephone}")
-    first_item = autofill_popup_obj.get_nth_element("1")
+    # Double-click on the name field to trigger the autocomplete dropdown
+    address_autofill.double_click("form-field", labels=["tel"])
 
-    # get relevant fields
-    autofill_popup_obj.hover(first_item)
-    actual_value = autofill_popup_obj.get_primary_value(first_item)
-    normalized_number = util.normalize_phone_number(actual_value)
-    original_number = util.normalize_phone_number(autofill_sample_data.telephone)
+    # Get the first element from the autocomplete dropdown
+    first_item = autofill_popup.get_nth_element(1)
+    actual_value = autofill_popup.hover(first_item).get_primary_value(first_item)
+    # normalize phone number
+    actual_value = util.normalize_phone_number(actual_value)
 
-    logging.info(f"Original: {actual_value}, Normalized: {normalized_number}")
-    logging.info(
-        f"Original: {autofill_sample_data.telephone}, Normalized: {original_number}"
+    # Get the primary value (telephone) from the first item in the dropdown and assert that the actual value
+    # matches the expected value
+    expected_telephone = util.normalize_phone_number(autofill_sample_data.telephone)
+    assert expected_telephone == actual_value, (
+        f"Expected {expected_telephone}, but got {actual_value}"
     )
-
-    # verify
-    assert normalized_number == original_number

--- a/tests/form_autofill/test_telephone_autofill_attribute.py
+++ b/tests/form_autofill/test_telephone_autofill_attribute.py
@@ -1,13 +1,9 @@
-import logging
-
 import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
 from modules.util import Utilities
-
-COUNTRY_CODE = "US"
 
 
 @pytest.fixture()
@@ -21,6 +17,7 @@ def test_telephone_attribute_autofill(
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
     util: Utilities,
+    region: str,
 ):
     """
     C122356 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
@@ -31,12 +28,13 @@ def test_telephone_attribute_autofill(
         address_autofill: AddressFill instance
         autofill_popup: AutofillPopup instance
         util: Utilities instance
+        region: country code in use
     """
     # open the navigation page
     address_autofill.open()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
+    autofill_sample_data = util.fake_autofill_data(region)
     address_autofill.save_information_basic(autofill_sample_data)
     autofill_popup.click_doorhanger_button("save")
 

--- a/tests/form_autofill/test_updating_address.py
+++ b/tests/form_autofill/test_updating_address.py
@@ -4,9 +4,7 @@ from selenium.webdriver import Firefox, Keys
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object import AboutPrefs
 from modules.page_object_autofill import AddressFill
-from modules.util import BrowserActions, Utilities
-
-COUNTRY_CODE = "US"
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -14,47 +12,55 @@ def test_case():
     return "122354"
 
 
-def test_update_address(driver: Firefox):
+def test_update_address(
+    driver: Firefox,
+    about_prefs_privacy: AboutPrefs,
+    address_autofill: AddressFill,
+    autofill_popup: AutofillPopup,
+    util: Utilities,
+    region: str,
+):
     """
     C122354 - This test verifies that after updating and saving the autofill name field, the updated value appears in the Saved Addresses section.
+
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        address_autofill: AddressFill instance
+        autofill_popup: AutofillPopup instance
+        util: Utilities instance
+        region: country code in use
     """
-    # Instantiate objects and open the navigation page
-    address_form_fields = AddressFill(driver).open()
-    autofill_popup_panel = AutofillPopup(driver)
-    util = Utilities()
-    browser_action_obj = BrowserActions(driver)
+    address_autofill.open()
 
     # Create fake data, fill in the form, and press submit and save on the doorhanger
-    autofill_sample_data = util.fake_autofill_data(COUNTRY_CODE)
-    address_form_fields.save_information_basic(autofill_sample_data)
-    autofill_popup_panel.click_doorhanger_button("save")
+    autofill_sample_data = util.fake_autofill_data(region)
+    address_autofill.save_information_basic(autofill_sample_data)
+    autofill_popup.click_doorhanger_button("save")
 
     # Double-click on the name field to trigger the autocomplete dropdown
-    address_form_fields.double_click("form-field", labels=["name"])
-    address_form_fields.click_on("form-field", labels=["name"])
-    autofill_popup_panel.click_autofill_form_option()
+    address_autofill.double_click("form-field", labels=["name"])
+    # address_autofill.click_on("form-field", labels=["name"])
+    autofill_popup.click_autofill_form_option()
 
     # Add a middle name inside the Name field
-    address_form_fields.click_on("form-field", labels=["name"])
-    address_form_fields.send_keys_to_element("form-field", "name", " Doe" + Keys.ENTER)
+    address_autofill.click_on("form-field", labels=["name"])
+    address_autofill.send_keys_to_element("form-field", "name", " Doe" + Keys.ENTER)
 
     # Save the updated address
-    autofill_popup_panel.click_doorhanger_button("update")
+    autofill_popup.click_doorhanger_button("update")
 
     # Navigate to settings
-    about_prefs = AboutPrefs(driver, category="privacy").open()
-    iframe = about_prefs.get_saved_addresses_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs_privacy.open()
+    about_prefs_privacy.open_and_switch_to_saved_addresses_popup()
 
     # Verify no dupe is saved
-    element_list = about_prefs.get_elements("saved-addresses")
+    element_list = about_prefs_privacy.get_elements("saved-addresses")
     assert len(element_list) == 1, (
         f"Expected 1 saved address, but found {len(element_list)}."
     )
-    print("Assertion passed: There is exactly 1 saved address.")
 
     # Assert that "Doe" is present in updated entry
-    elements = about_prefs.get_elements("saved-addresses-values")
+    elements = about_prefs_privacy.get_elements("saved-addresses-values")
     found_updated_address = any("Doe" in element.text for element in elements)
     assert found_updated_address, (
         "The value 'Doe' was not found in any of the address entries."

--- a/tests/form_autofill/test_updating_credit_card.py
+++ b/tests/form_autofill/test_updating_credit_card.py
@@ -7,7 +7,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object import AboutPrefs
 from modules.page_object_autofill import CreditCardFill
-from modules.util import BrowserActions, Utilities
+from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -15,78 +15,52 @@ def test_case():
     return "122406"
 
 
-fields = ["cc-name", "cc-exp-month", "cc-exp-year"]
+fields = ["cc-name", "cc-exp-month", "cc-exp-year", "cc-number"]
 
 
 @pytest.mark.parametrize("field", fields)
-def test_update_cc_no_dupe_name(driver: Firefox, field: str):
+def test_update_cc_no_dupe_name(
+    driver: Firefox,
+    about_prefs_privacy: AboutPrefs,
+    autofill_popup: AutofillPopup,
+    credit_card_autofill: CreditCardFill,
+    util: Utilities,
+    field: str,
+):
     """
     C122406, ensures that updating the credit card saves the correct information with no dupe profile for the name and expiry dates
-    """
-    util = Utilities()
+    for cvv, must create a new profile
 
-    credit_card_fill_obj = CreditCardFill(driver).open()
-    autofill_popup_obj = AutofillPopup(driver)
-    browser_action_obj = BrowserActions(driver)
+    Arguments:
+        about_prefs_privacy: AboutPrefs instance (privacy category)
+        autofill_popup: AutofillPopup instance
+        credit_card_autofill: CreditCardFill instance
+        util: Utilities instance
+        field: credit card field being checked
+    """
+    credit_card_autofill.open()
 
     credit_card_sample_data = util.fake_credit_card_data()
-    credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
-    autofill_popup_obj.click_doorhanger_button("save")
-    credit_card_fill_obj.press_autofill_panel(autofill_popup_obj)
+    credit_card_autofill.fill_credit_card_info(credit_card_sample_data)
+    autofill_popup.click_doorhanger_button("save")
+
+    credit_card_autofill.press_autofill_panel(autofill_popup)
 
     # updating the name of the cc holder
-    credit_card_fill_obj.update_cc(
-        util, credit_card_sample_data, autofill_popup_obj, field
-    )
+    credit_card_autofill.update_cc(util, credit_card_sample_data, autofill_popup, field)
 
     # navigate to settings
-    about_prefs = AboutPrefs(driver, category="privacy").open()
-    iframe = about_prefs.get_saved_payments_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
+    about_prefs_privacy.open()
+    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
     # assert no dupe profile is saved
-    element = about_prefs.get_element("cc-saved-options", multiple=True)
-    assert len(element) == 1
+    saved_cc = about_prefs_privacy.get_element("cc-saved-options", multiple=True)
+    assert len(saved_cc) == 1 if field != "cc-number" else len(saved_cc) == 2
 
     # preprocessing for validations
-    cc_info_json = json.loads(element[0].get_dom_attribute("data-l10n-args"))
-    browser_action_obj.switch_to_content_context()
+    cc_info_json = json.loads(saved_cc[0].get_dom_attribute("data-l10n-args"))
     logging.info(f"The extracted JSON: {cc_info_json}")
     logging.info(f"The extracted cc data: {credit_card_sample_data}")
 
     # verify the items in the JSON vs the sample data
-    about_prefs.verify_cc_json(cc_info_json, credit_card_sample_data)
-
-
-def test_update_cc_number_new_profile(driver: Firefox):
-    """
-    C122406, continuation ensures that updating the credit card number saves a new card instead of updating the new one
-    """
-    util = Utilities()
-
-    credit_card_fill_obj = CreditCardFill(driver).open()
-    autofill_popup_obj = AutofillPopup(driver)
-    browser_action_obj = BrowserActions(driver)
-
-    credit_card_sample_data = util.fake_credit_card_data()
-    credit_card_fill_obj.fill_credit_card_info(credit_card_sample_data)
-    autofill_popup_obj.click_doorhanger_button("save")
-    credit_card_fill_obj.press_autofill_panel(autofill_popup_obj)
-
-    # updating the card number of the cc holder
-    new_sample_data = util.fake_credit_card_data()
-    credit_card_fill_obj.update_credit_card_information(
-        autofill_popup_obj,
-        "cc-number",
-        new_sample_data.card_number,
-        save_card=True,
-    )
-
-    # navigate to settings
-    about_prefs = AboutPrefs(driver, category="privacy").open()
-    iframe = about_prefs.get_saved_payments_popup_iframe()
-    browser_action_obj.switch_to_iframe_context(iframe)
-
-    # assert new profile is saved
-    element = about_prefs.get_element("cc-saved-options", multiple=True)
-    assert len(element) == 2
+    about_prefs_privacy.verify_cc_json(cc_info_json, credit_card_sample_data)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1953257](https://bugzilla.mozilla.org/show_bug.cgi?id=1953257)
TestRail: _

### Description of Code / Doc Changes

First set of Refactors for the Form Autofill test suite.
Refactor includes:
 - Basic test clean up.
 - Decorators added to object models.
 - Moved class instantiation to conftest.
 - Added docstrings to clarify tests.


### Process Changes Required

_Mark the relevant boxes:_

- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs, CreditCardFill, AddressFill ...

### Comments or Future Work

Will follow up with a PR to continue refactor on the object models that are used in the test suite. Followed by improvements to the tests as well.

### Workflow Checklist

- [ ] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
