### PR TITLE
Anca/ Add sidebar expand collapse on hover unaffected by right side position

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1232,6 +1232,10 @@ sidebar:
     result: pass
     splits:
     - functional2
+  test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position:
+    result: pass
+    splits:
+    - functional2
   test_sidebar_button_always_displayed_on_fresh_profile:
     result: pass
     splits:

--- a/modules/browser_object_sidebar.py
+++ b/modules/browser_object_sidebar.py
@@ -114,10 +114,11 @@ class Sidebar(BasePage):
         Must be called from within a @BasePage.context_chrome method.
         """
         return self.driver.execute_script(
+            "const l10nId = arguments[0];"
             "const cd = document.querySelector('browser#sidebar')?.contentDocument;"
             "if (!cd || cd.readyState !== 'complete') return null;"
             "function search(root) {"
-            "  const el = root.querySelector('[data-l10n-id=\"' + arguments[0] + '\"]');"
+            "  const el = root.querySelector('[data-l10n-id=\"' + l10nId + '\"]');"
             "  if (el) return " + js_on_element + ";"
             "  for (const host of root.querySelectorAll('*')) {"
             "    if (host.shadowRoot) {"

--- a/modules/browser_object_sidebar.py
+++ b/modules/browser_object_sidebar.py
@@ -206,12 +206,10 @@ class Sidebar(BasePage):
         width, ensuring any panel-close animation has finished before the caller
         proceeds to measure a baseline width.
         """
-        last: list[float] = [None]
+        last: list[float | None] = [None]
 
         def _stable(_):
-            w = self.driver.execute_script(
-                "return document.querySelector('sidebar-main')?.getBoundingClientRect().width ?? 0;"
-            )
+            w = self.get_sidebar_strip_width()
             if w > 0 and w == last[0]:
                 return True
             last[0] = w

--- a/modules/browser_object_sidebar.py
+++ b/modules/browser_object_sidebar.py
@@ -199,6 +199,28 @@ class Sidebar(BasePage):
         )
 
     @BasePage.context_chrome
+    def expect_sidebar_strip_collapsed(self) -> "Sidebar":
+        """Wait until the sidebar strip width has stabilized to its collapsed state.
+
+        Polls until two consecutive readings (500 ms apart) return the same non-zero
+        width, ensuring any panel-close animation has finished before the caller
+        proceeds to measure a baseline width.
+        """
+        last: list[float] = [None]
+
+        def _stable(_):
+            w = self.driver.execute_script(
+                "return document.querySelector('sidebar-main')?.getBoundingClientRect().width ?? 0;"
+            )
+            if w > 0 and w == last[0]:
+                return True
+            last[0] = w
+            return False
+
+        self.wait.until(_stable)
+        return self
+
+    @BasePage.context_chrome
     def expect_expand_on_hover_unavailable(self):
         """Wait until the expand-on-hover option is no longer available.
 

--- a/modules/browser_object_sidebar.py
+++ b/modules/browser_object_sidebar.py
@@ -144,6 +144,67 @@ class Sidebar(BasePage):
         return self
 
     @BasePage.context_chrome
+    def click_expand_on_hover_in_panel(self) -> BasePage:
+        """Click the 'Expand sidebar on hover' checkbox in the Customize Sidebar panel.
+
+        Uses the same shadow-root piercing pattern as _exec_on_vertical_tab_element.
+        Finds the moz-checkbox with data-l10n-id="expand-sidebar-on-hover" and clicks it.
+        """
+        self.wait.until(
+            lambda _: self.driver.execute_script(
+                "const cd = document.querySelector('browser#sidebar')?.contentDocument;"
+                "if (!cd || cd.readyState !== 'complete') return null;"
+                "function search(root) {"
+                "  const el = root.querySelector('[data-l10n-id=\"expand-sidebar-on-hover\"]');"
+                "  if (el) { el.click(); return true; }"
+                "  for (const host of root.querySelectorAll('*')) {"
+                "    if (host.shadowRoot) {"
+                "      const r = search(host.shadowRoot);"
+                "      if (r !== null) return r;"
+                "    }"
+                "  }"
+                "  return null;"
+                "}"
+                "return search(cd);"
+            )
+        )
+        return self
+
+    @BasePage.context_chrome
+    def click_move_sidebar_to_right_in_panel(self) -> BasePage:
+        """Click the 'Move sidebar to the right' checkbox in the Customize Sidebar panel.
+
+        Uses the same shadow-root piercing pattern as _exec_on_vertical_tab_element.
+        Searches for the moz-checkbox with data-l10n-id="sidebar-show-on-the-right".
+        """
+        self.wait.until(
+            lambda _: self.driver.execute_script(
+                "const cd = document.querySelector('browser#sidebar')?.contentDocument;"
+                "if (!cd || cd.readyState !== 'complete') return null;"
+                "function search(root) {"
+                "  const el = root.querySelector('[data-l10n-id=\"sidebar-show-on-the-right\"]');"
+                "  if (el) { el.click(); return true; }"
+                "  for (const host of root.querySelectorAll('*')) {"
+                "    if (host.shadowRoot) {"
+                "      const r = search(host.shadowRoot);"
+                "      if (r !== null) return r;"
+                "    }"
+                "  }"
+                "  return null;"
+                "}"
+                "return search(cd);"
+            )
+        )
+        return self
+
+    @BasePage.context_chrome
+    def get_sidebar_strip_width(self) -> float:
+        """Return the current rendered width of the sidebar-main element in pixels."""
+        return self.driver.execute_script(
+            "return document.querySelector('sidebar-main')?.getBoundingClientRect().width ?? 0;"
+        )
+
+    @BasePage.context_chrome
     def click_manage_extensions(self):
         """Click the Manage Extensions link in the Customize Sidebar panel.
 

