### PR TITLE
Anca/ Active tab test stabilization

### DIFF
--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -392,7 +392,12 @@ def organize_l10n_entries(
         if not test_results[category].get(run_id):
             test_results[category][run_id] = []
         test_results[category][run_id].append(
-            {"suite_id": suite_id, "site": site, "test_case": test_case, "duration": f"{duration}s"}
+            {
+                "suite_id": suite_id,
+                "site": site,
+                "test_case": test_case,
+                "duration": f"{duration}s",
+            }
         )
 
     return test_results

--- a/tests/tabs/test_active_tab.py
+++ b/tests/tabs/test_active_tab.py
@@ -17,14 +17,15 @@ def test_active_tab(driver: Firefox):
     tabs = TabBar(driver)
     num_tabs = 5
 
-    # opening 5 tabs
+    # Open 5 tabs
     for i in range(num_tabs):
         tabs.new_tab_by_button()
 
-    # go through all the tabs and ensure highlighted one is correct, +2 since 1 indexed and additional tab for the beginning
+    # Go through all the tabs and ensure the focus is correct
     for i in range(1, num_tabs + 2):
-        target_tab = tabs.get_tab(i)
         with driver.context(driver.CONTEXT_CHROME):
+            target_tab = tabs.get_tab(i)
             target_tab.click()
-            visibility = target_tab.get_attribute("visuallyselected")
-            assert visibility == ""
+            tabs.custom_wait(timeout=3).until(
+                lambda d: target_tab.get_attribute("visuallyselected") == ""
+            )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1979286](https://bugzilla.mozilla.org/show_bug.cgi?id=1979286)
TestRail: https://mozilla.testrail.io/index.php?/cases/view/134646

### Description of Code / Doc Changes
- test_active_tab fails intermitently in CI on mac. Can't reproduce it locally. Added a wait condition and handle in one take the context switching to avoid potential stalling.


### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [ ] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
