### PR TITLE
Test 134642: Created test to verify tabs can be reloaded (overriding cache) by using keyboard shortcuts (Bug 1976547)

### DIFF
--- a/tests/tabs/test_reload_overiding_cache_keys.py
+++ b/tests/tabs/test_reload_overiding_cache_keys.py
@@ -1,0 +1,66 @@
+import pytest
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+from modules.browser_object import TabBar
+
+
+@pytest.fixture()
+def test_case():
+    return "134642"
+
+
+TEST_URL = "https://postman-echo.com/headers"
+
+
+def test_reload_overiding_cache_keys(driver: Firefox, sys_platform: str):
+    """
+    C134642 - Verify that tabs can be hard reloaded (overriding cache) using keyboard shortcut CTRL/CMD + SHIFT + R.
+    """
+
+    browser = TabBar(driver)
+
+    # New tab + navigate
+    browser.new_tab_by_button()
+    driver.switch_to.window(driver.window_handles[-1])
+    driver.get(TEST_URL)
+
+    # Hard reload action sequence hold CTRL/CMD + SHIFT and press "r"
+    with driver.context(driver.CONTEXT_CHROME):
+        actions = browser.actions
+        if sys_platform == "Darwin":
+            actions.key_down(Keys.COMMAND).key_down(Keys.SHIFT).send_keys("r").key_up(
+                Keys.SHIFT
+            ).key_up(Keys.COMMAND).perform()
+        else:
+            actions.key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys("r").key_up(
+                Keys.SHIFT
+            ).key_up(Keys.CONTROL).perform()
+
+    # Verify cache is not being used by checking for http request headers
+    # Header "if-none-match" should not be sent
+    try:
+        etag = driver.find_element(By.ID, "/headers/if-none-match").get_attribute(
+            "innerText"
+        )
+        assert False, f"Unexpected If-None-Match present: {etag!r}"
+    except NoSuchElementException:
+        pass
+
+    # Header "pragma" should be sent with with value "no-cache"
+    pragma_text = driver.find_element(By.ID, "/headers/pragma").get_attribute(
+        "innerText"
+    )
+    assert "no-cache" in pragma_text, (
+        f"Expected 'no-cache' in pragma; got: {pragma_text!r}"
+    )
+
+    # Header "cache-control" should be sent with with value "no-cache"
+    cache_control_text = driver.find_element(
+        By.ID, "/headers/cache-control"
+    ).get_attribute("innerText")
+    assert "no-cache" in cache_control_text, (
+        f"Expected 'no-cache' in cache-control; got: {cache_control_text!r}"
+    )


### PR DESCRIPTION
### Relevant Links

Bugzilla:  https://bugzilla.mozilla.org/show_bug.cgi?id=1976547
TestRail:  134642

### Description of Code / Doc Changes

- Created a test to verify that tabs can be hard reloaded and override any cache by using the keyboard shortcuts (CTRL/CMD + SHIFT + "r").

### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

1. We create a new browser and tab.
2. We navigate to the 'https://postman-echo.com/headers' website which allows us to view the headers sent in the http request through html elements.
3. Perform an action sequence to hold CTRL/CMD + SHIFT and press "r"
4. Check the html elements to verify that the 'If-None-Match header' is not present and checks that both the 'pragma' and 'cache-control' headers contain "no-cache".
5. This lets us know that the page will load without using cache. 

### Comments or Future Work

- We may want to consider making a test to check whether BFC (back-forward-cache) is being used or not after a hard reload. 
- Since this test uses the website 'https://postman-echo.com/headers', we may have to consider in the future if the website is still active and working or not. 
- It would be better to be able to check cache use without having to rely on loading a specific website. 

### Workflow Checklist

- [x] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
