### PR TITLE
Anca/Add close button displayed on hovering vertical tab test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1220,6 +1220,10 @@ session_restore:
     splits:
     - functional2
 sidebar:
+  test_close_button_is_displayed_on_hovering_a_vertical_tab:
+    result: pass
+    splits:
+    - functional2
   test_hide_sidebar_behaviour:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1220,7 +1220,7 @@ session_restore:
     splits:
     - functional2
 sidebar:
-  test_close_button_is_displayed_on_hovering_a_vertical_tab:
+  test_close_button_present_on_hovering_or_selecting_a_vertical_tab:
     result: pass
     splits:
     - functional2

--- a/tests/sidebar/test_close_button_is_displayed_on_hovering_a_vertical_tab.py
+++ b/tests/sidebar/test_close_button_is_displayed_on_hovering_a_vertical_tab.py
@@ -1,0 +1,47 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.keys import Keys
+
+from modules.browser_object import Navigation, TabBar
+
+URLS = ["about:robots", "about:logo", "about:mozilla", "about:blank"]
+NUM_TABS = 4
+
+
+@pytest.fixture()
+def test_case():
+    return "2652733"
+
+
+def test_close_button_is_displayed_on_hovering_a_vertical_tab(driver: Firefox):
+    """
+    C2652733 - Verify the close (X) button is displayed and functional on a vertical tab when it is selected,
+    hovered, or focused via keyboard.
+    """
+    # Instantiate objects
+    tabs = TabBar(driver)
+    nav = Navigation(driver)
+
+    # Open the sidebar with a few vertical tabs
+    nav.toggle_vertical_tabs()
+    tabs.open_urls_in_tabs(URLS, open_first_in_current_tab=True)
+    tabs.wait_for_num_tabs(NUM_TABS)
+
+    # Select a vertical tab - close button is displayed, close the tab
+    tab = tabs.get_tab(NUM_TABS)
+    tabs.click_tab_by_index(NUM_TABS)
+    tabs.close_tab(tab)
+    tabs.wait_for_num_tabs(NUM_TABS - 1)
+
+    # Hover over a vertical tab - close button is displayed, close the tab
+    tab = tabs.get_tab(NUM_TABS - 1)
+    tabs.hover(tab)
+    tabs.close_tab(tab)
+    tabs.wait_for_num_tabs(NUM_TABS - 2)
+
+    # Focus a vertical tab using the keyboard — close button is displayed, close the tab
+    tabs.click_tab_by_index(1)
+    tabs.perform_key_combo_chrome(Keys.ARROW_DOWN)
+    tab = tabs.get_tab(2)
+    tabs.close_tab(tab)
+    tabs.wait_for_num_tabs(NUM_TABS - 3)

--- a/tests/sidebar/test_close_button_present_on_hovering_or_selecting_a_vertical_tab.py
+++ b/tests/sidebar/test_close_button_present_on_hovering_or_selecting_a_vertical_tab.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.keys import Keys
 from modules.browser_object import Navigation, TabBar
 
 URLS = ["about:robots", "about:logo", "about:mozilla", "about:blank"]
-NUM_TABS = 4
+NUM_TABS = len(URLS)
 
 
 @pytest.fixture()
@@ -18,30 +18,41 @@ def test_close_button_present_on_hovering_or_selecting_a_vertical_tab(driver: Fi
     C2652733 - Verify the close (X) button is displayed and functional on a vertical tab when it is selected,
     hovered, or focused via keyboard.
     """
-    # Instantiate objects
     tabs = TabBar(driver)
     nav = Navigation(driver)
 
-    # Open the sidebar with a few vertical tabs
     nav.toggle_vertical_tabs()
     tabs.open_urls_in_tabs(URLS, open_first_in_current_tab=True)
     tabs.wait_for_num_tabs(NUM_TABS)
 
-    # Select a vertical tab - close button is displayed, close the tab
+    # Select a vertical tab and verify its close button is visible and works.
     tab = tabs.get_tab(NUM_TABS)
     tabs.click_tab_by_index(NUM_TABS)
+    tabs.expect_in_chrome(
+        lambda d: tabs.get_element("tab-x-icon", parent_element=tab).is_displayed()
+    )
     tabs.close_tab(tab)
     tabs.wait_for_num_tabs(NUM_TABS - 1)
 
-    # Hover over a vertical tab - close button is displayed, close the tab
+    # Hover a vertical tab and verify its close button is visible and works.
     tab = tabs.get_tab(NUM_TABS - 1)
     tabs.hover(tab)
+    tabs.expect_in_chrome(
+        lambda d: tabs.get_element("tab-x-icon", parent_element=tab).is_displayed()
+    )
     tabs.close_tab(tab)
     tabs.wait_for_num_tabs(NUM_TABS - 2)
 
-    # Focus a vertical tab using the keyboard — close button is displayed, close the tab
-    tabs.click_tab_by_index(1)
+    # Move focus into the vertical tab list with the keyboard, then move to the next tab.
+    # Verify the focused tab shows the close button and can be closed.
+    for _ in range(2):
+        tabs.perform_key_combo_chrome(Keys.TAB)
+
     tabs.perform_key_combo_chrome(Keys.ARROW_DOWN)
+
     tab = tabs.get_tab(2)
+    tabs.expect_in_chrome(
+        lambda d: tabs.get_element("tab-x-icon", parent_element=tab).is_displayed()
+    )
     tabs.close_tab(tab)
     tabs.wait_for_num_tabs(NUM_TABS - 3)

--- a/tests/sidebar/test_close_button_present_on_hovering_or_selecting_a_vertical_tab.py
+++ b/tests/sidebar/test_close_button_present_on_hovering_or_selecting_a_vertical_tab.py
@@ -13,7 +13,7 @@ def test_case():
     return "2652733"
 
 
-def test_close_button_is_displayed_on_hovering_a_vertical_tab(driver: Firefox):
+def test_close_button_present_on_hovering_or_selecting_a_vertical_tab(driver: Firefox):
     """
     C2652733 - Verify the close (X) button is displayed and functional on a vertical tab when it is selected,
     hovered, or focused via keyboard.


### PR DESCRIPTION
Bugzilla: [2010838](https://bugzilla.mozilla.org/show_bug.cgi?id=2010838)
TestRail: [2652733](https://mozilla.testrail.io/index.php?/cases/view/2652733)

### Description of Code / Doc Changes

- Add close button displayed on hovering vertical tab test

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
