### PR TITLE
Add test to verify middle-mouse click closes tab

### DIFF
--- a/tests/tabs/test_close_tab_through_middle_mouse_click.py
+++ b/tests/tabs/test_close_tab_through_middle_mouse_click.py
@@ -1,0 +1,34 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_tabbar import TabBar
+from modules.page_object import ExamplePage
+
+
+@pytest.fixture()
+def test_case():
+    return "134645"
+
+
+@pytest.mark.headed
+def test_close_tab_through_middle_mouse_click(driver: Firefox):
+    """
+    C134645 - Verify that middle clicking a tab will close it
+    """
+
+    example = ExamplePage(driver)
+    tabs = TabBar(driver)
+    example.open()
+
+    # Open 2 additional tabs for a total of 3
+    for _ in range(2):
+        tabs.new_tab_by_button()
+    tabs.wait_for_num_tabs(3)
+
+    # Ensure each tab exists and middle-click to close it
+    for i in range(3, 1, -1):
+        with driver.context(driver.CONTEXT_CHROME):
+            tab_to_close = tabs.get_tab(i)
+            assert tab_to_close is not None, f"Expected tab index {i} to exist"
+            tabs.middle_click(tab_to_close)
+        tabs.wait_for_num_tabs(i - 1)


### PR DESCRIPTION
### Relevant Links

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1976525
TestRail: 134645

### Description of Code / Doc Changes

_Leave a bullet-pointed list of changes you made._

Created a test to verify that middle-mouse clicking a tab closes it. 
### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [X] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
