### PR TITLE
update tr api logic to report durations

### DIFF
--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -585,7 +585,9 @@ class Navigation(BasePage):
         """
         self.panel_ui.element_clickable("bookmark-by-title", labels=[bookmark_title])
         self.panel_ui.context_click("bookmark-by-title", labels=[bookmark_title])
-        self.context_menu.click_on("context-menu-toolbar-open-in-new-private-window")
+        self.context_menu.click_and_hide_menu(
+            "context-menu-toolbar-open-in-new-private-window"
+        )
         return self
 
     @BasePage.context_chrome

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -905,13 +905,15 @@ class BasePage(Page):
             return float(css_zoom)
 
         # If zoom property is not explicitly set, check the transform scale
-        css_transform_scale = self.driver.execute_script("""
+        css_transform_scale = self.driver.execute_script(
+            """
             const transform = window.getComputedStyle(document.body).transform;
             if (transform && transform !== 'none') {
                 return transform;
             } else {
                 return null;
-        """)
+        """
+        )
 
         # Parse the transform matrix to extract the scale factor (e.g., matrix(a, b, c, d, e, f))
         if css_transform_scale:

--- a/modules/testrail.py
+++ b/modules/testrail.py
@@ -387,6 +387,7 @@ class TestRail:
         testrail_suite_id,
         test_case_ids=[],
         status="passed",
+        more_results={},
     ):
         """Given a project id, a run id, and a suite id, for each case given a status,
         update the test objects with the correct status code"""
@@ -404,6 +405,13 @@ class TestRail:
                 for test_case_id in test_case_ids
             ]
         }
+        for test_case_id, new_item in more_results.items():
+            if test_case_id in test_case_ids:
+                for result in data.get("results"):
+                    if result.get("case_id") == test_case_id:
+                        new_field, new_data = new_item.items()
+                        result[new_field] = new_data
+
         return self._update_test_run_results(testrail_run_id, data)
 
     # Private Methods

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -216,6 +216,12 @@ def mark_results(testrail_session: TestRail, test_results):
                 result.get("test_case") for result in test_results[category][run_id]
             ]
 
+            # Organize durations
+            durations = test_results[category][run_id].get("durations")
+            durations_info = {
+                tc: {"elapsed": f"{durations.get(tc)}s"} for tc in durations
+            }
+
             # Don't set passed tests to another status.
             test_cases = [tc for tc in all_test_cases if current_results.get(tc) != 1]
             logging.warn(
@@ -227,6 +233,7 @@ def mark_results(testrail_session: TestRail, test_results):
                 testrail_suite_id=suite_id,
                 test_case_ids=test_cases,
                 status=category,
+                more_results=durations_info,
             )
 
 
@@ -251,6 +258,7 @@ def organize_entries(testrail_session: TestRail, expected_plan: dict, suite_info
     cases_in_suite = suite_info.get("cases")
     cases_in_suite = [int(n) for n in cases_in_suite]
     results = suite_info.get("results")
+    durations = suite_info.get("durations")
     plan_title = expected_plan.get("name")
 
     suite_entries = [
@@ -355,7 +363,11 @@ def organize_entries(testrail_session: TestRail, expected_plan: dict, suite_info
         if not test_results[category].get(run_id):
             test_results[category][run_id] = []
         test_results[category][run_id].append(
-            {"suite_id": suite_id, "test_case": test_case}
+            {
+                "suite_id": suite_id,
+                "test_case": test_case,
+                "duration": durations.get(test_case),
+            }
         )
 
     return test_results
@@ -469,6 +481,7 @@ def collect_changes(testrail_session: TestRail, report):
     last_suite_id = None
     last_description = None
     results_by_suite = {}
+    durations_by_suite = {}
     full_test_results = {}
     tests = [
         test
@@ -498,9 +511,20 @@ def collect_changes(testrail_session: TestRail, report):
             outcome = test.get("call").get("outcome")
         logging.info(f"TC: {test_case}: {outcome}")
 
+        duration = round(
+            test.get("setup").get("duration")
+            + test.get("call").get("duration")
+            + test.get("teardown").get("duration")
+        )
+
         if not results_by_suite.get(suite_id):
             results_by_suite[suite_id] = {}
         results_by_suite[suite_id][test_case] = outcome
+
+        if not durations_by_suite.get(suite_id):
+            durations_by_suite[suite_id] = {}
+        durations_by_suite[suite_id][test_case] = duration
+
         if suite_id != last_suite_id:
             # When we get the last test_case in a suite, add entry, run, results
             if last_suite_id:
@@ -515,6 +539,7 @@ def collect_changes(testrail_session: TestRail, report):
                     "config_id": config_id,
                     "cases": cases_in_suite,
                     "results": results_by_suite[last_suite_id],
+                    "durations": durations_by_suite[last_suite_id],
                 }
 
                 full_test_results = merge_results(
@@ -535,6 +560,7 @@ def collect_changes(testrail_session: TestRail, report):
         "config_id": config_id,
         "cases": cases_in_suite,
         "results": results_by_suite[last_suite_id],
+        "durations": durations_by_suite[last_suite_id],
     }
 
     logging.info(f"n run {last_suite_id}, {last_description}")

--- a/tests/bookmarks_and_history/test_open_bookmark_in_private_window_via_toolbar_context_menu.py
+++ b/tests/bookmarks_and_history/test_open_bookmark_in_private_window_via_toolbar_context_menu.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import ContextMenu, Navigation, PanelUi, TabBar
+from modules.browser_object import Navigation, TabBar
 from modules.page_object_generics import GenericPage
 
 


### PR DESCRIPTION
### Description of Code / Doc Changes

* Update `modules/testrail.py` method `update_test_cases` to account for additional information beyond test execution results.
* Update `modules/testrail_integration.py` methods `collect_changes`, `organize_entries`, and `mark_results` to collect duration information from the JSON report and report it as "elapsed" in the TestRail report
* Linter caught base_page lol

### Process Changes Required

_Mark the relevant boxes:_

- [x] Changes the BasePage
- [x] Changes scheduled Beta or DevEdition

### Screenshots or Explanations

Durations are reported for setup, test (`"call"`), and teardown. We add those and create a new entry in the `suite_info` dict for those. Then they piggyback along through the organization and reporting phases.

### Comments or Future Work

May want to consider summing the durations of the reruns as well, since that's more accurate to the final result.

### Workflow Checklist

- [x] Please request reviewers
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
