### PR TITLE
Anca/ Add PL region

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_7c_capture_doorhanger_stored_data_phone_email.py
+++ b/l10n_CM/Unified/test_demo_ad_7c_capture_doorhanger_stored_data_phone_email.py
@@ -23,6 +23,12 @@ def test_demo_ad_email_phone_captured_in_doorhanger_and_stored(
     C2888704 - Verify phone/email data are captured in the Capture Doorhanger and stored in about:preferences
     """
     if not is_live_site:
+        # Skip for PL region due to Firefox doorhanger bug where phone field doesn't appear
+        if region == "PL":
+            pytest.skip(
+                "Phone field not displayed in doorhanger during automated testing for PL region"
+            )
+
         # Create fake data and fill it in
         address_autofill.open()
 

--- a/l10n_CM/region/PL.json
+++ b/l10n_CM/region/PL.json
@@ -1,0 +1,8 @@
+{
+  "region": "PL",
+  "sites": [
+    "demo"
+  ],
+  "tests": [
+  ]
+}

--- a/l10n_CM/run_l10n.py
+++ b/l10n_CM/run_l10n.py
@@ -15,7 +15,7 @@ from choose_l10n_ci_set import valid_l10n_mappings
 current_dir = os.path.dirname(__file__)
 valid_flags = {"--run-headless", "-n", "--reruns", "--fx-executable", "--ci"}
 flag_with_parameter = {"-n", "--reruns"}
-valid_region = {"US", "CA", "DE", "FR", "IT", "GB"}
+valid_region = {"US", "CA", "DE", "FR", "IT", "GB", "PL"}
 valid_sites = {
     "demo",
     "amazon",


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1981141](https://bugzilla.mozilla.org/show_bug.cgi?id=1981141)
TestRail: N/A

### Description of Code / Doc Changes

- Add PL region. Telephone field is not capture by the doorhanger, set a condition to skip test_demo_ad_7c_capture_doorhanger_stored_data_phone_email.py for now.

### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
