### PR TITLE
Philimon/report_only_on_beta_l10n

### DIFF
--- a/.github/workflows/check-beta-l10n.yml
+++ b/.github/workflows/check-beta-l10n.yml
@@ -1,7 +1,6 @@
 name: Check new beta version
 
 on:
-  pull_request:
   schedule:
     - cron: "40 */1 * * *"
 env:

--- a/.github/workflows/check-beta-l10n.yml
+++ b/.github/workflows/check-beta-l10n.yml
@@ -1,0 +1,61 @@
+name: Check new beta version
+
+on:
+  pull_request:
+  schedule:
+    - cron: "40 */1 * * *"
+env:
+  LATEST: ""
+permissions:
+  contents: "write"
+
+jobs:
+  Check-Beta-Version:
+    runs-on: ubuntu-latest
+    outputs:
+      win_reportable: ${{ steps.reportable.outputs.win }}
+      mac_reportable: ${{ steps.reportable.outputs.mac }}
+      mac_l10n_reportable: ${{ steps.l10n-reportable.outputs.mac_l10n }}
+      win_l10n_reportable: ${{ steps.l10n-reportable.outputs.win_l10n }}
+      linux_l10n_reportable: ${{ steps.l10n-reportable.outputs.linux_l10n }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check if the l10n run is reportable
+        id: l10n-reportable
+        env:
+          TESTRAIL_REPORT: true
+          FX_L10N: true
+          TESTRAIL_BASE_URL: ${{ secrets.TESTRAIL_BASE_URL }}
+          TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
+          TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
+        run: |
+          pip3 install 'pipenv==2023.11.15';
+          pipenv install
+          echo win_l10n=$(pipenv run python -c 'from modules import testrail_integration as tri; print(tri.reportable("Windows"))') >> "$GITHUB_OUTPUT"
+          echo mac_l10n=$(pipenv run python -c 'from modules import testrail_integration as tri; print(tri.reportable("Darwin"))') >> "$GITHUB_OUTPUT"
+          echo linux_l10n=$(pipenv run python -c 'from modules import testrail_integration as tri; print(tri.reportable("Linux"))') >> "$GITHUB_OUTPUT"
+
+  Run-L10N-Mac-Smoke:
+    needs: Check-Beta-Version
+    if: ${{ needs.Check-Beta-Version.outputs.mac_l10n_reportable == 'True' }}
+    uses: ./.github/workflows/l10n.yml
+    with:
+      job_to_run: L10N-MacOS
+    secrets: inherit
+
+  Run-L10N-Win-Smoke:
+    needs: Check-Beta-Version
+    if: ${{ needs.Check-Beta-Version.outputs.win_l10n_reportable == 'True' }}
+    uses: ./.github/workflows/l10n.yml
+    with:
+      job_to_run: L10N-Windows
+    secrets: inherit
+
+  Run-L10N-Linux-Smoke:
+    needs: Check-Beta-Version
+    if: ${{ needs.Check-Beta-Version.outputs.linux_l10n_reportable == 'True' }}
+    uses: ./.github/workflows/l10n.yml
+    with:
+      job_to_run: L10N-Linux
+    secrets: inherit

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -157,27 +157,25 @@ def reportable(platform_to_test=None):
     plan_entries = this_plan.get("entries")
     if os.environ.get("FX_L10N"):
         l10n_mappings = valid_l10n_mappings()
-        covered_suites = 0
+        covered_mappings = 0
+        # keeping this logic to still see how many mappings are reported.
         for entry in plan_entries:
             if entry.get("name") in l10n_mappings:
                 site = entry.get("name")
                 for run_ in entry.get("runs"):
                     if run_.get("config"):
                         run_region, run_platform = run_.get("config").split("-")
-                        covered_suites += (
+                        covered_mappings += (
                             1
                             if run_region in l10n_mappings[site]
                             and platform in run_platform
                             else 0
                         )
-        num_suites = 0
-        for site, regions in l10n_mappings.items():
-            # each region for win and mac (linux not yet added)
-            num_suites += len(regions)
         logging.warning(
-            f"Potentially matching run found for {platform}, may be reportable. ({covered_suites} out of {num_suites} site/region mappings already reported.)"
+            f"Potentially matching run found for {platform}, may be reportable. (Found {covered_mappings} site/region mappings reported.)"
         )
-        return covered_suites < num_suites
+        # Only report when there is a new beta and no other site/region mappings are reported.
+        return covered_mappings == 0
     else:
         covered_suites = 0
         for entry in plan_entries:


### PR DESCRIPTION
### Relevant Links

### Description of Code / Doc Changes

* move l10n schedule beta runs to separate workflow.
* change reportable logic for l10n to only run when there is a new beta and no other site/region mappings are reported.
### Process Changes Required

_Mark the relevant boxes:_

- [x] Changes CI flow
- [x] Changes scheduled Beta or DevEdition

### Workflow Checklist

- [x] Please request reviewers
- [x] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
