### PR TITLE
Add Test to Verify Pinned Tab Closes via Mouse Middle-Click

### DIFF
--- a/tests/tabs/test_close_pinned_tab_via_mouse.py
+++ b/tests/tabs/test_close_pinned_tab_via_mouse.py
@@ -16,7 +16,8 @@ def test_close_pinned_tab_via_middle_click(driver: Firefox):
     C134726 - Verify middle-clicking pinned tab will close it
     """
 
-    example = ExamplePage(driver).open()
+    example = ExamplePage(driver)
+    example.open()
     tabs = TabBar(driver)
     tab_menu = ContextMenu(driver)
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1976554
TestRail: 134726

### Description of Code / Doc Changes

_Leave a bullet-pointed list of changes you made._
- Created test to verify that middle clicking on a pinned tab will close it. This test opens up 2 new tabs, pins the first tab in the tab bar, checks that it is pinned, and then middle clicks on it. Finally it will check that the number of tabs has decreased to 2. 
### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [X] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
