### PR TITLE
Hani/ Test edit autofill after pp dismissed

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -802,6 +802,10 @@ password_manager:
     result: pass
     splits:
     - functional2
+  test_edit_autofill_after_pp_dismissed:
+    result: pass
+    splits:
+    - functional2
   test_edit_generated_password_triggers_autosave:
     result: pass
     splits:

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -183,3 +183,13 @@ class AutofillPopup(BasePage):
             ).is_displayed()
         )
         return self
+
+    @BasePage.context_chrome
+    def is_autocomplete_option_present(self, value: str) -> bool:
+        """Checks whether an autocomplete option with the given value is visible."""
+        try:
+            return self.get_element(
+                "select-form-option-by-value", labels=[value]
+            ).is_displayed()
+        except Exception:
+            return False

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -183,3 +183,12 @@ class AutofillPopup(BasePage):
             ).is_displayed()
         )
         return self
+
+    def is_autocomplete_option_present(self, value: str) -> bool:
+        """Checks whether an autocomplete option with the given value is visible."""
+        try:
+            return self.get_element(
+                "select-form-option-by-value", labels=[value]
+            ).is_displayed()
+        except Exception:
+            return False

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -183,12 +183,3 @@ class AutofillPopup(BasePage):
             ).is_displayed()
         )
         return self
-
-    def is_autocomplete_option_present(self, value: str) -> bool:
-        """Checks whether an autocomplete option with the given value is visible."""
-        try:
-            return self.get_element(
-                "select-form-option-by-value", labels=[value]
-            ).is_displayed()
-        except Exception:
-            return False

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -183,13 +183,3 @@ class AutofillPopup(BasePage):
             ).is_displayed()
         )
         return self
-
-    @BasePage.context_chrome
-    def is_autocomplete_option_present(self, value: str) -> bool:
-        """Checks whether an autocomplete option with the given value is visible."""
-        try:
-            return self.get_element(
-                "select-form-option-by-value", labels=[value]
-            ).is_displayed()
-        except Exception:
-            return False

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -467,6 +467,16 @@ class AboutLogins(BasePage):
         )
         return self
 
+    def dismiss_pp_if_appears(self, timeout=3):
+        """Dismiss the Primary Password prompt only if it appears within a short time window"""
+        try:
+            self.custom_wait(timeout=timeout).until(
+                lambda d: self.is_element_present("primary-password-dialog", timeout=0)
+            )
+            self.dismiss_primary_password_prompt()
+        except Exception:
+            pass
+
 
 class AboutPrivatebrowsing(BasePage):
     """

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -472,10 +472,9 @@ class AboutLogins(BasePage):
         Dismiss the Primary Password alert if it appears within timeout seconds
         """
         try:
-            self.custom_wait(timeout=timeout).until(lambda d: d.switch_to.alert)
+            WebDriverWait(self.driver, timeout).until(EC.alert_is_present())
             self.driver.switch_to.alert.dismiss()
         except Exception:
-            # No alert appeared within timeout → continue test
             pass
         return self
 

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -468,14 +468,22 @@ class AboutLogins(BasePage):
         return self
 
     def dismiss_pp_if_appears(self, timeout=3):
-        """Dismiss the Primary Password prompt only if it appears within a short time window"""
+        """
+        Dismiss the Primary Password prompt if it appears.
+
+        This method waits for a short period of time for the primary password
+        dialog to be triggered. If the dialog is present, it will be dismissed.
+        If no dialog appears within the timeout, execution continues silently.
+        """
         try:
             self.custom_wait(timeout=timeout).until(
-                lambda d: self.is_element_present("primary-password-dialog", timeout=0)
+                lambda d: d.switch_to.alert
             )
-            self.dismiss_primary_password_prompt()
+            self.driver.switch_to.alert.dismiss()
         except Exception:
+            # No alert appeared within timeout → continue test
             pass
+        return self
 
 
 class AboutPrivatebrowsing(BasePage):

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -469,16 +469,10 @@ class AboutLogins(BasePage):
 
     def dismiss_pp_if_appears(self, timeout=3):
         """
-        Dismiss the Primary Password prompt if it appears.
-
-        This method waits for a short period of time for the primary password
-        dialog to be triggered. If the dialog is present, it will be dismissed.
-        If no dialog appears within the timeout, execution continues silently.
+        Dismiss the Primary Password alert if it appears within timeout seconds
         """
         try:
