### PR TITLE
Hani/ Test no generated password option with pp and no credentials

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -827,6 +827,10 @@ password_manager:
     result: pass
     splits:
     - smoke
+  test_no_generated_password_options_with_pp_and_no_credentials:
+    result: pass
+    splits:
+    - functional2
   test_password_csv_correctness:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:

--- a/modules/browser_object_context_menu.py
+++ b/modules/browser_object_context_menu.py
@@ -91,9 +91,7 @@ class ContextMenu(BasePage):
     def verify_item_disabled(self, reference: str, labels=None):
         """Assert a context menu item is disabled (grayed out)."""
         el = self.get_element(reference, labels=labels)
-        assert el.get_attribute("disabled") == "true", (
-            f"{reference} is not disabled"
-        )
+        assert el.get_attribute("disabled") == "true", f"{reference} is not disabled"
         return self
 
 

--- a/modules/browser_object_context_menu.py
+++ b/modules/browser_object_context_menu.py
@@ -87,6 +87,14 @@ class ContextMenu(BasePage):
         )
         return self
 
+    @BasePage.context_chrome
+    def verify_item_disabled(self, reference: str, labels=None):
+        """Assert a context menu item is disabled (grayed out)."""
+        el = self.get_element(reference, labels=labels)
+        assert el.get_attribute("disabled") == "true", (
+            f"{reference} is not disabled"
+        )
+
 
 class AboutDownloadsContextMenu(ContextMenu):
     """

--- a/modules/browser_object_context_menu.py
+++ b/modules/browser_object_context_menu.py
@@ -94,6 +94,7 @@ class ContextMenu(BasePage):
         assert el.get_attribute("disabled") == "true", (
             f"{reference} is not disabled"
         )
+        return self
 
 
 class AboutDownloadsContextMenu(ContextMenu):

--- a/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
+++ b/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
@@ -1,0 +1,71 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_context_menu import ContextMenu
+from modules.browser_object_tabbar import TabBar
+from modules.page_object_about_pages import AboutLogins
+from modules.page_object_autofill import LoginAutofill
+from modules.page_object_prefs import AboutPrefs
+from modules.util import BrowserActions
+
+TEST_PAGE_URL = "https://facebook.com"
+USERNAME = "username"
+PASSWORD = "password"
+PRIMARY_PASSWORD = "securePassword1"
+ALERT_MESSAGE = "Primary Password successfully changed."
+
+
+@pytest.fixture()
+def test_case():
+    return "2245189"
+
+
+def test_no_generated_password_options_with_pp_and_no_credentials(driver: Firefox):
+    """
+    C2245189 - Verify that Generated Password options are not available when no credentials are saved and a PP is set
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    ba = BrowserActions(driver)
+    tabs = TabBar(driver)
+    about_logins = AboutLogins(driver)
+    login_autofill = LoginAutofill(driver)
+    context_menu = ContextMenu(driver)
+
+    # Have a Primary Password set
+    about_prefs.open()
+    about_prefs.open_primary_password_popup(ba)
+    about_prefs.set_primary_password(PRIMARY_PASSWORD)
+    about_prefs.accept_alert_and_verify_text(ALERT_MESSAGE)
+
+    # Open about:logins page and create a login entry
+    tabs.switch_to_new_tab()
+    about_logins.open()
+    about_logins.add_login(TEST_PAGE_URL, USERNAME, PASSWORD)
+
+    # Attempt to view the saved password in order to trigger the primary password prompt
+    about_logins.element_visible("show-password-checkbox")
+    about_logins.click_on("show-password-checkbox")
+
+    # Dismiss the primary password prompt without entering the password
+    about_logins.dismiss_primary_password_prompt()
+
+    # Go to the test website
+    tabs.switch_to_new_tab()
+    login_autofill.open()
+
+    # Right-click on the username field
+    login_autofill.context_click("username-field")
+
+    # Saved Password option is grayed out in the context menu
+    context_menu.verify_item_disabled("context-menu-use-saved-password")
+
+    # Right-click on the password field
+    login_autofill.context_click("password-login-field")
+
+    # Saved Password option is grayed out in the context menu
+    context_menu.verify_item_disabled("context-menu-use-saved-password")
+
+    # Suggest strong password option is grayed out in the context menu
+    context_menu.verify_item_disabled("context-menu-suggest-strong-password")

--- a/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
+++ b/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
@@ -1,11 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_context_menu import ContextMenu
-from modules.browser_object_tabbar import TabBar
-from modules.page_object_about_pages import AboutLogins
-from modules.page_object_autofill import LoginAutofill
-from modules.page_object_prefs import AboutPrefs
+from modules.browser_object import ContextMenu, TabBar
+from modules.page_object import AboutLogins, LoginAutofill, AboutPrefs
 from modules.util import BrowserActions
 
 CREDENTIAL_ORIGIN = "https://facebook.com"

--- a/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
+++ b/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
@@ -8,7 +8,7 @@ from modules.page_object_autofill import LoginAutofill
 from modules.page_object_prefs import AboutPrefs
 from modules.util import BrowserActions
 
-TEST_PAGE_URL = "https://facebook.com"
+CREDENTIAL_ORIGIN = "https://facebook.com"
 USERNAME = "username"
 PASSWORD = "password"
 PRIMARY_PASSWORD = "securePassword1"
@@ -42,7 +42,7 @@ def test_no_generated_password_options_with_pp_and_no_credentials(driver: Firefo
     # Open about:logins page and create a login entry
     tabs.switch_to_new_tab()
     about_logins.open()
-    about_logins.add_login(TEST_PAGE_URL, USERNAME, PASSWORD)
+    about_logins.add_login(CREDENTIAL_ORIGIN, USERNAME, PASSWORD)
 
     # Attempt to view the saved password in order to trigger the primary password prompt
     about_logins.element_visible("show-password-checkbox")

--- a/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
+++ b/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
@@ -2,7 +2,7 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import ContextMenu, TabBar
-from modules.page_object import AboutLogins, LoginAutofill, AboutPrefs
+from modules.page_object import AboutLogins, AboutPrefs, LoginAutofill
 from modules.util import BrowserActions
 
 CREDENTIAL_ORIGIN = "https://facebook.com"


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009985](https://bugzilla.mozilla.org/show_bug.cgi?id=2009985)
TestRail: [2245189](https://mozilla.testrail.io/index.php?/cases/view/2245189)

### Description of Code / Doc Changes

* Verify that Generated Password options are not available when no credentials are saved and a PP is set

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
