### PR TITLE
Fix tests that would fail in 151 - export + search mode

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,6 +28,7 @@ ABOUT_FIREFOX = "chrome://browser/content/aboutDialog.xhtml"
 FX_VERSION_RE = re.compile(r"Mozilla Firefox (\d+)\.(\d\d?)b(\d\d?)")
 TESTRAIL_FX_DESK_PRJ = "17"
 TESTRAIL_RUN_FMT = "[{channel} {major}] Automated testing {major}.{minor}b{build}"
+VERSION_TEST_NAME = "test_fx_version"
 
 # Number of suites that exist in the repo, that shouldn't report to TR. Currently meta and pocket.
 SUITE_COVERAGE_TOLERANCE = 2
@@ -311,8 +312,10 @@ def version(fx_executable: str):
 
 
 @pytest.fixture(scope="session")
-def build_version():
+def build_version(request):
     """Collect executables, but just the version number for Fx"""
+    if not os.environ.get("CI") and request.node.name != VERSION_TEST_NAME:
+        return None
     return collect_executables.main("-n")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,6 @@ ABOUT_FIREFOX = "chrome://browser/content/aboutDialog.xhtml"
 FX_VERSION_RE = re.compile(r"Mozilla Firefox (\d+)\.(\d\d?)b(\d\d?)")
 TESTRAIL_FX_DESK_PRJ = "17"
 TESTRAIL_RUN_FMT = "[{channel} {major}] Automated testing {major}.{minor}b{build}"
-VERSION_TEST_NAME = "test_fx_version"
 
 # Number of suites that exist in the repo, that shouldn't report to TR. Currently meta and pocket.
 SUITE_COVERAGE_TOLERANCE = 2
@@ -314,7 +313,7 @@ def version(fx_executable: str):
 @pytest.fixture(scope="session")
 def build_version(request):
     """Collect executables, but just the version number for Fx"""
-    if not os.environ.get("CI") and request.node.name != VERSION_TEST_NAME:
+    if not os.environ.get("CI"):
         return None
     return collect_executables.main("-n")
 

--- a/conftest.py
+++ b/conftest.py
@@ -311,7 +311,7 @@ def version(fx_executable: str):
 
 
 @pytest.fixture(scope="session")
-def build_version(request):
+def build_version():
     """Collect executables, but just the version number for Fx"""
     if not os.environ.get("CI"):
         return None

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -972,7 +972,11 @@ preferences:
     splits:
     - functional2
   test_clear_cookie_data:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033620
+    result:
+      win: unstable
+      linux: pass
+      mac: pass
     splits:
     - smoke
   test_firefox_home_new_tabs:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -974,9 +974,9 @@ preferences:
   test_clear_cookie_data:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033620
     result:
-      win: unstable
       linux: pass
       mac: pass
+      win: unstable
     splits:
     - smoke
   test_firefox_home_new_tabs:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -317,9 +317,9 @@ bookmarks_and_history:
   test_import_bookmarks_chrome:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033604
     result:
-      win: unstable
       linux: pass
       mac: pass
+      win: unstable
     splits:
     - smoke
   test_import_bookmarks_edge:
@@ -643,9 +643,9 @@ networking:
   test_default_dns_protection:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033605
     result:
-      win: unstable
-      mac: pass
       linux: pass
+      mac: pass
+      win: unstable
     splits:
     - smoke
   test_http_site:
@@ -1018,9 +1018,9 @@ profile:
   test_set_default_profile:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033608
     result:
-      win: unstable
-      mac: pass
       linux: pass
+      mac: pass
+      win: unstable
     splits:
     - smoke
 reader_view:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -315,7 +315,11 @@ bookmarks_and_history:
     splits:
     - functional1
   test_import_bookmarks_chrome:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033604
+    result:
+      win: unstable
+      linux: pass
+      mac: pass
     splits:
     - smoke
   test_import_bookmarks_edge:
