### PR TITLE
Anca/ zoom text only stabilization

### DIFF
--- a/tests/scrolling_panning_zooming/test_zoom_text_only.py
+++ b/tests/scrolling_panning_zooming/test_zoom_text_only.py
@@ -100,11 +100,11 @@ def test_zoom_text_only_from_settings(
     nav = Navigation(driver)
     panel_ui = PanelUi(driver)
 
-    # Save the original positions of elements for comparison
+    # Save the original sizes and positions for comparison
     panel_ui.open_and_switch_to_new_window("tab")
     nav.search(WEBSITE_2)
     web_page.wait.until(lambda _: web_page.title_contains("DuckDuckGo"))
-    original_positions = save_original_positions(driver, web_page)
+    original_data = save_original_data(driver, web_page)
 
     # Set the pref to zoom text only
     panel_ui.open_and_switch_to_new_window("tab")
@@ -115,7 +115,7 @@ def test_zoom_text_only_from_settings(
     about_prefs.set_default_zoom_level(110)
 
     # Verify results
-    zoom_text_only_functionality_test(driver, nav, web_page, original_positions)
+    zoom_text_only_functionality_test(driver, nav, web_page, original_data)
 
     # Reset the zoom settings so the config is no longer zoom text only, and default zoom level is 100%
     about_prefs = AboutPrefs(driver, category="General").open()
@@ -136,11 +136,11 @@ def test_zoom_text_only_after_restart(
     nav = Navigation(driver)
     panel_ui = PanelUi(driver)
 
-    # Save the original positions of elements for comparison
+    # Save the original sizes and positions for comparison
     panel_ui.open_and_switch_to_new_window("tab")
     nav.search(WEBSITE_2)
     web_page.wait.until(lambda _: web_page.title_contains("DuckDuckGo"))
-    original_positions = save_original_positions(driver, web_page)
+    original_data = save_original_data(driver, web_page)
 
     # Set default zoom level
     panel_ui.open_and_switch_to_new_window("tab")
@@ -148,7 +148,7 @@ def test_zoom_text_only_after_restart(
     about_prefs.set_default_zoom_level(110)
 
     # Verify results
-    zoom_text_only_functionality_test(driver, nav, web_page, original_positions)
+    zoom_text_only_functionality_test(driver, nav, web_page, original_data)
 
     # Reset the zoom settings so the config is no longer zoom text only, and default zoom level is 100%
     about_prefs = AboutPrefs(driver, category="General").open()
@@ -156,42 +156,42 @@ def test_zoom_text_only_after_restart(
     about_prefs.click_on("zoom-text-only")
 
 
-def save_original_positions(driver, web_page):
+def save_original_data(driver, web_page):
     """
-    Saves the original positions of elements to be tested to verify the effects of zooming
+    Saves the original positions and sizes for comparison.
     """
     driver.switch_to.window(driver.window_handles[0])
     original_website1_image_position = web_page.get_element("yahoo-logo").location["x"]
     original_website1_text_position = web_page.get_element(
         "yahoo-login-button"
     ).location["x"]
+
     driver.switch_to.window(driver.window_handles[1])
-    original_website2_image_position = web_page.get_element("duckduckgo-logo").location[
-        "x"
-    ]
+    original_website2_image_size = web_page.get_element("duckduckgo-logo").size
     original_website2_text_position = web_page.get_element(
         "duckduckgo-tagline"
     ).location["x"]
+
     return (
         original_website1_image_position,
         original_website1_text_position,
-        original_website2_image_position,
+        original_website2_image_size,
         original_website2_text_position,
     )
 
 
-def zoom_text_only_functionality_test(driver, nav, web_page, original_positions):
+def zoom_text_only_functionality_test(driver, nav, web_page, original_data):
     """
     Verifies that zoom text only works
     """
     (
         original_website1_image_position,
         original_website1_text_position,
-        original_website2_image_position,
+        original_website2_image_size,
         original_website2_text_position,
-    ) = original_positions
+    ) = original_data
 
-    # Verify only text is enlarged
+    # Verify Yahoo: image position unchanged, text position changed
     driver.switch_to.window(driver.window_handles[0])
     new_image_position = web_page.get_element("yahoo-logo").location["x"]
     new_text_position = web_page.get_element("yahoo-login-button").location["x"]
@@ -208,7 +208,7 @@ def zoom_text_only_functionality_test(driver, nav, web_page, original_positions)
     with driver.context(driver.CONTEXT_CHROME):
         nav.expect_element_attribute_contains("toolbar-zoom-level", "label", "90%")
 
-    # Verify that only text is zoomed out
+    # Verify Yahoo at 90%: image position still unchanged, text position changed
     assert (
         web_page.get_element("yahoo-logo").location["x"]
         == original_website1_image_position
@@ -218,12 +218,11 @@ def zoom_text_only_functionality_test(driver, nav, web_page, original_positions)
         > original_website1_text_position
     )
 
-    # Verify that zoom level is default level for a different website and only text is enlarged
+    # Verify DuckDuckGo: image SIZE unchanged, text position changed
     driver.switch_to.window(driver.window_handles[1])
     assert (
-        web_page.get_element("duckduckgo-logo").location["x"]
-        == original_website2_image_position
-    )
+        web_page.get_element("duckduckgo-logo").size == original_website2_image_size
+    ), "DuckDuckGo image size should not change (text-only zoom)"
     assert (
         web_page.get_element("duckduckgo-tagline").location["x"]
         < original_website2_text_position


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1991139](https://bugzilla.mozilla.org/show_bug.cgi?id=1991139)
TestRail: [545733](https://mozilla.testrail.io/index.php?/cases/view/545733)

### Description of Code / Doc Changes

- Changed the DuckDuckGo assertion to verify image size remains unchanged instead of position on zoom text only setting. Yahoo's div is anchored to the left edge (fixed position), while DuckDuckGo's image is centered (calculated position). Page reflow due to the text enlarge caused the DuckDuckGo logo to shift position, even though the image itself wasn't scaling. 
### Process Changes Required

_Mark the relevant boxes:_

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Please request reviewers
- [ ] If this is an unblocker, please post in Slack.
- [ ] If asked to address comments, please resolve conversations.
- [ ] If asked to change code, please re-request review from the person who wanted changes.

Thank you!
