### PR TITLE
Remove add prefs

### DIFF
--- a/tests/address_bar_and_search/test_addon_suggestion.py
+++ b/tests/address_bar_and_search/test_addon_suggestion.py
@@ -23,14 +23,6 @@ def test_case():
     return "3029292"
 
 
-@pytest.fixture()
-def add_to_prefs_list():
-    return [
-        ("browser.urlbar.suggest.addons", True),
-        ("browser.urlbar.addons.featureGate", True),
-    ]
-
-
 @pytest.mark.noxvfb
 def test_addon_suggestion_based_on_search_input(driver: Firefox):
     """


### PR DESCRIPTION
### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1971323

#### Description of Code / Doc Changes
Remove the add prefs list. Both Prefs in Firefox are now set to those values, by default.  For some reason sre-etting these through STArFox caused the test to fail on Windows.

#### Workflow Checklist
- [X] Please request reviewers