@@ -637,7 +641,11 @@ meta:
     splits: []
 networking:
   test_default_dns_protection:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033605
+    result:
+      win: unstable
+      mac: pass
+      linux: pass
     splits:
     - smoke
   test_http_site:
@@ -1008,7 +1016,11 @@ printing_ui:
     - functional2
 profile:
   test_set_default_profile:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033608
+    result:
+      win: unstable
+      mac: pass
+      linux: pass
     splits:
     - smoke
 reader_view:

--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -302,9 +302,16 @@ class Navigation(BasePage):
         # check if search_mode is valid, otherwise raise error.
         if search_mode not in self.VALID_SEARCH_MODES:
             raise ValueError("search location is not valid.")
-        # switch to chrome context
-        # get list of all valid search modes and filter by label
-        self.get_element("search-mode-switcher-option", labels=[search_mode]).click()
+
+        # wait for menu to fully render
+        self.element_visible("search-mode-switcher-prefs")
+        self.element_clickable("search-mode-switcher-option", labels=[search_mode])
+
+        # We get "cannot scroll into view", so force with JS
+        self.driver.execute_script(
+            "arguments[0].click();",
+            self.fetch("search-mode-switcher-option", labels=[search_mode]),
+        )
         return self
 
     @BasePage.context_chrome

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -110,8 +110,8 @@
         "groups": []
     },
     "searchmode-switcher": {
-        "selectorData": "urlbar-searchmode-switcher",
-        "strategy": "id",
+        "selectorData": "searchmode-switcher",
+        "strategy": "class",
         "groups": []
     },
     "legacy-searchbar-switcher-popup": {
@@ -127,9 +127,18 @@
         ]
     },
     "search-mode-switcher-option": {
-        "selectorData": "menuitem[label*='{title}']",
+        "selectorData": "#searchmode-switcher-panel-list-urlbar panel-item[label*='{title}']",
         "strategy": "css",
-        "groups": []
+        "groups": [
+            "doNotCache"
+        ]
+    },
+    "search-mode-switcher-prefs": {
+        "selectorData": "searchmode-switcher-panel-search-settings-button",
+        "strategy": "class",
+        "groups": [
+            "doNotCache"
+        ]
     },
     "downloads-button": {
         "selectorData": "downloads-button",
@@ -582,7 +591,9 @@
     "searchbar-input": {
         "selectorData": "input[aria-controls='searchbar-results']",
         "strategy": "css",
-        "groups": ["doNotCache"]
+        "groups": [
+            "doNotCache"
+        ]
     },
     "searchbar-suggestions": {
         "selectorData": "div.urlbarView-row",
@@ -747,7 +758,9 @@
     "password-notification-popup-panel": {
         "selectorData": "notification-popup",
         "strategy": "id",
-        "groups": ["doNotCache"]
+        "groups": [
+            "doNotCache"
+        ]
     },
     "password-notification-save-button": {
         "selectorData": "button.popup-notification-primary-button[label='Save']",

--- a/tests/bookmarks_and_history/test_import_bookmarks_chrome.py
+++ b/tests/bookmarks_and_history/test_import_bookmarks_chrome.py
@@ -17,6 +17,11 @@ def test_case():
 
 
 @pytest.fixture()
+def hard_quit():
+    return True
+
+
+@pytest.fixture()
 def add_to_prefs_list():
     return [
         ("browser.migrate.chrome.get_permissions.enabled", True),


### PR DESCRIPTION
### Relevant Links

No bugs yet

### Description of Code / Doc Changes

* Hard quit on chrome import because "welcome" modal isn't allowing Fx shutdown
* Fix searchmode dropdown (impacted two tests)
* Fix issue where tests failing on local at critical part of release cycle

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes or creates a BOM/POM (name the object model): Navigation

### Screenshots or Explanations

We shouldn't collect executables for any local runs; testing version should only happen when test_version.py is called (in the pre-commit)

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