-            self.custom_wait(timeout=timeout).until(
-                lambda d: d.switch_to.alert
-            )
+            self.custom_wait(timeout=timeout).until(lambda d: d.switch_to.alert)
             self.driver.switch_to.alert.dismiss()
         except Exception:
             # No alert appeared within timeout → continue test

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1001,6 +1001,7 @@ class AboutPrefs(BasePage):
         return self
 
     def create_primary_password(self, password: str, alert_text: str, ba):
+        """Creates a Primary Password, confirms alert"""
         self.open()
         self.open_primary_password_popup(ba)
         self.set_primary_password(password)

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1000,6 +1000,13 @@ class AboutPrefs(BasePage):
         alert.accept()
         return self
 
+    def create_primary_password(self, password: str, alert_text: str, ba):
+        self.open()
+        self.open_primary_password_popup(ba)
+        self.set_primary_password(password)
+        self.accept_alert_and_verify_text(alert_text)
+        return self
+
 
 class AboutAddons(BasePage):
     """

--- a/tests/password_manager/test_about_logins_copy_prompts_primary_password.py
+++ b/tests/password_manager/test_about_logins_copy_prompts_primary_password.py
@@ -29,10 +29,7 @@ def test_about_logins_copy_prompts_primary_password(driver: Firefox):
     nav = Navigation(driver)
 
     # Have a Primary Password set
-    about_prefs.open()
-    about_prefs.open_primary_password_popup(ba)
-    about_prefs.set_primary_password(PRIMARY_PASSWORD)
-    about_prefs.accept_alert_and_verify_text(ALERT_MESSAGE)
+    about_prefs.create_primary_password(PRIMARY_PASSWORD, ALERT_MESSAGE, ba)
 
     # Have at least one saved login
     about_logins.open()

--- a/tests/password_manager/test_about_logins_edit_prompts_primary_password.py
+++ b/tests/password_manager/test_about_logins_edit_prompts_primary_password.py
@@ -29,10 +29,7 @@ def test_about_logins_edit_prompts_primary_password(driver: Firefox):
     ba = BrowserActions(driver)
 
     # Have a Primary Password set
-    about_prefs.open()
-    about_prefs.open_primary_password_popup(ba)
-    about_prefs.set_primary_password(PRIMARY_PASSWORD)
-    about_prefs.accept_alert_and_verify_text(ALERT_MESSAGE)
+    about_prefs.create_primary_password(PRIMARY_PASSWORD, ALERT_MESSAGE, ba)
 
     # Have at least one saved login
     about_logins.open()

--- a/tests/password_manager/test_delete_primary_password.py
+++ b/tests/password_manager/test_delete_primary_password.py
@@ -23,15 +23,8 @@ def test_delete_primary_password(driver: Firefox):
     about_prefs = AboutPrefs(driver, category="privacy")
     ba = BrowserActions(driver)
 
-    # Select the "Use a primary password" check box to trigger the "Change Primary Password" window
-    about_prefs.open()
-    about_prefs.open_primary_password_popup(ba)
-
-    # Add primary passwords
-    about_prefs.set_primary_password(PRIMARY_PASSWORD)
-
-    # Check that the pop-up appears
-    about_prefs.accept_alert_and_verify_text(ALERT_MESSAGE)
+    # Have a Primary Password set
+    about_prefs.create_primary_password(PRIMARY_PASSWORD, ALERT_MESSAGE, ba)
 
     # Uncheck the "Use a Primary Password" checkbox
     about_prefs.open()

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 import pytest
 from selenium.webdriver import Firefox
 

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -54,7 +54,7 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     about_logins.click_on("show-password-checkbox")
 
     # Dismiss the primary password prompt without entering the password
-    about_logins.dismiss_primary_password_prompt()
+    about_logins.dismiss_pp_if_appears()
 
     # Go to the test website
     tabs.open_and_switch_to_new_tab()

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -60,11 +60,12 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     tabs.open_and_switch_to_new_tab()
     login_autofill.open()
 
-    # Fill in both the username and password (other credentials other than the one from precondition)
+    # Fill in both the username and password with new credentials and dismiss pp if appears
     login_form = LoginAutofill.LoginForm(login_autofill)
     login_form.fill_username(SECOND_USERNAME)
-    about_logins.dismiss_primary_password_prompt()
+    about_logins.dismiss_pp_if_appears()
     login_form.fill_password(SECOND_PASSWORD)
+    about_logins.dismiss_pp_if_appears()
 
     # Submit the form
     login_form.submit()

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import pytest
 from selenium.webdriver import Firefox
 
@@ -77,6 +79,7 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # Click on the grey key icon, choose to save the credentials and reload the form
     nav.click_on("password-notification-key")
     autofill_popup_panel.click_doorhanger_button("save")
+    sleep(1)
     tabs.open_and_switch_to_new_tab()
     login_autofill.open()
 
@@ -84,8 +87,4 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # (1 from preconditions and 1 for the newly saved credentials)
     login_autofill.click_on("username-login-field")
     autofill_popup_panel.verify_autocomplete_option(USERNAME)
-    if not autofill_popup_panel.is_autocomplete_option_present(SECOND_USERNAME):
-        login_autofill.open()
-        login_autofill.click_on("username-login-field")
-
     autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -76,6 +76,7 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
 
     # Click on the grey key icon, choose to save the credentials and reload the form
     nav.click_on("password-notification-key")
+    autofill_popup_panel.verify_username_value(SECOND_USERNAME)
     autofill_popup_panel.click_doorhanger_button("save")
     tabs.open_and_switch_to_new_tab()
     login_autofill.open()
@@ -84,8 +85,4 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # (1 from preconditions and 1 for the newly saved credentials)
     login_autofill.click_on("username-login-field")
     autofill_popup_panel.verify_autocomplete_option(USERNAME)
-    if not autofill_popup_panel.is_autocomplete_option_present(SECOND_USERNAME):
-        login_autofill.open()
-        login_autofill.click_on("username-login-field")
-
     autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import pytest
 from selenium.webdriver import Firefox
 
@@ -77,6 +79,7 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # Click on the grey key icon, choose to save the credentials and reload the form
     nav.click_on("password-notification-key")
     autofill_popup_panel.click_doorhanger_button("save")
+    nav.element_not_visible("password-notification-key")
     tabs.open_and_switch_to_new_tab()
     login_autofill.open()
 

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -59,6 +59,7 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # Go to the test website
     tabs.open_and_switch_to_new_tab()
     login_autofill.open()
+    about_logins.dismiss_pp_if_appears()
 
     # Fill in both the username and password with new credentials and dismiss pp if appears
     login_form = LoginAutofill.LoginForm(login_autofill)

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -1,0 +1,84 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_autofill_popup import AutofillPopup
+from modules.browser_object_navigation import Navigation
+from modules.browser_object_tabbar import TabBar
+from modules.page_object import AboutLogins, AboutPrefs, LoginAutofill
+from modules.util import BrowserActions
+
+CREDENTIAL_ORIGIN = "https://mozilla.github.io"
+USERNAME = "username"
+PASSWORD = "password"
+PRIMARY_PASSWORD = "securePassword1"
+ALERT_MESSAGE = "Primary Password successfully changed."
+SECOND_USERNAME = "SecondUsername"
+SECOND_PASSWORD = "secondPassword"
+
+
+@pytest.fixture()
+def test_case():
+    return "2244618"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("signon.rememberSignons", True)]
+
+
+def test_edit_autofill_after_pp_dismissed(driver: Firefox):
+    """
+    C2244618 - [PP] Verify that editing autofilled entries after PP was dismissed is possible
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    ba = BrowserActions(driver)
+    tabs = TabBar(driver)
+    about_logins = AboutLogins(driver)
+    login_autofill = LoginAutofill(driver)
+    nav = Navigation(driver)
+    autofill_popup_panel = AutofillPopup(driver)
+
+    # Have a Primary Password set
+    about_prefs.create_primary_password(PRIMARY_PASSWORD, ALERT_MESSAGE, ba)
+
+    # Open about:logins page and create a login entry
+    tabs.open_and_switch_to_new_tab()
+    about_logins.open()
+    about_logins.add_login(CREDENTIAL_ORIGIN, USERNAME, PASSWORD)
+
+    # Attempt to view the saved password in order to trigger the primary password prompt
+    about_logins.element_visible("show-password-checkbox")
+    about_logins.click_on("show-password-checkbox")
+
+    # Dismiss the primary password prompt without entering the password
+    about_logins.dismiss_primary_password_prompt()
+
+    # Go to the test website
+    tabs.open_and_switch_to_new_tab()
+    login_autofill.open()
+
+    # Fill in both the username and password (other credentials other than the one from precondition)
+    login_form = LoginAutofill.LoginForm(login_autofill)
+    login_form.fill_username(SECOND_USERNAME)
+    about_logins.dismiss_primary_password_prompt()
+    login_form.fill_password(SECOND_PASSWORD)
+
+    # Submit the form
+    login_form.submit()
+
+    # Fill in the correct primary password
+    about_logins.enter_primary_password(PRIMARY_PASSWORD)
+
+    # Click on the grey key icon, choose to save the credentials and reload the form
+    nav.click_on("password-notification-key")
+    autofill_popup_panel.click_doorhanger_button("save")
+    login_autofill.open()
+
+    # The credentials were saved and the autocomplete dropdown appear on page load with 2 entries.
+    # (1 from preconditions and 1 for the newly saved credentials)
+    login_autofill.click_on("username-login-field")
+    autofill_popup_panel.verify_autocomplete_option("username")
+    autofill_popup_panel.verify_autocomplete_option("SecondUsername")

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 import pytest
 from selenium.webdriver import Firefox
 
