### PR TITLE
get correct executable for mac headed devedition

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Run Smoke Tests in MacOS (Headed)
         if: steps.setup.conclusion == 'success' && always()
         env:
-          FX_EXECUTABLE: /Volumes/Firefox/Firefox.app/Contents/MacOS/firefox
+          FX_EXECUTABLE: /Volumes/${{ steps.setup.outputs.app_name }}/${{ steps.setup.outputs.app_name }}.app/Contents/MacOS/firefox
           REPORTABLE: true
         run: |
           mv ./ci_pyproject_headed.toml ./pyproject.toml;


### PR DESCRIPTION
### Relevant Links

no ticket

### Description of Code / Doc Changes

When we added devedition testing, we created a script to construct the path to the Fx executable because it was no longer something we could hard code. This path was not brought over to the headed testing step and needs to be there.

### Process Changes Required

_Mark the relevant boxes:_

- [x] Changes CI flow
- [x] Changes scheduled Beta or DevEdition

### Workflow Checklist

- [x] Please request reviewers
- [x] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
