### PR TITLE
fix error in previous division of machine archs

### DIFF
--- a/collect_executables.py
+++ b/collect_executables.py
@@ -24,13 +24,16 @@ def get_fx_platform():
     if _system == "Darwin":
         return "mac"
     if _system == "Linux":
+        # ARM specifications in uname().machine don't have 32/64
         if "64" in u.machine:
             return "linux-x86_64"
+        elif "arm" in u.machine.lower():
+            return "linux-aarch64"
         return "linux-i686"
     if _system == "Windows":
-        if u.machine == "AMD64" and not environ.get("GITHUB_ACTIONS"):
+        if "arm" in u.machine.lower():
             return "win64-aarch64"
-        if "64" in u.machine:
+        elif "64" in u.machine:
             return "win64"
         return "win32"
 


### PR DESCRIPTION
### Relevant Links

no ticket

### Description of Code / Doc Changes

* In collect_executables.py, change all platform-choosing logic to reflect the actual machine running the code (including getting the correct arch for VMs)

### Process Changes Required

_Mark the relevant boxes:_

- [x] Changes CI flow

### Screenshots or Explanations

I goofed--I got "AMD" and "ARM" mixed up briefly, copied code, and then patched the issue with some weird logic.

### Workflow Checklist

- [x] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
