### PR TITLE
Fix linux manual workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -267,7 +267,7 @@ jobs:
         run: |
           "$FX_EXECUTABLE" --version;
           pipenv run python choose_ci_set.py;
-          Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log;
+          Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log &
           DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
       - name: Run Smoke Tests in Ubuntu (Headed)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -261,22 +261,13 @@ jobs:
           #. ./keyring-unlock.sh;
       - name: Run Smoke Tests in Ubuntu
         if: steps.setup.conclusion == 'success'
+        uses: coactions/setup-xvfb@v1
         env:
           FX_EXECUTABLE: ./firefox/firefox
         run: |
           "$FX_EXECUTABLE" --version
           pipenv run python choose_ci_set.py
           pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
-          exit $TEST_EXIT_CODE
-      - name: Run Smoke Tests in Ubuntu (Headed)
-        if: steps.setup.conclusion == 'success' && always()
-        env:
-          FX_EXECUTABLE: ./firefox/firefox
-          REPORTABLE: true
-        run: |
-          mv ./ci_pyproject_headed.toml ./pyproject.toml;
-          pipenv run python choose_ci_set.py
-          pipenv run pytest --fx-executable="$FX_EXECUTABLE" $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 
   Use-Artifacts:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -281,6 +281,7 @@ jobs:
           exit $TEST_EXIT_CODE
 
   Use-Artifacts:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs:
       - Smoke-Windows

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -267,7 +267,7 @@ jobs:
         run: |
           "$FX_EXECUTABLE" --version
           pipenv run python choose_ci_set.py
-          Xvfb :99 '1600x1200x24' > ~/artifacts/xvfb/xvfb.log 2>&1
+          Xvfb :99 '1600x1200x24' > ~/artifacts/xvfb.log 2>&1
           DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
       - name: Run Smoke Tests in Ubuntu (Headed)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,15 +18,15 @@ on:
     inputs:
       win_installer_link:
         description: 'The link to the Windows installer (win64) for the Fx under test'
-        required: true
+        required: false
         type: string
       mac_installer_link:
         description: 'The link to the macOS installer for the Fx under test'
-        required: true
+        required: false
         type: string
       linux_tarball_link:
         description: 'The link to the Linux tarball (linux-x86_64) for the Fx under test'
-        required: true
+        required: false
         type: string
 env:
   FX_CHANNEL: ${{ inputs.channel }}
@@ -37,7 +37,7 @@ env:
 
 jobs:
   Smoke-Windows:
-    if: ${{ inputs.job_to_run == 'Smoke-Windows' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ inputs.job_to_run == 'Smoke-Windows' || github.event_name == 'pull_request' || inputs.win_installer_link }}
     runs-on: windows-latest
     steps:
       - name: Create app token
@@ -146,7 +146,7 @@ jobs:
           name: artifacts-win
           path: artifacts-win
   Smoke-MacOS:
-    if: ${{ inputs.job_to_run == 'Smoke-MacOS' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ inputs.job_to_run == 'Smoke-MacOS' || github.event_name == 'pull_request' || inputs.mac_installer_link }}
     runs-on: macos-latest
     steps:
       - name: Create app token
@@ -220,7 +220,7 @@ jobs:
           name: artifacts-mac
           path: artifacts-mac
   Smoke-Linux:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ inputs.linux_tarball_link }}
     runs-on: ubuntu-latest
     steps:
       - name: Create app token
@@ -249,8 +249,8 @@ jobs:
         run: |
           echo "MANUAL='true'" >> "$GITHUB_ENV";
           echo "Running smoke tests on supplied executable";
+          sudo apt install gnome-screenshot
           uname -m;
-          sudo apt install xvfb;
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
@@ -267,7 +267,8 @@ jobs:
         run: |
           "$FX_EXECUTABLE" --version
           pipenv run python choose_ci_set.py
-          Xvfb :99 & DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
+          Xvfb :99 '1600x1200x24' > ~/artifacts/xvfb/xvfb.log 2>&1
+          DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
       - name: Run Smoke Tests in Ubuntu (Headed)
         if: steps.setup.conclusion == 'success' && always()
@@ -276,7 +277,7 @@ jobs:
         run: |
           mv ./ci_pyproject_headed.toml ./pyproject.toml;
           pipenv run python choose_ci_set.py
