### PR TITLE
get color values for all bgs

### DIFF
--- a/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
+++ b/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 from selenium.webdriver import Firefox
 
@@ -29,7 +27,6 @@ def colors_match(a, b):
     b_colors = [float(n) for n in b_colorstring.split(",")]
     for i in range(len(a_colors)):
         diff = abs((a_colors[i] / b_colors[i]) - 1.0)
-        logging.warning(f"a: {a_colors[i]}, b: {b_colors[i]}, diff: {diff}")
         if diff > tolerance:
             return False
     return True
@@ -88,7 +85,6 @@ def test_alpenglow_theme(driver: Firefox):
         nav, "firefox-alpenglow_mozilla_org-heading", "", perform_assert=False
     )
 
-    logging.warning(f"alpenglow: {current_bg}")
     # assert current_bg == alpenglow_map["light"] or current_bg == alpenglow_map["dark"]
     assert colors_match(current_bg, alpenglow_map["light"]) or colors_match(
         current_bg, alpenglow_map["dark"]


### PR DESCRIPTION
### Relevant Links

Bugzilla: [Link](https://bugzilla.mozilla.org/show_bug.cgi?id=1974109)

### Description of Code / Doc Changes

* Reenable test
* Add method to check if theme color is "close enough" to the key

### Process Changes Required

None

### Screenshots or Explanations

The current AboutAddons.activate_theme contains a `perform_assert` check to ensure that the theme was applied successfully. We need to _not_ do that so we can use our "close enough" method.

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

I think it would be worthwhile to consider removing the theme color assertion in `AboutAddons.activate_theme()` and update all relevant tests.

### Workflow Checklist

- [x] Please request reviewers
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
