### PR TITLE
don't skip version check in TC

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -313,7 +313,7 @@ def version(fx_executable: str):
 @pytest.fixture(scope="session")
 def build_version():
     """Collect executables, but just the version number for Fx"""
-    if not os.environ.get("CI"):
+    if not os.environ.get("CI") and not os.environ.get("MOZ_AUTOMATION"):
         return None
     return collect_executables.main("-n")
 


### PR DESCRIPTION
Quick fix

### Description of Code / Doc Changes

* Check for Firefox CI env var when guarding version check

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes scheduled Beta / DevEdition / RC

### Screenshots or Explanations

* In a previous PR, we guarded the version test to only fire in CI by checking env var `CI`. This doesn't exist in Firefox CI, so we have to check for `MOZ_AUTOMATION` as well.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [x] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
