### PR TITLE
Philimon/l10n_report_by_site_only

### DIFF
--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -189,20 +189,12 @@ def reportable(platform_to_test=None):
     if os.environ.get("FX_L10N"):
         beta_version = int(minor_num.split("b")[-1])
         distributed_mappings = select_l10n_mappings(beta_version)
-        expected_mappings = sum(map(lambda x: len(x), distributed_mappings.values()))
+        expected_mappings = len(distributed_mappings)
         covered_mappings = 0
         # keeping this logic to still see how many mappings are reported.
         for entry in plan_entries:
             if entry.get("name") in distributed_mappings:
-                site = entry.get("name")
-                for run_ in entry.get("runs"):
-                    if run_.get("config"):
-                        run_region, run_platform = run_.get("config").split("-")
-                        if (
-                            run_region in distributed_mappings[site]
-                            and platform in run_platform
-                        ):
-                            covered_mappings += 1
+                covered_mappings += 1
         logging.warning(
             f"Potentially matching run found for {platform}, may be reportable. (Found {covered_mappings} site/region mappings reported, expected {expected_mappings}.)"
         )


### PR DESCRIPTION
### Relevant Links

### Description of Code / Doc Changes

* change reporting logic for l10n to depend on sites alone, not the region or platform already reported.
* if a site stated to be reported is already showed as a test plan, then it is stated as reported for all platforms and regions.
### Process Changes Required

_Mark the relevant boxes:_

- [x] Changes scheduled Beta or DevEdition


### Workflow Checklist

- [x] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
