### PR TITLE
Add test to verify customize firefox tab displays

### DIFF
--- a/modules/data/customize_firefox.components.json
+++ b/modules/data/customize_firefox.components.json
@@ -22,5 +22,11 @@
         "selectorData": "wrapper-search-container",
         "strategy": "id",
         "groups": []
+    },
+
+    "customize-page": {
+        "selectorData": "customization-container",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/tabs/test_display_customize_button.py
+++ b/tests/tabs/test_display_customize_button.py
@@ -1,10 +1,10 @@
 import pytest
 from selenium.webdriver import Firefox
-from selenium.webdriver.common.by import By
 
 from modules.browser_object_panel_ui import PanelUi
 from modules.browser_object_tabbar import TabBar
 from modules.page_object import ExamplePage
+from modules.page_object_customize_firefox import CustomizeFirefox
 
 
 @pytest.fixture()
@@ -20,6 +20,7 @@ def test_customize_button_displayed_in_tab_bar(driver: Firefox):
 
     panel_ui = PanelUi(driver)
     tabs = TabBar(driver)
+    custom_page = CustomizeFirefox(driver)
 
     # Open an initial example page
     example = ExamplePage(driver)
@@ -43,5 +44,5 @@ def test_customize_button_displayed_in_tab_bar(driver: Firefox):
     # Verify that the customize firefox tab is opened and correct
     example.switch_to_new_tab()
     with driver.context(driver.CONTEXT_CHROME):
-        element = driver.find_element(By.ID, "customization-container")
+        element = custom_page.get_element("customize-page")
         assert element, "element not found"


### PR DESCRIPTION
### Relevant Links

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1976542
TestRail: 134463

### Description of Code / Doc Changes

_Leave a bullet-pointed list of changes you made._

Verifies that the customize toolbar tab is correctly displayed. Verifies it is correctly open in the background as well as in focus.

### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [X] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
