### PR TITLE
[Draft] Anca/ Attempt to fix IT demo ad capture tests

### DIFF
--- a/l10n_CM/Unified/conftest.py
+++ b/l10n_CM/Unified/conftest.py
@@ -62,6 +62,7 @@ def prefs_list(add_to_prefs_list: List[tuple[str, str | bool]], region: str):
         ("extensions.formautofill.creditCards.reauth.optout", False),
         ("extensions.formautofill.reauth.enabled", False),
         ("extensions.formautofill.addresses.supportedCountries", region),
+        ("extensions.formautofill.addresses.experiments.enabled", True),
         ("browser.aboutConfig.showWarning", False),
         ("browser.search.region", region),
     ]
@@ -106,9 +107,9 @@ def cc_site_data(live_site, region):
 @pytest.fixture
 def is_live_site(live_site, region):
     """Determine if the site is live.
-    Treat demo IT as a live site until the doorhanger bug is fixed.
+    Demo sites are never live sites, regardless of region.
     """
-    return live_site != "demo" or region in {"IT"}
+    return live_site != "demo"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: N/A

### Description of Code / Doc Changes

- In order for the address capture to work on IT region, extensions.formautofill.addresses.experiments.enabled needs to be set on TRUE. The problem is that the capture ad tests fail. Capture functionality works on IT manual builds. And after playing a while on the build opened by Selenium, I've managed to trigger the address capture doorhanger, but i don't have reliable steps. Needs further investigation.

### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [ ] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
