### PR TITLE
tracy/Disable flaky mixed content downloads test

### DIFF
--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -25,6 +25,9 @@ MIXED_CONTENT_DOWNLOAD_URL = "https://file-examples.com/wp-content/storage/2018/
 MAX_CHECKS = 30
 
 
+@pytest.mark.unstable(
+    reason="Flaky in CI, see bug https://bugzilla.mozilla.org/show_bug.cgi?id=1976520"
+)
 def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     """
     C1756722: Verify that the user can download mixed content via HTTPS
@@ -41,7 +44,9 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
         download_name = WebDriverWait(driver, 10).until(
             EC.presence_of_element_located((By.CLASS_NAME, "downloadTarget"))
         )
-
+        #
+        # Test failing here:
+        #
         download_status = WebDriverWait(driver, 10).until(
             EC.presence_of_element_located((By.CLASS_NAME, "downloadProgress"))
         )


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1976520
TestRail: https://mozilla.testrail.io/index.php?/tests/view/7263183&source=tests

####  Description of Code / Doc Changes
Disable tests/downloads/test_mixed_content_download_via_https.py

#### Comments or Future Work
The bug has been put in the unstable/skipped bucket in Bugzilla and marked disabled in TestRail.  Need to investigate why this continues to be flaky and find a stable solution.

#### Workflow Checklist
- [#] Please request reviewers