-          Xvfb :99 & DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" $(cat selected_tests) || TEST_EXIT_CODE=$?
+          DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 
   Use-Artifacts:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -249,7 +249,8 @@ jobs:
         run: |
           echo "MANUAL='true'" >> "$GITHUB_ENV";
           echo "Running smoke tests on supplied executable";
-          uname -m
+          uname -m;
+          apt install xvfb;
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
@@ -261,26 +262,22 @@ jobs:
           #. ./keyring-unlock.sh;
       - name: Run Smoke Tests in Ubuntu
         if: steps.setup.conclusion == 'success'
-        uses: coactions/setup-xvfb@v1
         env:
           FX_EXECUTABLE: ./firefox/firefox
-        with:
-          run: |
-            "$FX_EXECUTABLE" --version
-            pipenv run python choose_ci_set.py
-            pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
-            exit $TEST_EXIT_CODE
+        run: |
+          "$FX_EXECUTABLE" --version
+          pipenv run python choose_ci_set.py
+          Xvfb :99 & DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
+          exit $TEST_EXIT_CODE
       - name: Run Smoke Tests in Ubuntu (Headed)
         if: steps.setup.conclusion == 'success' && always()
-        uses: coactions/setup-xvfb@v1
         env:
           FX_EXECUTABLE: ./firefox/firefox
-        with:
-          run: |
-            mv ./ci_pyproject_headed.toml ./pyproject.toml;
-            pipenv run python choose_ci_set.py
-            pipenv run pytest --fx-executable="$FX_EXECUTABLE" $(cat selected_tests) || TEST_EXIT_CODE=$?
-            exit $TEST_EXIT_CODE
+        run: |
+          mv ./ci_pyproject_headed.toml ./pyproject.toml;
+          pipenv run python choose_ci_set.py
+          Xvfb :99 & DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" $(cat selected_tests) || TEST_EXIT_CODE=$?
+          exit $TEST_EXIT_CODE
 
   Use-Artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -265,9 +265,9 @@ jobs:
         env:
           FX_EXECUTABLE: ./firefox/firefox
         run: |
-          "$FX_EXECUTABLE" --version
-          pipenv run python choose_ci_set.py
-          Xvfb :99 '1600x1200x24' > ~/artifacts/xvfb.log 2>&1
+          "$FX_EXECUTABLE" --version;
+          pipenv run python choose_ci_set.py;
+          Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log 2>&1;
           DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
       - name: Run Smoke Tests in Ubuntu (Headed)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       win_installer_link:
-        description: 'The link to the Windows installer for the Fx under test'
+        description: 'The link to the Windows installer (win64) for the Fx under test'
         required: true
         type: string
       mac_installer_link:
@@ -25,7 +25,7 @@ on:
         required: true
         type: string
       linux_tarball_link:
-        description: 'The link to the Linux tarball for the Fx under test'
+        description: 'The link to the Linux tarball (linux-x86_64) for the Fx under test'
         required: true
         type: string
 env:
@@ -249,6 +249,7 @@ jobs:
         run: |
           echo "MANUAL='true'" >> "$GITHUB_ENV";
           echo "Running smoke tests on supplied executable";
+          uname -m
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
@@ -257,7 +258,7 @@ jobs:
           pipenv install;
           ./collect_executables.sh
           ./firefox/firefox --version;
-          . ./keyring-unlock.sh;
+          #. ./keyring-unlock.sh;
       - name: Run Smoke Tests in Ubuntu
         if: steps.setup.conclusion == 'success'
         env:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -264,11 +264,23 @@ jobs:
         uses: coactions/setup-xvfb@v1
         env:
           FX_EXECUTABLE: ./firefox/firefox
-        run: |
-          "$FX_EXECUTABLE" --version
-          pipenv run python choose_ci_set.py
-          pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
-          exit $TEST_EXIT_CODE
+        with:
+          run: |
+            "$FX_EXECUTABLE" --version
+            pipenv run python choose_ci_set.py
+            pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
+            exit $TEST_EXIT_CODE
+      - name: Run Smoke Tests in Ubuntu (Headed)
+        if: steps.setup.conclusion == 'success' && always()
+        uses: coactions/setup-xvfb@v1
+        env:
+          FX_EXECUTABLE: ./firefox/firefox
+        with:
+          run: |
+            mv ./ci_pyproject_headed.toml ./pyproject.toml;
+            pipenv run python choose_ci_set.py
+            pipenv run pytest --fx-executable="$FX_EXECUTABLE" $(cat selected_tests) || TEST_EXIT_CODE=$?
+            exit $TEST_EXIT_CODE
 
   Use-Artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -250,7 +250,7 @@ jobs:
           echo "MANUAL='true'" >> "$GITHUB_ENV";
           echo "Running smoke tests on supplied executable";
           uname -m;
