### PR TITLE
Hani/ Test add username via doorhanger

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -779,6 +779,10 @@ password_manager:
     result: pass
     splits:
     - functional2
+  test_add_username_via_doorhanger:
+    result: pass
+    splits:
+    - functional2
   test_auto_saved_generated_password_context_menu:
     result: pass
     splits:

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -183,3 +183,9 @@ class AutofillPopup(BasePage):
             ).is_displayed()
         )
         return self
+
+    @BasePage.context_chrome
+    def type_username_in_password_doorhanger(self, username: str) -> BasePage:
+        """Type a username into the Password Manager doorhanger."""
+        self.get_element("password-notification-username-field").send_keys(username)
+        return self

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -478,6 +478,20 @@ class AboutLogins(BasePage):
             pass
         return self
 
+    def assert_username_present(self, username: str) -> BasePage:
+        """
+        Waits until a visible login list item with the given username is present
+        """
+        self.wait.until(
+            lambda _: any(
+                r.get_attribute("username") == username
+                for r in self.get_elements("login-list-item")
+                if r.is_displayed()
+            ),
+            message=f"{username} not found in saved logins",
+        )
+        return self
+
 
 class AboutPrivatebrowsing(BasePage):
     """

--- a/tests/password_manager/test_add_username_via_doorhanger.py
+++ b/tests/password_manager/test_add_username_via_doorhanger.py
@@ -1,0 +1,51 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import AutofillPopup, Navigation
+from modules.page_object import AboutLogins, LoginAutofill
+
+PASSWORD = "testPassword"
+USERNAME = "testUsername"
+
+
+@pytest.fixture()
+def test_case():
+    return "2244613"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("signon.rememberSignons", True)]
+
+
+def test_add_username_via_doorhanger(driver: Firefox):
+    """
+    C2244613 - Verify that a username can be added in doorhanger
+    """
+
+    # Instantiate objects
+    login_autofill = LoginAutofill(driver)
+    nav = Navigation(driver)
+    autofill_popup_panel = AutofillPopup(driver)
+    about_logins = AboutLogins(driver)
+
+    # Access a website that requires a username and password
+    login_autofill.open()
+    login_form = LoginAutofill.LoginForm(login_autofill)
+
+    # Fill in only the password field and submit the form
+    login_form.fill_password(PASSWORD)
+    login_form.submit()
+
+    # The Password Manager dialog is displayed
+    nav.element_visible("password-notification-popup")
+
+    # Fill in the username field with a username and Save the changes
+    autofill_popup_panel.type_username_in_password_doorhanger(USERNAME)
+    autofill_popup_panel.click_doorhanger_button("save")
+
+    # Password saved message is displayed -> check about:logins
+    nav.element_exists("confirmation-hint")
+    about_logins.open()
+    about_logins.assert_username_present(USERNAME)

--- a/tests/password_manager/test_add_username_via_doorhanger.py
+++ b/tests/password_manager/test_add_username_via_doorhanger.py
@@ -46,6 +46,6 @@ def test_add_username_via_doorhanger(driver: Firefox):
     autofill_popup_panel.click_doorhanger_button("save")
 
     # Password saved message is displayed -> check about:logins
-    nav.element_exists("confirmation-hint")
+    nav.element_visible("confirmation-hint")
     about_logins.open()
     about_logins.assert_username_present(USERNAME)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009979](https://bugzilla.mozilla.org/show_bug.cgi?id=2009979)
TestRail: [2244613](https://mozilla.testrail.io/index.php?/cases/view/2244613)

### Description of Code / Doc Changes

* Add test to verify that a username can be added in doorhanger.
* Instead of triggering the doorhanger by focusing out of the password field, I had to submit the form because somehow the password wasn't captured every time in the doorhanger while running the test automatically.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
