### PR TITLE
vs/lint-and-change-artifacts logic

### DIFF
--- a/.github/workflows/main-l10n.yml
+++ b/.github/workflows/main-l10n.yml
@@ -136,7 +136,7 @@ jobs:
           exit $SCRIPT_EXIT_CODE;
 
       - name: Upload artifacts
-        if: ${{ always() && github.event_name == 'pull_request' && inputs.dry_run != true }}
+        if: ${{ always() && inputs.is_pull_request == true && inputs.dry_run != true }}
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-mac-l10n

--- a/.github/workflows/main-l10n.yml
+++ b/.github/workflows/main-l10n.yml
@@ -377,7 +377,7 @@ jobs:
           path: artifacts-win
 
   Use-Artifacts:
-    if: ${{ github.event_name != 'workflow_dispatch' && inputs.dry_run != true }}
+    if: ${{ always() && github.event_name != 'workflow_dispatch' && inputs.dry_run != true && inputs.is_pull_request == true }}
     runs-on: ubuntu-latest
     needs:
       - L10N-Windows
@@ -398,33 +398,40 @@ jobs:
           pipenv install
 
       - name: Download Windows artifact
+        if: ${{ needs.L10N-Windows.result == 'success' }}
         uses: actions/download-artifact@v4
         with:
           name: artifacts-win-l10n
           path: artifacts-win
 
       - name: Download Linux artifact
+        if: ${{ needs.L10N-Linux.result == 'success' }}
         uses: actions/download-artifact@v4
         with:
           name: artifacts-linux-l10n
           path: artifacts-linux
 
       - name: Download MacOS artifact
+        if: ${{ needs.L10N-MacOS.result == 'success' }}
         uses: actions/download-artifact@v4
         with:
           name: artifacts-mac-l10n
           path: artifacts-mac
 
       - name: List downloaded Windows files
+        if: ${{ needs.L10N-Windows.result == 'success' }}
         run: ls artifacts-win/
 
       - name: List downloaded Linux files
+        if: ${{ needs.L10N-Linux.result == 'success' }}
         run: ls artifacts-linux/
 
       - name: List downloaded MacOS files
+        if: ${{ needs.L10N-MacOS.result == 'success' }}
         run: ls artifacts-mac/
 
       - name: Run script with secret
+        if: ${{ needs.L10N-Windows.result == 'success' || needs.L10N-Linux.result == 'success' || needs.L10N-MacOS.result == 'success' }}
         env:
           SLACK_KEY: ${{ secrets.SLACK_KEY }}
           GCP_CREDENTIAL: ${{ secrets.GCP_CREDENTIAL }}

--- a/.github/workflows/main-l10n.yml
+++ b/.github/workflows/main-l10n.yml
@@ -441,3 +441,4 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           pipenv run python scripts/notifier.py
+          


### PR DESCRIPTION
### Relevant Links

Bugzilla: no ticket. Cherry-picked from  1231
TestRail: _

### Description of Code / Doc Changes

Took changes from 1231 since that PR is dropped. 
Limit changes to the Use-Artifacts job and make it more resilient to partial failures.
Run Use-Artifacts even if one of the L10N jobs fails (using always()), so we can still process available artifacts.
Download artifacts only from jobs that completed successfully, to avoid failing on missing artifacts.
Align artifact names with what is uploaded by the OS jobs (artifacts-*-l10n).
Only run the notifier step if at least one artifact was downloaded, to avoid running it with no data.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness


Thank you!
