### PR TITLE
Anca/Stabilization default dns protection

### DIFF
--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -583,30 +583,40 @@ class AboutNetworking(BasePage):
         # Use dynamic ID based on the option name
         self.get_element("networking-sidebar-category", labels=[option]).click()
 
-    def get_all_dns_rows(self):
-        """Get all DNS rows with their TRR status in the DNS table"""
+    def get_all_dns_rows(self) -> list[tuple[str, str]]:
+        """Get all DNS rows as (host, trr) text tuples."""
         self.element_visible("dns-content")
-        names = self.find_elements(
-            By.XPATH, "//tbody[@id='dns_content']/tr/td[position()=1]"
-        )
-        trr = self.find_elements(
-            By.XPATH, "//tbody[@id='dns_content']/tr/td[position()=3]"
-        )
-        return list(zip(names, trr))
+        rows = self.find_elements(By.XPATH, "//tbody[@id='dns_content']/tr")
+        result = []
+        for row in rows:
+            try:
+                cells = row.find_elements(By.TAG_NAME, "td")
+                if len(cells) >= 3:
+                    result.append(
+                        (cells[0].text.strip(), cells[2].text.strip().lower())
+                    )
+            except StaleElementReferenceException:
+                continue
+        return result
 
     def wait_for_dns_entry(self, host: str, trr: str = "true") -> BasePage:
         """Wait until a DNS entry for the given host appears in the table."""
-
-        # Wait once for the table to be visible
         self.element_visible("dns-content")
 
-        # Then poll for the specific row
+        expected_host = host.strip()
+        expected_trr = trr.strip().lower()
+
+        def _entry_present(_):
+            try:
+                return any(
+                    row_host == expected_host and row_trr == expected_trr
+                    for row_host, row_trr in self.get_all_dns_rows()
+                )
+            except StaleElementReferenceException:
+                return False
+
         self.wait.until(
-            lambda _: any(
-                name.text == host and trr_el.text == trr
-                for name, trr_el in self.get_all_dns_rows()
-            ),
+            _entry_present,
             message=f"DNS entry for host '{host}' with TRR='{trr}' did not appear",
         )
-
         return self

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -584,7 +584,7 @@ class AboutNetworking(BasePage):
         self.get_element("networking-sidebar-category", labels=[option]).click()
 
     def get_all_dns_rows(self) -> list[tuple[str, str]]:
-        """Get all DNS rows as (host, trr) text tuples. Caller must ensure the table is visible first."""
+        """Get all DNS rows as (host, trr) text tuples."""
         rows = self.find_elements(By.XPATH, "//tbody[@id='dns_content']/tr")
         result = []
         for row in rows:
@@ -599,20 +599,20 @@ class AboutNetworking(BasePage):
         return result
 
     def wait_for_dns_entry(self, host: str, trr: str = "true") -> BasePage:
-        """Wait until a DNS entry for the given host appears in the table."""
+        """Wait until a DNS entry for the given host appears in the table.
+
+        Ensures the table is visible before polling.
+        """
         self.element_visible("dns-content")
 
         expected_host = host.strip()
         expected_trr = trr.strip().lower()
 
         def _entry_present(_):
