### PR TITLE
Anca/ Test stabilization - Fix Win failures for Other Bookmarks

### DIFF
--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -344,26 +344,24 @@ class Navigation(BasePage):
         return self
 
     @BasePage.context_chrome
-    def add_bookmark_advanced(
+    def add_bookmark_via_other_bookmark_context_menu(
         self, bookmark_data: Bookmark, ba: BrowserActions
     ) -> BasePage:
         iframe = self.get_element("bookmark-iframe")
         ba.switch_to_iframe_context(iframe)
         # fill name
-        if bookmark_data.name is not None:
-            self.actions.send_keys(bookmark_data.name).perform()
+        self.actions.send_keys(bookmark_data.name).perform()
         self.actions.send_keys(Keys.TAB).perform()
         # fill url
         self.actions.send_keys(bookmark_data.url + Keys.TAB).perform()
         # fill tags
-        if bookmark_data.tags is not None:
-            self.actions.send_keys(bookmark_data.tags).perform()
+        self.actions.send_keys(bookmark_data.tags).perform()
+        self.actions.send_keys(Keys.TAB).perform()
         self.actions.send_keys(Keys.TAB).perform()
         # fill keywords
-        if bookmark_data.keyword is not None:
-            self.actions.send_keys(bookmark_data.keyword).perform()
-        self.actions.send_keys(Keys.TAB, Keys.TAB, Keys.TAB, Keys.ENTER).perform()
-        ba.switch_to_content_context()
+        self.actions.send_keys(bookmark_data.keyword).perform()
+        # save the bookmark
+        self.actions.send_keys(Keys.ENTER).perform()
         return self
 
     @BasePage.context_chrome

--- a/tests/bookmarks_and_history/test_add_new_other_bookmark.py
+++ b/tests/bookmarks_and_history/test_add_new_other_bookmark.py
@@ -1,6 +1,3 @@
-import sys
-from os import environ
-
 import pytest
 from selenium.webdriver import Firefox
 
@@ -16,25 +13,26 @@ def test_case():
 
 
 BOOKMARK_URL = "about:robots"
+BOOKMARK_NAME = "Robots 2"
+BOOKMARK_TAGS = "a"
+BOOKMARK_KEYBOARD = "about"
 
 
-WIN_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("win")
-
-
-@pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
 def test_add_new_other_bookmark(driver: Firefox):
     """
-    C2084518: verify user can add another bookmark from other bookmarks
+    C2084518 - Verify another bookmark (with name, url, tag, keyboard) can be added from other bookmarks toolbar
+    context menu
     """
     nav = Navigation(driver)
     ba = BrowserActions(driver)
-    GenericPage(driver, url=BOOKMARK_URL).open()
+    page = GenericPage(driver, url=BOOKMARK_URL)
     context_menu = ContextMenu(driver)
 
-    # create a bookmark for other
+    # Create the first bookmark in Other Bookmarks folder
+    page.open()
     nav.bookmark_page_other()
 
-    # get other bookmarks
+    # Create a new bookmark from Other Bookmark context menu
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("other-bookmarks").click()
         nav.context_click("other-bookmarks-popup")
@@ -43,8 +41,11 @@ def test_add_new_other_bookmark(driver: Firefox):
         context_menu.hide_popup_by_child_node("context-menu-add-bookmark")
         nav.hide_popup("OtherBookmarksPopup")
 
-    nav.add_bookmark_advanced(Bookmark(url="about:robots", name="Robots 2"), ba)
+        nav.add_bookmark_via_other_bookmark_context_menu(
+            Bookmark(BOOKMARK_URL, BOOKMARK_NAME, BOOKMARK_TAGS, BOOKMARK_KEYBOARD), ba
+        )
 
+    # Verify the presence of the second added bookmarked page
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("other-bookmarks").click()
         nav.element_visible("bookmark-robots")

--- a/tests/bookmarks_and_history/test_delete_other_bookmarks.py
+++ b/tests/bookmarks_and_history/test_delete_other_bookmarks.py
@@ -1,6 +1,3 @@
-import sys
-from os import environ
-
 import pytest
 from selenium.webdriver import Firefox
 
@@ -11,9 +8,9 @@ from modules.util import BrowserActions
 
 BOOKMARK_URL = "about:robots"
 BOOKMARK_URL_2 = "about:cache"
-
-
-WIN_GHA = environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("win")
+BOOKMARK_NAME = "Cache"
+BOOKMARK_TAGS = "a"
+BOOKMARK_KEYBOARD = "about"
 
 
 @pytest.fixture()
@@ -21,20 +18,20 @@ def test_case():
     return "2084524"
 
 
-@pytest.mark.skipif(WIN_GHA, reason="Test unstable in Windows Github Actions")
 def test_delete_other_bookmarks(driver: Firefox):
     """
-    C2084524: Verify that a user can Delete a bookmark from 'Other Bookmarks' folder
+    C2084524 - Verify that a user can Delete a bookmark from 'Other Bookmarks' folder
     """
     nav = Navigation(driver)
-    GenericPage(driver, url=BOOKMARK_URL).open()
+    page = GenericPage(driver, url=BOOKMARK_URL)
     ba = BrowserActions(driver)
     context_menu = ContextMenu(driver)
 
-    # create the first bookmark for other
+    # Create the first bookmark in Other Bookmarks folder
+    page.open()
     nav.bookmark_page_other()
 
-    # get other bookmarks
+    # Create a new bookmark from Other Bookmark context menu
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("other-bookmarks").click()
         nav.context_click("other-bookmarks-popup")
@@ -43,10 +40,11 @@ def test_delete_other_bookmarks(driver: Firefox):
         context_menu.hide_popup_by_child_node("context-menu-add-bookmark")
         nav.hide_popup("OtherBookmarksPopup")
 
-    # add second bookmark
-    nav.add_bookmark_advanced(Bookmark(url=BOOKMARK_URL_2, name="Cache"), ba)
+    nav.add_bookmark_via_other_bookmark_context_menu(
+        Bookmark(BOOKMARK_URL_2, BOOKMARK_NAME, BOOKMARK_TAGS, BOOKMARK_KEYBOARD), ba
+    )
 
-    # delete first bookmark and verify it's not present anymore
+    # Delete the first bookmark and verify it's not present anymore
     with driver.context(driver.CONTEXT_CHROME):
         nav.get_element("other-bookmarks").click()
         nav.context_click("bookmark-about-robots")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1969409](https://bugzilla.mozilla.org/show_bug.cgi?id=1969409), [1969433](https://bugzilla.mozilla.org/show_bug.cgi?id=1969433)
TestRail: [2084518](https://mozilla.testrail.io/index.php?/cases/view/2084518), [2084524](https://mozilla.testrail.io/index.php?/cases/view/2084524)

### Description of Code / Doc Changes
- Those two tests were marked as skipped on Windows  in CI and failed locally on my end as well. Made some changes to one method (and extended the functionality as per the test case). Can't access element locators in Add Bookmark dialog, but Tab navigation seams stable.

### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

- Those tests need further refactorization, I've target only the fix.

### Workflow Checklist

- [x] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