@@ -79,7 +77,6 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # Click on the grey key icon, choose to save the credentials and reload the form
     nav.click_on("password-notification-key")
     autofill_popup_panel.click_doorhanger_button("save")
-    sleep(1)
     tabs.open_and_switch_to_new_tab()
     login_autofill.open()
 
@@ -87,4 +84,8 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # (1 from preconditions and 1 for the newly saved credentials)
     login_autofill.click_on("username-login-field")
     autofill_popup_panel.verify_autocomplete_option(USERNAME)
+    if not autofill_popup_panel.is_autocomplete_option_present(SECOND_USERNAME):
+        login_autofill.open()
+        login_autofill.click_on("username-login-field")
+
     autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -77,6 +77,7 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # Click on the grey key icon, choose to save the credentials and reload the form
     nav.click_on("password-notification-key")
     autofill_popup_panel.click_doorhanger_button("save")
+    tabs.open_and_switch_to_new_tab()
     login_autofill.open()
 
     # The credentials were saved and the autocomplete dropdown appear on page load with 2 entries.

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -85,4 +85,10 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # (1 from preconditions and 1 for the newly saved credentials)
     login_autofill.click_on("username-login-field")
     autofill_popup_panel.verify_autocomplete_option(USERNAME)
-    autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)
+    # autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)
+    try:
+        autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)
+    except Exception:
+        # re-trigger dropdown and try again
+        login_autofill.double_click("username-login-field")
+        autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -77,7 +77,6 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # Click on the grey key icon, choose to save the credentials and reload the form
     nav.click_on("password-notification-key")
     autofill_popup_panel.click_doorhanger_button("save")
