### PR TITLE
Anca/ Add vertical tabs closing options test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1249,10 +1249,6 @@ sidebar:
     result: pass
     splits:
     - functional2
-  test_sidebar_vertical_tabs_mute_unmute:
-    result: pass
-    splits:
-    - functional2
   test_switch_between_horizontal_vertical_tabs:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1241,7 +1241,15 @@ sidebar:
     result: pass
     splits:
     - functional2
+  test_sidebar_vertical_tabs_closing_options:
+    result: pass
+    splits:
+    - functional2
   test_sidebar_vertical_tabs_move_options:
+    result: pass
+    splits:
+    - functional2
+  test_sidebar_vertical_tabs_mute_unmute:
     result: pass
     splits:
     - functional2

--- a/modules/browser_object_tabbar.py
+++ b/modules/browser_object_tabbar.py
@@ -135,6 +135,22 @@ class TabBar(BasePage):
             assert False, "Error checking tab pinned status"
 
     @BasePage.context_chrome
+    def toggle_mute_shortcut(self) -> BasePage:
+        """Toggle mute on the current tab using the CTRL+M keyboard shortcut"""
+        self.actions.key_down(Keys.CONTROL).send_keys("m").key_up(
+            Keys.CONTROL
+        ).perform()
+        return self
+
+    @BasePage.context_chrome
+    def close_tab_shortcut(self) -> BasePage:
+        """Close the current tab using the CTRL+W keyboard shortcut"""
+        self.actions.key_down(Keys.CONTROL).send_keys("w").key_up(
+            Keys.CONTROL
+        ).perform()
+        return self
+
+    @BasePage.context_chrome
     def click_tab_mute_button(self, identifier: Union[str, int]) -> BasePage:
         """Click the tab icon overlay, no matter what's happening with media"""
         logging.info(f"toggling tab mute for {identifier}")

--- a/modules/browser_object_tabbar.py
+++ b/modules/browser_object_tabbar.py
@@ -135,14 +135,6 @@ class TabBar(BasePage):
             assert False, "Error checking tab pinned status"
 
     @BasePage.context_chrome
