### PR TITLE
sidebar test linux + mac

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1174,11 +1174,7 @@ security_and_privacy:
     splits:
     - functional2
   test_sidebar_removed_on_end_private_session:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2026669
-    result:
-      linux: unstable
-      mac: pass
-      win: pass
+    result: pass
     splits:
     - functional2
   test_third_party_content_blocked_private_browsing:

--- a/modules/browser_object_menu_bar.py
+++ b/modules/browser_object_menu_bar.py
@@ -8,6 +8,7 @@ class MenuBar(BasePage):
     def activate_menu_bar(self) -> BasePage:
         """Enables the Menu Bar at the top of the window (if needed)"""
         if self.sys_platform() != "Darwin":
+            self.element_visible("toolbar-blank-space")
             self.context_click("toolbar-blank-space")
             self.click_and_hide_menu("menu-bar-checkbox")
         return self
@@ -20,10 +21,12 @@ class MenuBar(BasePage):
 
     @BasePage.context_chrome
     def open_sidebar_panel_from_menu_bar(self, panel: str) -> BasePage:
-        """Opens the specified sidebar panel via MenuBar > View > Sidebar > {panel}. Not supported on macOS (native
-        menu bar is not accessible via WebDriver); callers should skip the test on macOS before calling this method.
-        Argument: panel: The sidebar panel label as shown in the menu, e.g. "History", "Bookmarks", "Synced Tabs",
-        "AI Chatbot", "Passwords". A matching "view-sidebar-{panel}" entry must exist in the components JSON.
+        """Opens the specified sidebar panel via MenuBar > View > Sidebar > {panel}. Not supported
+        on macOS (native menu bar is not accessible via WebDriver); callers should skip the test
+        on macOS before calling this method.
+
+        Argument: panel: The sidebar panel label as shown in the menu, e.g. "History", "Bookmarks",
+        "Passwords". A matching "view-sidebar-{panel}" entry must exist in the components JSON.
         """
         self.activate_menu_bar()
         self.open_menu("View")

--- a/tests/security_and_privacy/test_sidebar_removed_on_end_private_session.py
+++ b/tests/security_and_privacy/test_sidebar_removed_on_end_private_session.py
@@ -19,6 +19,9 @@ def add_to_prefs_list():
     ]
 
 
+# bump
+
+
 def test_sidebar_removed_on_end_private_session(
     driver: Firefox, menu_bar: MenuBar, nav: Navigation, panel_ui: PanelUi
 ):

--- a/tests/security_and_privacy/test_sidebar_removed_on_end_private_session.py
+++ b/tests/security_and_privacy/test_sidebar_removed_on_end_private_session.py
@@ -4,7 +4,7 @@ import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.keys import Keys
 
-from modules.browser_object import MenuBar, Navigation, PanelUi
+from modules.browser_object import Navigation, PanelUi
 
 
 @pytest.fixture()
@@ -21,7 +21,7 @@ def add_to_prefs_list():
 
 
 def test_sidebar_removed_on_end_private_session(
-    driver: Firefox, menu_bar: MenuBar, nav: Navigation, panel_ui: PanelUi
+    driver: Firefox, nav: Navigation, panel_ui: PanelUi
 ):
     """
     C2359316 - Verify that the Sidebar is removed when "End Private Session"
@@ -30,11 +30,11 @@ def test_sidebar_removed_on_end_private_session(
     # Open a private window and switch to it
     panel_ui.open_and_switch_to_new_window("private")
 
-    # Activate the Sidebar via menu bar (or hotkey on Mac)
+    # Activate the Sidebar via hotkey
     if platform.system() == "Darwin":
         nav.perform_key_combo_chrome(Keys.SHIFT, Keys.COMMAND, "h")
     else:
-        menu_bar.open_sidebar_panel_from_menu_bar("History")
+        nav.perform_key_combo_chrome(Keys.SHIFT, Keys.CONTROL, "h")
 
     # Verify the sidebar is open
     nav.element_visible("sidebar-box")

--- a/tests/security_and_privacy/test_sidebar_removed_on_end_private_session.py
+++ b/tests/security_and_privacy/test_sidebar_removed_on_end_private_session.py
@@ -2,6 +2,7 @@ import platform
 
 import pytest
 from selenium.webdriver import Firefox
+from selenium.webdriver.common.keys import Keys
 
 from modules.browser_object import MenuBar, Navigation, PanelUi
 
@@ -19,9 +20,6 @@ def add_to_prefs_list():
     ]
 
 
-# bump
-
-
 def test_sidebar_removed_on_end_private_session(
     driver: Firefox, menu_bar: MenuBar, nav: Navigation, panel_ui: PanelUi
 ):
@@ -32,10 +30,11 @@ def test_sidebar_removed_on_end_private_session(
     # Open a private window and switch to it
     panel_ui.open_and_switch_to_new_window("private")
 
-    # Activate the Sidebar via menu bar (native on macOS, not supported)
+    # Activate the Sidebar via menu bar (or hotkey on Mac)
     if platform.system() == "Darwin":
-        pytest.skip("View menu bar sidebar navigation is not supported on macOS")
-    menu_bar.open_sidebar_panel_from_menu_bar("History")
+        nav.perform_key_combo_chrome(Keys.SHIFT, Keys.COMMAND, "h")
+    else:
+        menu_bar.open_sidebar_panel_from_menu_bar("History")
 
     # Verify the sidebar is open
     nav.element_visible("sidebar-box")

--- a/tests/security_and_privacy/test_sidebar_removed_on_end_private_session.py
+++ b/tests/security_and_privacy/test_sidebar_removed_on_end_private_session.py
@@ -34,7 +34,7 @@ def test_sidebar_removed_on_end_private_session(
     if platform.system() == "Darwin":
         nav.perform_key_combo_chrome(Keys.SHIFT, Keys.COMMAND, "h")
     else:
-        nav.perform_key_combo_chrome(Keys.SHIFT, Keys.CONTROL, "h")
+        nav.perform_key_combo_chrome(Keys.CONTROL, "h")
 
     # Verify the sidebar is open
     nav.element_visible("sidebar-box")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [link](https://bugzilla.mozilla.org/show_bug.cgi?id=2026669)

### Description of Code / Doc Changes

* Update sidebar closes at end of private session test to use hotkey
* Update the menu bar method in case it is needed later

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes or creates a BOM/POM (name the object model): MenuBar

### Comments or Future Work

* May need to remove `MenuBar.open_sidebar_panel_from_menu_bar()` in future

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
