### PR TITLE
Hani/ Test edit generated password triggers autosave

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -804,6 +804,10 @@ password_manager:
     result: pass
     splits:
     - functional2
+  test_edit_generated_password_triggers_autosave:
+    result: pass
+    splits:
+    - functional2
   test_edit_primary_password:
     result: pass
     splits:

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -456,6 +456,18 @@ class AboutLogins(BasePage):
 
         return self
 
+    def assert_revealed_password(self, expected_password: str) -> BasePage:
+        """Reveal saved password and assert it matches the expected value"""
+        self.click_reveal_password_button()
+        saved_password = self.get_element(
+            "about-logins-page-password-revealed"
+        ).get_attribute("value")
+
+        assert saved_password == expected_password, (
+            f"Expected '{expected_password}', got '{saved_password}'"
+        )
+        return self
+
 
 class AboutPrivatebrowsing(BasePage):
     """

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -458,7 +458,6 @@ class AboutLogins(BasePage):
 
     def assert_revealed_password(self, expected_password: str) -> BasePage:
         """Reveal saved password and assert it matches the expected value"""
-        self.click_reveal_password_button()
         saved_password = self.get_element(
             "about-logins-page-password-revealed"
         ).get_attribute("value")

--- a/tests/password_manager/test_edit_generated_password_triggers_autosave.py
+++ b/tests/password_manager/test_edit_generated_password_triggers_autosave.py
@@ -1,11 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.browser_object_navigation import Navigation
-from modules.browser_object_tabbar import TabBar
-from modules.page_object_about_pages import AboutLogins
-from modules.page_object_autofill import LoginAutofill
+from modules.browser_object import AutofillPopup, Navigation, TabBar
+from modules.page_object import AboutLogins, LoginAutofill
 
 EDIT_PASSWORD = "GG"
 SECOND_EDIT_PASSWORD = "RR"
@@ -70,6 +67,7 @@ def test_edit_generated_password_triggers_autosave(driver: Firefox):
     )
 
     # Entry shows edited password is saved
+    about_logins.click_reveal_password_button()
     about_logins.assert_revealed_password(expected_password)
 
     # Go back to the password field tab and focus again the password field
@@ -93,6 +91,7 @@ def test_edit_generated_password_triggers_autosave(driver: Firefox):
 
     # Go back to again about:logins
     driver.switch_to.window(driver.window_handles[1])
+    about_logins.open()
 
     # Entry shows an empty username
     about_logins.element_attribute_contains(
@@ -100,4 +99,5 @@ def test_edit_generated_password_triggers_autosave(driver: Firefox):
     )
 
     # Entry shows edited password is saved
+    about_logins.click_reveal_password_button()
     about_logins.assert_revealed_password(expected_password_updated)

--- a/tests/password_manager/test_edit_generated_password_triggers_autosave.py
+++ b/tests/password_manager/test_edit_generated_password_triggers_autosave.py
@@ -1,0 +1,103 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.browser_object_navigation import Navigation
+from modules.browser_object_tabbar import TabBar
+from modules.page_object_about_pages import AboutLogins
+from modules.page_object_autofill import LoginAutofill
+
+EDIT_PASSWORD = "GG"
+SECOND_EDIT_PASSWORD = "RR"
+
+
+@pytest.fixture()
+def test_case():
+    return "2248179"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("signon.rememberSignons", True)]
+
+
+def test_edit_generated_password_triggers_autosave(driver: Firefox):
+    """
+    C2248179 - Verify that editing a generated password triggers auto-save
+    """
+
+    # Instantiate objects
+    login_autofill = LoginAutofill(driver)
+    autofill_popup_panel = AutofillPopup(driver)
+    nav = Navigation(driver)
+    about_logins = AboutLogins(driver)
+    tabs = TabBar(driver)
+
+    # Navigate to a signup form
+    login_autofill.open()
+
+    # Generate a secure password
+    login_autofill.click_on("password-signup-field")
+    autofill_popup_panel.click_securely_generated_password()
+
+    # A blue key icon is displayed on the left side of the address bar and "Password Saved!" message is also displayed
+    nav.element_visible("password-notification-key")
+    nav.element_visible("confirmation-hint")
+
+    # Edit the generated password directly in the password field
+    login_autofill.get_element("password-signup-field").send_keys(EDIT_PASSWORD)
+
+    expected_password = login_autofill.get_element(
+        "password-signup-field"
+    ).get_attribute("value")
+
+    # Focus away from the password field
+    login_autofill.click_on("username-field")
+
+    # A blue key icon is displayed on the left side of the address bar and "Password Saved!" message is also displayed
+    nav.element_visible("password-notification-key")
+    nav.element_visible("confirmation-hint")
+
+    # Open about:logins, locate the entry for the above edited generated password and reveal password
+    tabs.new_tab_by_button()
+    tabs.switch_to_new_tab()
+    about_logins.open()
+
+    # Entry shows an empty username
+    about_logins.element_attribute_contains(
+        "about-logins-page-username-field", "placeholder", "(no username)"
+    )
+
+    # Entry shows edited password is saved
+    about_logins.assert_revealed_password(expected_password)
+
+    # Go back to the password field tab and focus again the password field
+    driver.switch_to.window(driver.window_handles[0])
+    login_autofill.click_on("password-signup-field")
+    autofill_popup_panel.click_autofill_form_option()
+
+    # Make additional edits to the initial edited password
+    login_autofill.get_element("password-signup-field").send_keys(SECOND_EDIT_PASSWORD)
+
+    expected_password_updated = login_autofill.get_element(
+        "password-signup-field"
+    ).get_attribute("value")
+
+    # Focus away from the password field
+    login_autofill.click_on("username-field")
+
+    # A blue key icon is displayed on the left side of the address bar and "Password Saved!" message is also displayed
+    nav.element_visible("password-notification-key")
+    nav.element_visible("confirmation-hint")
+
+    # Go back to again about:logins
+    driver.switch_to.window(driver.window_handles[1])
+
+    # Entry shows an empty username
+    about_logins.element_attribute_contains(
+        "about-logins-page-username-field", "placeholder", "(no username)"
+    )
+
+    # Entry shows edited password is saved
+    about_logins.assert_revealed_password(expected_password_updated)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009994](https://bugzilla.mozilla.org/show_bug.cgi?id=2009994)
TestRail: [2248179](https://mozilla.testrail.io/index.php?/cases/view/2248179)

### Description of Code / Doc Changes

* Add test to verify that editing a generated password triggers auto-save

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