-    def toggle_mute_shortcut(self) -> BasePage:
-        """Toggle mute on the current tab using the CTRL+M keyboard shortcut"""
-        self.actions.key_down(Keys.CONTROL).send_keys("m").key_up(
-            Keys.CONTROL
-        ).perform()
-        return self
-
-    @BasePage.context_chrome
     def close_tab_shortcut(self) -> BasePage:
         """Close the current tab using the CTRL+W keyboard shortcut"""
         self.actions.key_down(Keys.CONTROL).send_keys("w").key_up(

--- a/modules/browser_object_tabbar.py
+++ b/modules/browser_object_tabbar.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 from typing import Union
 
 from selenium.common.exceptions import NoSuchElementException
@@ -136,10 +137,9 @@ class TabBar(BasePage):
 
     @BasePage.context_chrome
     def close_tab_shortcut(self) -> BasePage:
-        """Close the current tab using the CTRL+W keyboard shortcut"""
-        self.actions.key_down(Keys.CONTROL).send_keys("w").key_up(
-            Keys.CONTROL
-        ).perform()
+        """Close the current tab using the CTRL+W / CMD+W keyboard shortcut"""
+        modifier = Keys.COMMAND if platform.system() == "Darwin" else Keys.CONTROL
+        self.actions.key_down(modifier).send_keys("w").key_up(modifier).perform()
         return self
 
     @BasePage.context_chrome

--- a/modules/browser_object_tabbar.py
+++ b/modules/browser_object_tabbar.py
@@ -330,6 +330,16 @@ class TabBar(BasePage):
         return self
 
     @BasePage.context_chrome
+    def close_tab_by_middle_click(self, identifier: Union[str, int]) -> BasePage:
+        """Close a tab by middle-clicking it using W3C pointer actions"""
+        tab = self.get_tab(identifier)
+        self.actions.move_to_element(tab).perform()
+        self.actions.w3c_actions.pointer_action.pointer_down(1)
+        self.actions.w3c_actions.pointer_action.pointer_up(1)
+        self.actions.perform()
+        return self
+
+    @BasePage.context_chrome
     def close_last_n_tabs(self, total_tabs: int, count: int) -> "TabBar":
         """
         Close the last N tabs in the current window, starting from the rightmost tab.

--- a/modules/browser_object_tabbar.py
+++ b/modules/browser_object_tabbar.py
@@ -1,5 +1,4 @@
 import logging
-import platform
 from typing import Union
 
 from selenium.common.exceptions import NoSuchElementException
@@ -136,9 +135,9 @@ class TabBar(BasePage):
             assert False, "Error checking tab pinned status"
 
     @BasePage.context_chrome
-    def close_tab_shortcut(self) -> BasePage:
+    def close_tab_shortcut(self, sys_platform: str) -> BasePage:
         """Close the current tab using the CTRL+W / CMD+W keyboard shortcut"""
-        modifier = Keys.COMMAND if platform.system() == "Darwin" else Keys.CONTROL
+        modifier = Keys.COMMAND if sys_platform == "Darwin" else Keys.CONTROL
         self.actions.key_down(modifier).send_keys("w").key_up(modifier).perform()
         return self
 
@@ -323,7 +322,10 @@ class TabBar(BasePage):
 
     @BasePage.context_chrome
     def close_tab_by_middle_click(self, identifier: Union[str, int]) -> BasePage:
-        """Close a tab by middle-clicking it using W3C pointer actions"""
+        """Close a tab by middle-clicking it using W3C pointer actions (headless-compatible).
+        Note: w3c_actions is an internal Selenium API that may change across versions.
+        pointer_down/up with button index 1 represents the middle mouse button (0=left, 1=middle, 2=right).
+        """
         tab = self.get_tab(identifier)
         self.actions.move_to_element(tab).perform()
         self.actions.w3c_actions.pointer_action.pointer_down(1)

--- a/tests/sidebar/test_sidebar_vertical_tabs_closing_options.py
+++ b/tests/sidebar/test_sidebar_vertical_tabs_closing_options.py
@@ -14,8 +14,8 @@ def test_case():
 
 def test_sidebar_vertical_tabs_closing_options(driver: Firefox):
     """
-    C2652384 - Verify that vertical tabs in the sidebar can be closed via context menu,
-    keyboard shortcut (CTRL+W), the X button, and middle mouse click.
+    C2652384 - Verify that vertical tabs in the sidebar can be closed via context menu, keyboard shortcut (CTRL+W),
+    the X button, and middle mouse click.
     """
     # Instantiate objects
     tabs = TabBar(driver)
@@ -42,6 +42,6 @@ def test_sidebar_vertical_tabs_closing_options(driver: Firefox):
     tabs.close_tab(tab_to_close)
     tabs.wait_for_num_tabs(NUM_TABS - 3)
 
-    # # Close a tab via middle mouse click
-    # tabs.middle_click(tabs.get_tab(NUM_TABS - 3))
-    # tabs.wait_for_num_tabs(NUM_TABS - 4)
+    # Close a tab via middle mouse click
+    tabs.close_tab_by_middle_click(NUM_TABS - 3)
+    tabs.wait_for_num_tabs(NUM_TABS - 4)

--- a/tests/sidebar/test_sidebar_vertical_tabs_closing_options.py
+++ b/tests/sidebar/test_sidebar_vertical_tabs_closing_options.py
@@ -32,7 +32,7 @@ def test_sidebar_vertical_tabs_closing_options(driver: Firefox):
     context_menu.click_and_hide_menu("context-menu-close-tab")
     tabs.wait_for_num_tabs(NUM_TABS - 1)
 
-    # Close a tab via CTRL+W
+    # Close a tab via CTRL+W (CMD+W on Mac)
     driver.switch_to.window(driver.window_handles[-1])
     tabs.close_tab_shortcut()
     tabs.wait_for_num_tabs(NUM_TABS - 2)

--- a/tests/sidebar/test_sidebar_vertical_tabs_closing_options.py
+++ b/tests/sidebar/test_sidebar_vertical_tabs_closing_options.py
@@ -12,7 +12,7 @@ def test_case():
     return "2652384"
 
 
-def test_sidebar_vertical_tabs_closing_options(driver: Firefox):
+def test_sidebar_vertical_tabs_closing_options(driver: Firefox, sys_platform: str):
     """
     C2652384 - Verify that vertical tabs in the sidebar can be closed via context menu, keyboard shortcut (CTRL+W),
     the X button, and middle mouse click.
@@ -34,7 +34,7 @@ def test_sidebar_vertical_tabs_closing_options(driver: Firefox):
 
     # Close a tab via CTRL+W (CMD+W on Mac)
     driver.switch_to.window(driver.window_handles[-1])
-    tabs.close_tab_shortcut()
+    tabs.close_tab_shortcut(sys_platform)
     tabs.wait_for_num_tabs(NUM_TABS - 2)
 
     # Close a tab via the X (Close) button

--- a/tests/sidebar/test_sidebar_vertical_tabs_closing_options.py
+++ b/tests/sidebar/test_sidebar_vertical_tabs_closing_options.py
@@ -1,0 +1,47 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import ContextMenu, Navigation, TabBar
+
+NUM_TABS = 5
+URLS = ["about:robots", "about:logo", "about:mozilla", "about:blank", "about:about"]
+
+
+@pytest.fixture()
+def test_case():
+    return "2652384"
+
+
+def test_sidebar_vertical_tabs_closing_options(driver: Firefox):
+    """
+    C2652384 - Verify that vertical tabs in the sidebar can be closed via context menu,
+    keyboard shortcut (CTRL+W), the X button, and middle mouse click.
+    """
+    # Instantiate objects
+    tabs = TabBar(driver)
+    context_menu = ContextMenu(driver)
+    nav = Navigation(driver)
+
+    # Enable vertical tabs and open tabs
+    nav.toggle_vertical_tabs()
+    tabs.open_urls_in_tabs(URLS, open_first_in_current_tab=True)
+    tabs.wait_for_num_tabs(NUM_TABS)
+
+    # Close a tab via context menu
+    tabs.context_click(tabs.get_tab(NUM_TABS))
+    context_menu.click_and_hide_menu("context-menu-close-tab")
+    tabs.wait_for_num_tabs(NUM_TABS - 1)
+
+    # Close a tab via CTRL+W
+    driver.switch_to.window(driver.window_handles[-1])
+    tabs.close_tab_shortcut()
+    tabs.wait_for_num_tabs(NUM_TABS - 2)
+
+    # Close a tab via the X (Close) button
+    tab_to_close = tabs.get_tab(NUM_TABS - 2)
+    tabs.close_tab(tab_to_close)
+    tabs.wait_for_num_tabs(NUM_TABS - 3)
+
+    # # Close a tab via middle mouse click
+    # tabs.middle_click(tabs.get_tab(NUM_TABS - 3))
+    # tabs.wait_for_num_tabs(NUM_TABS - 4)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2010776](https://bugzilla.mozilla.org/show_bug.cgi?id=2010776)
TestRail: [2652384](https://mozilla.testrail.io/index.php?/cases/view/2652384)

### Description of Code / Doc Changes

 - Add vertical tabs closing options test

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta or DevEdition
- [ ] Changes Git hooks or Github settings
- [ ] Changes L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

- Middle-click is implemented via W3C Pointer Actions instead of pynput because pynput relies on physical screen
  coordinates which don't map correctly to vertical sidebar tab elements, and using @pytest.mark.headed for a single
  step would exclude the entire test from the headless CI pipeline.

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