-          apt install xvfb;
+          sudo apt install xvfb;
           mkdir -p artifacts;
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -267,7 +267,7 @@ jobs:
         run: |
           "$FX_EXECUTABLE" --version;
           pipenv run python choose_ci_set.py;
-          Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log 2>&1;
+          Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log;
           DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" -n 4 $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
       - name: Run Smoke Tests in Ubuntu (Headed)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -255,7 +255,7 @@ jobs:
           pip3 install 'pipenv==2023.11.15';
           pip3 install 'ruff>=0.4.8,<0.5';
           rm ./pyproject.toml;
-          mv ./ci_pyproject.toml ./pyproject.toml;
+          mv ./ci_xvfb_pyproject.toml ./pyproject.toml;
           pipenv install;
           ./collect_executables.sh
           ./firefox/firefox --version;
@@ -275,7 +275,7 @@ jobs:
         env:
           FX_EXECUTABLE: ./firefox/firefox
         run: |
-          mv ./ci_pyproject_headed.toml ./pyproject.toml;
+          mv ./ci_xvfb_pyproject_headed.toml ./pyproject.toml;
           pipenv run python choose_ci_set.py
           DISPLAY=:99 pipenv run pytest --fx-executable="$FX_EXECUTABLE" $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE

--- a/ci_xvfb_pyproject.toml
+++ b/ci_xvfb_pyproject.toml
@@ -1,0 +1,23 @@
+[tool.pytest.ini_options]
+generate_report_on_test = true
+log_cli = true
+log_cli_level = "warn"
+markers = [
+    "audio: test is reliant on audio",
+    "headed: test must run in headed mode (e.g. uses pynput)",
+    "incident: incident smoke tests",
+    "unstable: temporary mark for unstable tests",
+    "slow: test is clocked at more than 30s on modern machines",
+    "ci: basic tests to run in ci",
+    "locale_de: tests run in DE locale versions",
+    "locale_fr: tests run in FR locale versions",
+    "locale_gb: tests run in GB locale versions",
+    "noxvfb: tests that should not run in xvfb sessions"
+]
+testpaths = [
+    "tests"
+]
+addopts = "-vs --ci --run-headless --json-report --json-report-file artifacts/report.json --reruns 3 --reruns-delay 3 -m 'not unstable and not headed and not noxvfb' --html=artifacts/report.html"
+
+[tool.ruff]
+target-version = "py310"

--- a/ci_xvfb_pyproject_headed.toml
+++ b/ci_xvfb_pyproject_headed.toml
@@ -1,0 +1,22 @@
+[tool.pytest.ini_options]
+generate_report_on_test = true
+log_cli = true
+log_cli_level = "warn"
+markers = [
+    "audio: test is reliant on audio",
+    "headed: test must run in headed mode (e.g. uses pynput)",
+    "incident: incident smoke tests",
+    "unstable: temporary mark for unstable tests",
+    "slow: test is clocked at more than 30s on modern machines",
+    "ci: basic tests to run in ci",
+    "locale_de: tests run in DE locale versions",
+    "locale_fr: tests run in FR locale versions",
+    "locale_gb: tests run in GB locale versions"
+]
+testpaths = [
+    "tests"
+]
+addopts = "-vs --ci --json-report --json-report-file artifacts/report_headed.json --reruns 3 --reruns-delay 2 -m 'not unstable and not noxvfb and headed' --html=artifacts/report_headed.html"
+
+[tool.ruff]
+target-version = "py310"

--- a/tests/address_bar_and_search/test_addon_suggestion.py
+++ b/tests/address_bar_and_search/test_addon_suggestion.py
@@ -31,6 +31,7 @@ def add_to_prefs_list():
     ]
 
 