-    nav.element_not_visible("password-notification-key")
     tabs.open_and_switch_to_new_tab()
     login_autofill.open()
 
@@ -85,10 +84,8 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # (1 from preconditions and 1 for the newly saved credentials)
     login_autofill.click_on("username-login-field")
     autofill_popup_panel.verify_autocomplete_option(USERNAME)
-    # autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)
-    try:
-        autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)
-    except Exception:
-        # re-trigger dropdown and try again
-        login_autofill.double_click("username-login-field")
-        autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)
+    if not autofill_popup_panel.is_autocomplete_option_present(SECOND_USERNAME):
+        login_autofill.open()
+        login_autofill.click_on("username-login-field")
+
+    autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -80,5 +80,5 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     # The credentials were saved and the autocomplete dropdown appear on page load with 2 entries.
     # (1 from preconditions and 1 for the newly saved credentials)
     login_autofill.click_on("username-login-field")
-    autofill_popup_panel.verify_autocomplete_option("username")
-    autofill_popup_panel.verify_autocomplete_option("SecondUsername")
+    autofill_popup_panel.verify_autocomplete_option(USERNAME)
+    autofill_popup_panel.verify_autocomplete_option(SECOND_USERNAME)

--- a/tests/password_manager/test_edit_primary_password.py
+++ b/tests/password_manager/test_edit_primary_password.py
@@ -28,15 +28,8 @@ def test_edit_primary_password(driver: Firefox):
     about_prefs = AboutPrefs(driver, category="privacy")
     ba = BrowserActions(driver)
 
