### PR TITLE
Hani/ confirm or edit generated password shows correct password

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -3059,6 +3059,13 @@ Description: Autocomplete dropdown is toggled for focused login fields on Mozill
 Location: Mozilla Github page load
 Path to .json: modules/data/login_autofill.components.json
 ```
+```
+Selector Name: password-signup-field
+Selector Data: "input[placeholder='new-password']"
+Description: Mozilla github registration password field
+Location: Mozilla github registration page
+Path to .json: modules/data/login_autofill.components.json
+```
 #### navigation
 ```
 Selector name: awesome-bar
@@ -3912,6 +3919,13 @@ Selector Name: password-notification-save-button
 Selector Data: "button[class='popup-notification-primary-button primary footer-button']"
 Description: Save button in the password notification popup
 Location: Save button in the password notification popup
+Path to .json: modules/data/navigation.components.json
+```
+```
+Selector Name: confirmation-hint
+Selector Data: "confirmation-hint"
+Description: Password saved! confirmation
+Location: In the Navigation bar, next to the url input field
 Path to .json: modules/data/navigation.components.json
 ```
 #### panel_ui

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -792,6 +792,10 @@ password_manager:
     result: pass
     splits:
     - functional2
+  test_confirm_or_edit_generated_password_shows_correct_password:
+    result: pass
+    splits:
+    - functional2
   test_delete_login:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -792,7 +792,7 @@ password_manager:
     result: pass
     splits:
     - functional2
-  test_confirm_or_edit_generated_password_shows_previously_edited_and_generated_passwords_option:
+  test_confirm_or_edit_generated_password_shows_previously_edited_and_generated_password_options:
     result: pass
     splits:
     - functional2

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -792,7 +792,7 @@ password_manager:
     result: pass
     splits:
     - functional2
-  test_confirm_or_edit_generated_password_shows_correct_password:
+  test_confirm_or_edit_generated_password_shows_previously_edited_and_generated_passwords_option:
     result: pass
     splits:
     - functional2

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -173,3 +173,13 @@ class AutofillPopup(BasePage):
         # Clicks the "Use a Securely Generated Password" option from the autofill popup
         self.click_on("generated-securely-password")
         return self
+
+    @BasePage.context_chrome
+    def verify_autocomplete_option(self, value: str):
+        self.wait.until(
+            lambda _: self.get_element(
+                "select-form-option-by-value",
+                labels=[value]
+            ).is_displayed()
+        )
+        return self

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -176,6 +176,7 @@ class AutofillPopup(BasePage):
 
     @BasePage.context_chrome
     def verify_autocomplete_option(self, value: str) -> BasePage:
+        """Wait until an autocomplete option containing `value` is displayed in the dropdown."""
         self.wait.until(
             lambda _: self.get_element(
                 "select-form-option-by-value", labels=[value]

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -170,16 +170,15 @@ class AutofillPopup(BasePage):
 
     @BasePage.context_chrome
     def click_securely_generated_password(self) -> BasePage:
-        # Clicks the "Use a Securely Generated Password" option from the autofill popup
+        """Click the 'Use a Securely Generated Password' option from the autofill popup."""
         self.click_on("generated-securely-password")
         return self
 
     @BasePage.context_chrome
-    def verify_autocomplete_option(self, value: str):
+    def verify_autocomplete_option(self, value: str) -> BasePage:
         self.wait.until(
             lambda _: self.get_element(
-                "select-form-option-by-value",
-                labels=[value]
+                "select-form-option-by-value", labels=[value]
             ).is_displayed()
         )
         return self

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -167,3 +167,9 @@ class AutofillPopup(BasePage):
         """Dismiss the Password Manager doorhanger using ESC."""
         self.get_element("password-notification-username-field").send_keys(Keys.ESCAPE)
         return self
+
+    @BasePage.context_chrome
+    def click_securely_generated_password(self) -> BasePage:
+        # Clicks the "Use a Securely Generated Password" option from the autofill popup
+        self.click_on("generated-securely-password")
+        return self

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -56,7 +56,7 @@
     ]
   },
   "select-form-option-by-value": {
-    "selectorData": ".autocomplete-richlistbox .autocomplete-richlistitem[ac-value='{value}']",
+    "selectorData": ".autocomplete-richlistbox .autocomplete-richlistitem[ac-value*='{value}']",
     "strategy": "css",
     "groups": []
   },

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -164,7 +164,7 @@
     "strategy": "id",
     "groups": []
   },
-   "generated-securely-password": {
+  "generated-securely-password": {
     "selectorData": "richlistitem.autocomplete-richlistitem[ac-value='Use a Securely Generated Password']",
     "strategy": "css",
     "groups": []

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -163,5 +163,10 @@
     "selectorData": "password-notification-username",
     "strategy": "id",
     "groups": []
+  },
+   "generated-securely-password": {
+    "selectorData": "richlistitem.autocomplete-richlistitem[ac-value='Use a Securely Generated Password']",
+    "strategy": "css",
+    "groups": []
   }
 }

--- a/modules/data/login_autofill.components.json
+++ b/modules/data/login_autofill.components.json
@@ -67,5 +67,10 @@
         "selectorData": "richlistitem.autocomplete-richlistitem[ac-value='testUser']",
         "strategy": "css",
         "groups": []
+    },
+    "password-signup-field": {
+        "selectorData": "input[placeholder='new-password']",
+        "strategy": "css",
+        "groups": []
     }
 }

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -748,5 +748,10 @@
         "selectorData": "button.popup-notification-primary-button[label='Save']",
         "strategy": "css",
         "groups": []
+    },
+    "confirmation-hint": {
+        "selectorData": "confirmation-hint",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/password_manager/test_confirm_or_edit_generated_password_shows_correct_password.py
+++ b/tests/password_manager/test_confirm_or_edit_generated_password_shows_correct_password.py
@@ -1,0 +1,38 @@
+from time import sleep
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.page_object_autofill import LoginAutofill
+
+
+@pytest.fixture()
+def test_case():
+    return "2248183"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("signon.rememberSignons", True)]
+
+
+def test_confirm_or_edit_generated_password_shows_correct_password(driver: Firefox):
+    """
+    C2248183 - Verify that the “Confirm/Retype Password” field autocomplete dropdown displays the previously edited and auto-saved generated password
+    """
+
+    # Instantiate objects
+    login_autofill = LoginAutofill(driver)
+    autofill_popup_panel = AutofillPopup(driver)
+
+    # Access a website with a signup page
+    login_autofill.open()
+    # login_form = LoginAutofill.LoginForm(login_autofill)
+
+    # Click on the password signup field and choose to "Use a Securely Generated" password
+    login_autofill.click_on("password-signup-field")
+    autofill_popup_panel.click_securely_generated_password()
+
+    # Edit the generated password (e.g. add/remove characters) and click out-side of the field

--- a/tests/password_manager/test_confirm_or_edit_generated_password_shows_correct_password.py
+++ b/tests/password_manager/test_confirm_or_edit_generated_password_shows_correct_password.py
@@ -1,10 +1,12 @@
-from time import sleep
-
 import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
+from modules.browser_object_navigation import Navigation
+from modules.browser_object_panel_ui import PanelUi
 from modules.page_object_autofill import LoginAutofill
+
+EDITED_PASSWORD = "T"
 
 
 @pytest.fixture()
@@ -26,13 +28,33 @@ def test_confirm_or_edit_generated_password_shows_correct_password(driver: Firef
     # Instantiate objects
     login_autofill = LoginAutofill(driver)
     autofill_popup_panel = AutofillPopup(driver)
+    panel = PanelUi(driver)
+    nav = Navigation(driver)
 
     # Access a website with a signup page
     login_autofill.open()
-    # login_form = LoginAutofill.LoginForm(login_autofill)
 
     # Click on the password signup field and choose to "Use a Securely Generated" password
     login_autofill.click_on("password-signup-field")
     autofill_popup_panel.click_securely_generated_password()
 
+    # A blue key icon is displayed on the left side of the address bar and "Password Saved!" message is also displayed
+    nav.element_visible("password-notification-key")
+    nav.element_visible("confirmation-hint")
+
     # Edit the generated password (e.g. add/remove characters) and click out-side of the field
+    login_autofill.get_element("password-signup-field").send_keys(EDITED_PASSWORD)
+    panel.click_outside_add_folder_panel()
+    
+    # A new “Password Saved!” blue message is displayed for every edit
+    nav.element_visible("confirmation-hint")
+
+    # Click on the Password field and clear its content
+    login_autofill.get_element("password-signup-field").clear()
+
+    # The autocomplete dropdown is displayed showing A "No username" entry
+    login_autofill.click_on("password-signup-field")
+    autofill_popup_panel.verify_autocomplete_option("No username")
+
+    # The autocomplete dropdown is displayed "Use a Securely Generated Password" option
+    autofill_popup_panel.verify_autocomplete_option("Use a Securely Generated Password")

--- a/tests/password_manager/test_confirm_or_edit_generated_password_shows_previously_edited_and_generated_password_options.py
+++ b/tests/password_manager/test_confirm_or_edit_generated_password_shows_previously_edited_and_generated_password_options.py
@@ -20,9 +20,12 @@ def add_to_prefs_list():
     return [("signon.rememberSignons", True)]
 
 
-def test_confirm_or_edit_generated_password_shows_correct_password(driver: Firefox):
+def test_confirm_or_edit_generated_password_shows_previously_edited_and_generated_password_options(
+    driver: Firefox,
+):
     """
-    C2248183 - Verify that the “Confirm/Retype Password” field autocomplete dropdown displays the previously edited and auto-saved generated password
+    C2248183 - Verify that the “Confirm/Retype Password” field autocomplete dropdown displays the previously edited
+     and auto-saved generated password
     """
 
     # Instantiate objects
@@ -45,7 +48,7 @@ def test_confirm_or_edit_generated_password_shows_correct_password(driver: Firef
     # Edit the generated password (e.g. add/remove characters) and click out-side of the field
     login_autofill.get_element("password-signup-field").send_keys(EDITED_PASSWORD)
     panel.click_outside_add_folder_panel()
-    
+
     # A new “Password Saved!” blue message is displayed for every edit
     nav.element_visible("confirmation-hint")
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009995](https://bugzilla.mozilla.org/show_bug.cgi?id=2009995)
TestRail: [2248183](https://mozilla.testrail.io/index.php?/cases/view/2248183)

### Description of Code / Doc Changes

* Add a test to verify that the “Confirm/Retype Password” field autocomplete dropdown displays the previously edited and auto-saved generated password.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