+@pytest.mark.noxvfb
 def test_addon_suggestion_based_on_search_input(driver: Firefox):
     """
     C2234714 - Verify that the address bar suggests relevant add-ons based on search input.

--- a/tests/audio_video/test_allow_audio_video_functionality.py
+++ b/tests/audio_video/test_allow_audio_video_functionality.py
@@ -23,6 +23,7 @@ TEST_URL = "https://www.mlb.com/video/rockies-black-agree-on-extension"
 
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
 @pytest.mark.audio
+@pytest.mark.noxvfb
 def test_allow_audio_video_functionality(driver: Firefox):
     """
     C330155 : 'Allow Audio and Video' functionality

--- a/tests/downloads/test_add_mime_type_doc.py
+++ b/tests/downloads/test_add_mime_type_doc.py
@@ -25,6 +25,7 @@ def delete_files_regex_string():
 
 
 @pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
+@pytest.mark.noxvfb
 def test_mime_type_doc(driver: Firefox, sys_platform: str, opt_ci: bool, delete_files):
     """
     C1756748: Verify the user can add the .doc type

--- a/tests/password_manager/test_password_csv_correctness.py
+++ b/tests/password_manager/test_password_csv_correctness.py
@@ -16,6 +16,7 @@ def test_case():
 
 
 @pytest.mark.headed
+@pytest.mark.noxvfb
 def test_password_csv_correctness(
     driver_and_saved_logins, downloads_folder, sys_platform
 ):

--- a/tests/password_manager/test_password_csv_export.py
+++ b/tests/password_manager/test_password_csv_export.py
@@ -15,6 +15,7 @@ def test_case():
 
 
 @pytest.mark.headed
+@pytest.mark.noxvfb
 def test_password_csv_export(
     driver_and_saved_logins, downloads_folder, sys_platform, opt_ci
 ):

--- a/tests/pdf_viewer/test_add_image_pdf.py
+++ b/tests/pdf_viewer/test_add_image_pdf.py
@@ -33,6 +33,7 @@ def add_to_prefs_list():
 
 
 @pytest.mark.headed
+@pytest.mark.noxvfb
 def test_add_image_pdf(driver: Firefox, sys_platform, pdf_viewer: GenericPdf):
     """
     C2228202: Verify that the user is able to add an image to a PDF file.

--- a/tests/pdf_viewer/test_pdf_navigation.py
+++ b/tests/pdf_viewer/test_pdf_navigation.py
@@ -144,6 +144,7 @@ def test_toolbar_options_cursor(driver: Firefox, pdf_viewer: GenericPdf):
     assert cursor_style == "auto"
 
 
+@pytest.mark.noxvfb
 def test_toolbar_options_rotate_cw(driver: Firefox, pdf_viewer: GenericPdf):
     """
     C3927.5: Ensure the correct rotation is shown
@@ -162,6 +163,7 @@ def test_toolbar_options_rotate_cw(driver: Firefox, pdf_viewer: GenericPdf):
         )
 
 
+@pytest.mark.noxvfb
 def test_toolbar_options_rotate_ccw(driver: Firefox, pdf_viewer: GenericPdf):
     """
     C3927.5: Ensure the correct rotation is shown

--- a/tests/preferences/test_manage_cookie_data.py
+++ b/tests/preferences/test_manage_cookie_data.py
@@ -17,6 +17,7 @@ COOKIE_SITE = "google.com"
 
 
 @pytest.mark.headed
+@pytest.mark.noxvfb
 def test_manage_cookie_data(driver: Firefox):
     """
     C143633 - Cookies and Site Data can be managed

--- a/tests/scrolling_panning_zooming/test_zoom_text_only.py
+++ b/tests/scrolling_panning_zooming/test_zoom_text_only.py
@@ -85,6 +85,7 @@ def reject_consent_page(web_page: GenericPage):
 
 
 @pytest.mark.ci
+@pytest.mark.noxvfb
 def test_zoom_text_only_from_settings(
     driver: Firefox, web_page: GenericPage, reject_consent_page
 ):


### PR DESCRIPTION
* Run tests in xvfb for Linux manual flow
* Make all fields optional for manual flow (can run each manual flow separately)
* Linux manual flow: Mark and skip tests that fail in xvfb so that we don't get false fails in future runs
* Don't use artifacts on manual runs