### PR TITLE
Anca/ DNS protection follow-up  => Revert status 

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -645,11 +645,7 @@ meta:
     splits: []
 networking:
   test_default_dns_protection:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033605
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - smoke
   test_http_site:


### PR DESCRIPTION
Bugzilla: [2033605](https://bugzilla.mozilla.org/show_bug.cgi?id=2033605)
TestRail: _

### Description of Code / Doc Changes

- Follow up On PR [1265 ](`https://github.com/mozilla/fx-desktop-qa-automation/pull/1265`), revert status in key.yaml

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
