### PR TITLE
tracy/ Disable refresh_firefox_dialog

### DIFF
--- a/tests/address_bar_and_search/test_refresh_firefox_dialog.py
+++ b/tests/address_bar_and_search/test_refresh_firefox_dialog.py
@@ -13,12 +13,14 @@ def test_case():
     return "3028765"
 
 
+@pytest.mark.unstable(
+    reason="Fx change landed: bug 1958537, we're tracking in bug 1958537"
+)
 def test_refresh_firefox_dialog(driver: Firefox):
     """
     C2914620 - Verify that the 'Refresh Firefox' dialog appears from the address bar.
     """
     nav = Navigation(driver)
-    nav.set_awesome_bar()
     nav.type_in_awesome_bar(SEARCH_QUERY)
 
     nav.click_on(REFRESH_BUTTON_ID)


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1987172
TestRail: https://mozilla.testrail.io/index.php?/cases/view/3028765

#### Description of Code / Doc Changes
Disable test due to change in Fx settings that we can't easily work around.  

#### Comments or Future Work
Investigate possible solutions

#### Workflow Checklist
- [X] Please request reviewers