-    # Select the "Use a primary password" check box to trigger the "Change Primary Password" window
-    about_prefs.open()
-    about_prefs.open_primary_password_popup(ba)
-
-    # Primary password can be changed
-    about_prefs.set_primary_password(PRIMARY_PASSWORD)
-
-    # Check that the pop-up appears
-    about_prefs.accept_alert_and_verify_text(ALERT_MESSAGE)
+    # Have a Primary Password set
+    about_prefs.create_primary_password(PRIMARY_PASSWORD, ALERT_MESSAGE, ba)
 
     # Click on the Change Primary Password button
     about_prefs.open()

--- a/tests/password_manager/test_facebook_login_autofill_dropdown.py
+++ b/tests/password_manager/test_facebook_login_autofill_dropdown.py
@@ -164,12 +164,16 @@ def test_facebook_login_autofill_dropdown(driver: Firefox, temp_selectors):
     web_page = open_facebook_login(driver, temp_selectors)
 
     web_page.wait.until(
-        lambda _: web_page.get_element("facebook-username-field").get_attribute("value")
-        == USERNAME_1
+        lambda _: (
+            web_page.get_element("facebook-username-field").get_attribute("value")
+            == USERNAME_1
+        )
     )
     web_page.wait.until(
-        lambda _: web_page.get_element("facebook-password-field").get_attribute("value")
-        == PASSWORD_1
+        lambda _: (
+            web_page.get_element("facebook-password-field").get_attribute("value")
+            == PASSWORD_1
+        )
     )
 
     # Step 4: add second credential for same origin
@@ -205,12 +209,14 @@ def test_facebook_login_autofill_dropdown(driver: Firefox, temp_selectors):
     web_page = open_facebook_login(driver, temp_selectors)
 
     web_page.wait.until(
-        lambda _: web_page.get_element("facebook-username-field").get_attribute("value")
-        == ""
+        lambda _: (
+            web_page.get_element("facebook-username-field").get_attribute("value") == ""
+        )
     )
     web_page.wait.until(
-        lambda _: web_page.get_element("facebook-password-field").get_attribute("value")
-        == ""
+        lambda _: (
+            web_page.get_element("facebook-password-field").get_attribute("value") == ""
+        )
     )
 
     username_field = web_page.get_element("facebook-username-field")

--- a/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
+++ b/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
@@ -31,10 +31,7 @@ def test_no_generated_password_options_with_pp_and_no_credentials(driver: Firefo
     context_menu = ContextMenu(driver)
 
     # Have a Primary Password set
-    about_prefs.open()
-    about_prefs.open_primary_password_popup(ba)
-    about_prefs.set_primary_password(PRIMARY_PASSWORD)
-    about_prefs.accept_alert_and_verify_text(ALERT_MESSAGE)
+    about_prefs.create_primary_password(PRIMARY_PASSWORD, ALERT_MESSAGE, ba)
 
     # Open about:logins page and create a login entry
     tabs.switch_to_new_tab()

--- a/tests/password_manager/test_primary_password_allows_csv_export.py
+++ b/tests/password_manager/test_primary_password_allows_csv_export.py
@@ -35,10 +35,7 @@ def test_primary_password_allows_csv_export(driver: Firefox, downloads_folder):
     about_logins.remove_password_csv(downloads_folder)
 
     # Have a Primary Password set
-    about_prefs.open()
-    about_prefs.open_primary_password_popup(ba)
-    about_prefs.set_primary_password(PRIMARY_PASSWORD)
-    about_prefs.accept_alert_and_verify_text(ALERT_MESSAGE)
+    about_prefs.create_primary_password(PRIMARY_PASSWORD, ALERT_MESSAGE, ba)
 
     # Have at least one saved login
     about_logins.open()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009982](https://bugzilla.mozilla.org/show_bug.cgi?id=2009982)
TestRail: [2244618](https://mozilla.testrail.io/index.php?/cases/view/2244618)

### Description of Code / Doc Changes

* Added test to verify that editing autofilled entries after PP was dismissed is possible.
* Created a new method to create primary password and refactored few tests.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