-            try:
-                return any(
-                    row_host == expected_host and row_trr == expected_trr
-                    for row_host, row_trr in self.get_all_dns_rows()
-                )
-            except StaleElementReferenceException:
-                return False
+            return any(
+                row_host == expected_host and row_trr == expected_trr
+                for row_host, row_trr in self.get_all_dns_rows()
+            )
 
         self.custom_wait(timeout=30).until(
             _entry_present,

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -584,22 +584,24 @@ class AboutNetworking(BasePage):
         self.get_element("networking-sidebar-category", labels=[option]).click()
 
     def get_all_dns_rows(self) -> list[tuple[str, str]]:
-        """Get all DNS rows as (host, trr) text tuples."""
-        try:
-            rows = self.find_elements(By.XPATH, "//tbody[@id='dns_content']/tr")
-            result = []
-            for row in rows:
-                try:
-                    cells = row.find_elements(By.TAG_NAME, "td")
-                    if len(cells) >= 3:
-                        result.append(
-                            (cells[0].text.strip(), cells[2].text.strip().lower())
-                        )
-                except StaleElementReferenceException:
-                    continue
-            return result
-        except StaleElementReferenceException:
-            return []
+        """Get all DNS rows as (host, trr) text tuples.
+
+        Caller must ensure the DNS table is visible before calling. Returns []
+        if an individual row goes stale mid-iteration (table is re-rendering);
+        callers that poll can treat [] as a retry signal.
+        """
+        rows = self.find_elements(By.XPATH, "//tbody[@id='dns_content']/tr")
+        result = []
+        for row in rows:
+            try:
+                cells = row.find_elements(By.TAG_NAME, "td")
+                if len(cells) >= 3:
+                    result.append(
+                        (cells[0].text.strip(), cells[2].text.strip().lower())
+                    )
+            except StaleElementReferenceException:
+                continue
+        return result
 
     def wait_for_dns_entry(self, host: str, trr: str = "true") -> BasePage:
         """Wait until a DNS entry for the given host appears in the table.

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -585,18 +585,21 @@ class AboutNetworking(BasePage):
 
     def get_all_dns_rows(self) -> list[tuple[str, str]]:
         """Get all DNS rows as (host, trr) text tuples."""
-        rows = self.find_elements(By.XPATH, "//tbody[@id='dns_content']/tr")
-        result = []
-        for row in rows:
-            try:
-                cells = row.find_elements(By.TAG_NAME, "td")
-                if len(cells) >= 3:
-                    result.append(
-                        (cells[0].text.strip(), cells[2].text.strip().lower())
-                    )
-            except StaleElementReferenceException:
-                continue
-        return result
+        try:
+            rows = self.find_elements(By.XPATH, "//tbody[@id='dns_content']/tr")
+            result = []
+            for row in rows:
+                try:
+                    cells = row.find_elements(By.TAG_NAME, "td")
+                    if len(cells) >= 3:
+                        result.append(
+                            (cells[0].text.strip(), cells[2].text.strip().lower())
+                        )
+                except StaleElementReferenceException:
+                    continue
+            return result
+        except StaleElementReferenceException:
+            return []
 
     def wait_for_dns_entry(self, host: str, trr: str = "true") -> BasePage:
         """Wait until a DNS entry for the given host appears in the table.

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -584,8 +584,7 @@ class AboutNetworking(BasePage):
         self.get_element("networking-sidebar-category", labels=[option]).click()
 
     def get_all_dns_rows(self) -> list[tuple[str, str]]:
-        """Get all DNS rows as (host, trr) text tuples."""
-        self.element_visible("dns-content")
+        """Get all DNS rows as (host, trr) text tuples. Caller must ensure the table is visible first."""
         rows = self.find_elements(By.XPATH, "//tbody[@id='dns_content']/tr")
         result = []
         for row in rows:
@@ -615,7 +614,7 @@ class AboutNetworking(BasePage):
             except StaleElementReferenceException:
                 return False
 
-        self.wait.until(
+        self.custom_wait(timeout=30).until(
             _entry_present,
             message=f"DNS entry for host '{host}' with TRR='{trr}' did not appear",
         )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2033605](https://bugzilla.mozilla.org/show_bug.cgi?id=2033605)
TestRail: N/A

### Description of Code / Doc Changes

- Refactored DNS row handling in AboutNetworking to make table validation more reliable during dynamic updates. get_all_dns_rows() now reads host and TRR values from the same <tr> instead of building separate column lists, reducing the risk of mismatched data. wait_for_dns_entry() was updated to compare normalized text values and tolerate temporary stale elements while polling, improving stability when the DNS table rerenders.
- Test failed intermittently for me - 2 out of 30 runs. With the fix I had a 30 out of 30 pass rate. 

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
