### PR TITLE
tracy/ Mark tests unstable

### DIFF
--- a/tests/bookmarks_and_history/test_add_new_other_bookmark.py
+++ b/tests/bookmarks_and_history/test_add_new_other_bookmark.py
@@ -22,6 +22,7 @@ WIN_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("w
 
 
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
+@pytest.mark.unstable(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1963396")
 def test_add_new_other_bookmark(driver: Firefox):
     """
     C2084518: verify user can add another bookmark from other bookmarks

--- a/tests/bookmarks_and_history/test_delete_other_bookmarks.py
+++ b/tests/bookmarks_and_history/test_delete_other_bookmarks.py
@@ -22,6 +22,7 @@ def test_case():
 
 
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
+@pytest.mark.unstable(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1963396")
 def test_delete_other_bookmarks(driver: Firefox):
     """
     C2084524: Verify that a user can Delete a bookmark from 'Other Bookmarks' folder

--- a/tests/bookmarks_and_history/test_edit_bookmark_from_bookmark_menu.py
+++ b/tests/bookmarks_and_history/test_edit_bookmark_from_bookmark_menu.py
@@ -18,6 +18,7 @@ ENABLE_ADD_TAG = """
         """
 
 
+@pytest.mark.unstable(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1963396")
 def test_edit_bookmark_from_bookmark_menu(driver: Firefox):
     """
     C2084490: Verify that the user can Edit a Bookmark from Bookmarks menu

--- a/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
+++ b/tests/bookmarks_and_history/test_edit_bookmark_via_star_button.py
@@ -15,6 +15,7 @@ URL_TO_EDIT = "https://www.mozilla.org/"
 URL_TO_SAVE = "https://monitor.mozilla.org/"
 
 
+@pytest.mark.unstable(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1963396")
 def test_edit_bookmark_via_star_button(driver: Firefox):
     """
     C2084549: Verify that the user can Edit a Bookmark options from the Star-shaped button


### PR DESCRIPTION
#### Relevant Links

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1963396

#### Description of Code / Doc Changes

test_add_new_other_bookmark.py, test_delete_other_bookmarks.py,
test_edit_bookmark_from_bookmark_menu.py and test_edit_bookmark_via_star_button.py are failing in. away we can't figure out the fix for.  Marking these test unstable so other work is not blocked in CI.

#### Future
Fix these tests

#### Workflow Checklist

- [X] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.