--- a/modules/browser_object_sidebar.py
+++ b/modules/browser_object_sidebar.py
@@ -104,6 +104,33 @@ class Sidebar(BasePage):
             "return search(cd);"
         )
 
+    def _exec_on_element_by_l10n_id(self, l10n_id: str, js_on_element: str):
+        """Find a customize-panel element by exact data-l10n-id and evaluate js_on_element on it.
+
+        General-purpose version of _exec_on_vertical_tab_element. l10n_id is passed as a JS
+        argument to avoid string injection; js_on_element is a developer-controlled code expression
+        concatenated at call time. Returns null if the panel is not ready or the element is not found.
+
+        Must be called from within a @BasePage.context_chrome method.
+        """
+        return self.driver.execute_script(
+            "const cd = document.querySelector('browser#sidebar')?.contentDocument;"
+            "if (!cd || cd.readyState !== 'complete') return null;"
+            "function search(root) {"
+            "  const el = root.querySelector('[data-l10n-id=\"' + arguments[0] + '\"]');"
+            "  if (el) return " + js_on_element + ";"
+            "  for (const host of root.querySelectorAll('*')) {"
+            "    if (host.shadowRoot) {"
+            "      const r = search(host.shadowRoot);"
+            "      if (r !== null) return r;"
+            "    }"
+            "  }"
+            "  return null;"
+            "}"
+            "return search(cd);",
+            l10n_id,
+        )
+
     @BasePage.context_chrome
     def expect_vertical_tabs_checkbox_visible(self):
         """Verify that the Vertical tabs checkbox is displayed in the Sidebar settings section of the customize panel."""
@@ -145,54 +172,20 @@ class Sidebar(BasePage):
 
     @BasePage.context_chrome
     def click_expand_on_hover_in_panel(self) -> BasePage:
-        """Click the 'Expand sidebar on hover' checkbox in the Customize Sidebar panel.
-
-        Uses the same shadow-root piercing pattern as _exec_on_vertical_tab_element.
-        Finds the moz-checkbox with data-l10n-id="expand-sidebar-on-hover" and clicks it.
-        """
+        """Click the 'Expand sidebar on hover' checkbox in the Customize Sidebar panel."""
         self.wait.until(
-            lambda _: self.driver.execute_script(
-                "const cd = document.querySelector('browser#sidebar')?.contentDocument;"
-                "if (!cd || cd.readyState !== 'complete') return null;"
-                "function search(root) {"
-                "  const el = root.querySelector('[data-l10n-id=\"expand-sidebar-on-hover\"]');"
-                "  if (el) { el.click(); return true; }"
-                "  for (const host of root.querySelectorAll('*')) {"
-                "    if (host.shadowRoot) {"
-                "      const r = search(host.shadowRoot);"
-                "      if (r !== null) return r;"
-                "    }"
-                "  }"
-                "  return null;"
-                "}"
-                "return search(cd);"
+            lambda _: self._exec_on_element_by_l10n_id(
+                "expand-sidebar-on-hover", "(el.click(), true)"
             )
         )
         return self
 
     @BasePage.context_chrome
     def click_move_sidebar_to_right_in_panel(self) -> BasePage:
-        """Click the 'Move sidebar to the right' checkbox in the Customize Sidebar panel.
-
-        Uses the same shadow-root piercing pattern as _exec_on_vertical_tab_element.
-        Searches for the moz-checkbox with data-l10n-id="sidebar-show-on-the-right".
-        """
+        """Click the 'Move sidebar to the right' checkbox in the Customize Sidebar panel."""
         self.wait.until(
-            lambda _: self.driver.execute_script(
-                "const cd = document.querySelector('browser#sidebar')?.contentDocument;"
-                "if (!cd || cd.readyState !== 'complete') return null;"
-                "function search(root) {"
-                "  const el = root.querySelector('[data-l10n-id=\"sidebar-show-on-the-right\"]');"
-                "  if (el) { el.click(); return true; }"
-                "  for (const host of root.querySelectorAll('*')) {"
-                "    if (host.shadowRoot) {"
-                "      const r = search(host.shadowRoot);"
-                "      if (r !== null) return r;"
-                "    }"
-                "  }"
-                "  return null;"
-                "}"
-                "return search(cd);"
+            lambda _: self._exec_on_element_by_l10n_id(
+                "sidebar-show-on-the-right", "(el.click(), true)"
             )
         )
         return self
@@ -202,6 +195,7 @@ class Sidebar(BasePage):
         """Return the current rendered width of the sidebar-main element in pixels."""
         return self.driver.execute_script(
             "return document.querySelector('sidebar-main')?.getBoundingClientRect().width ?? 0;"
+        )
 
     @BasePage.context_chrome
     def expect_expand_on_hover_unavailable(self):
@@ -233,7 +227,6 @@ class Sidebar(BasePage):
 
         self.wait.until(_is_unavailable)
         return self
-
 
     @BasePage.context_chrome
     def click_manage_extensions(self):

--- a/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
+++ b/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
@@ -9,11 +9,6 @@ def test_case():
     return "2947650"
 
 
-@pytest.fixture()
-def add_to_prefs_list():
-    return [("sidebar.revamp", True)]
-
-
 def test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position(
     driver: Firefox,
 ):

--- a/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
+++ b/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
@@ -29,6 +29,9 @@ def test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position(
     sidebar.click_expand_on_hover_in_panel()
     sidebar.click_move_sidebar_to_right_in_panel()
 
+    # Close the Customize Sidebar panel so the sidebar returns to its collapsed strip state
+    sidebar.click_customize_sidebar()
+
     # Hover over the sidebar strip and verify it expands
     collapsed_width = sidebar.get_sidebar_strip_width()
     sidebar.hover("sidebar-main")

--- a/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
+++ b/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
@@ -31,6 +31,7 @@ def test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position(
 
     # Close the Customize Sidebar panel so the sidebar returns to its collapsed strip state
     sidebar.click_customize_sidebar()
+    sidebar.expect_sidebar_strip_collapsed()
 
     # Hover over the sidebar strip and verify it expands
     collapsed_width = sidebar.get_sidebar_strip_width()

--- a/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
+++ b/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
@@ -40,5 +40,6 @@ def test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position(
 
     # Move the mouse away and verify the sidebar collapses again
     expanded_width = sidebar.get_sidebar_strip_width()
+    assert expanded_width > collapsed_width
     sidebar.hover("sidebar-button")
     sidebar.wait.until(lambda _: sidebar.get_sidebar_strip_width() < expanded_width)

--- a/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
+++ b/tests/sidebar/test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position.py
@@ -1,0 +1,45 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation, Sidebar
+
+
+@pytest.fixture()
+def test_case():
+    return "2947650"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("sidebar.revamp", True)]
+
+
+def test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position(
+    driver: Firefox,
+):
+    """
+    C2947650 - Verify that moving the sidebar to the right side does not break
+    expand/collapse on hover behaviour.
+    """
+    sidebar = Sidebar(driver)
+    nav = Navigation(driver)
+
+    # Enable vertical tabs via toolbar context menu
+    nav.toggle_vertical_tabs()
+
+    # Open Customize Sidebar panel
+    sidebar.click_customize_sidebar()
+
+    # Enable "Expand sidebar on hover" and move the sidebar to the right
+    sidebar.click_expand_on_hover_in_panel()
+    sidebar.click_move_sidebar_to_right_in_panel()
+
+    # Hover over the sidebar strip and verify it expands
+    collapsed_width = sidebar.get_sidebar_strip_width()
+    sidebar.hover("sidebar-main")
+    sidebar.wait.until(lambda _: sidebar.get_sidebar_strip_width() > collapsed_width)
+
+    # Move the mouse away and verify the sidebar collapses again
+    expanded_width = sidebar.get_sidebar_strip_width()
+    sidebar.hover("sidebar-button")
+    sidebar.wait.until(lambda _: sidebar.get_sidebar_strip_width() < expanded_width)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2010840](https://bugzilla.mozilla.org/show_bug.cgi?id=2010840)
TestRail: [2947650](https://mozilla.testrail.io/index.php?/cases/view/2947650)

### Description of Code / Doc Changes

- Add sidebar expand collapse on hover unaffected by right side position test

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
