### PR TITLE
vs/add test for google password manager

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -867,6 +867,10 @@ password_manager:
     result: pass
     splits:
     - functional2
+  test_password_manager_on_google_US:
+    result: pass
+    splits:
+    - functional1
   test_primary_password_allows_csv_export:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2004938
     result:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -868,7 +868,10 @@ password_manager:
     splits:
     - functional2
   test_password_manager_on_google_US:
-    result: pass
+    result:
+      linux: pass
+      mac: unstable
+      win: pass
     splits:
     - functional1
   test_primary_password_allows_csv_export:

--- a/tests/password_manager/test_password_manager_on_google_US.py
+++ b/tests/password_manager/test_password_manager_on_google_US.py
@@ -17,7 +17,7 @@ PASSWORD3 = "password3"
 
 @pytest.fixture()
 def test_case():
-    return "NEW_TEST_CASE_ID"
+    return "2245444"
 
 
 @pytest.fixture()
@@ -31,7 +31,7 @@ def temp_selectors():
         "google-email-field": {
             "selectorData": "identifierId",
             "strategy": "id",
-            "groups": [],
+            "groups": ["doNotCache"],
         }
     }
 
@@ -63,12 +63,20 @@ def test_google_login_saved_credentials_dropdown(driver: Firefox, temp_selectors
     google_login_page.click_on("google-email-field")
     autofill_popup.ensure_autofill_dropdown_visible()
 
-    for i, expected_username in enumerate([USERNAME, USERNAME2, USERNAME3], start=1):
-        credential = autofill_popup.get_nth_element(str(i))
-        assert autofill_popup.get_primary_value(credential) == expected_username
+    values = []
 
-    passkey = autofill_popup.get_nth_element("4")
-    assert autofill_popup.get_primary_value(passkey) == "Use a passkey"
+    for i in range(
+        1, 6
+    ):  # should be enough elements (3 credentials + passkey + Manage passwords)
+        try:
+            el = autofill_popup.get_nth_element(str(i))
+            values.append(autofill_popup.get_primary_value(el))
+        except Exception:
+            break
 
-    footer = autofill_popup.get_nth_element("5")
-    assert autofill_popup.get_primary_value(footer) == "Manage Passwords"
+    assert USERNAME in values
+    assert USERNAME2 in values
+    assert USERNAME3 in values
+
+    assert "Use a passkey" in values
+    assert "Manage Passwords" in values

--- a/tests/password_manager/test_password_manager_on_google_US.py
+++ b/tests/password_manager/test_password_manager_on_google_US.py
@@ -63,20 +63,15 @@ def test_google_login_saved_credentials_dropdown(driver: Firefox, temp_selectors
     google_login_page.click_on("google-email-field")
     autofill_popup.ensure_autofill_dropdown_visible()
 
-    values = []
+    for expected_username in [USERNAME, USERNAME2, USERNAME3]:
+        autofill_popup.element_visible(
+            "select-form-option-by-value", labels=[expected_username]
+        )
 
-    for i in range(
-        1, 6
-    ):  # should be enough elements (3 credentials + passkey + Manage passwords)
-        try:
-            el = autofill_popup.get_nth_element(str(i))
-            values.append(autofill_popup.get_primary_value(el))
-        except Exception:
-            break
+    autofill_popup.element_visible(
+        "select-form-option-by-value", labels=["Use a passkey"]
+    )
 
-    assert USERNAME in values
-    assert USERNAME2 in values
-    assert USERNAME3 in values
-
-    assert "Use a passkey" in values
-    assert "Manage Passwords" in values
+    autofill_popup.element_visible(
+        "select-form-option-by-value", labels=["Manage Passwords"]
+    )

--- a/tests/password_manager/test_password_manager_on_google_US.py
+++ b/tests/password_manager/test_password_manager_on_google_US.py
@@ -57,11 +57,13 @@ def test_google_login_saved_credentials_dropdown(driver: Firefox, temp_selectors
     add_login_and_wait(about_logins, GOOGLE_ORIGIN, USERNAME2, PASSWORD2)
     add_login_and_wait(about_logins, GOOGLE_ORIGIN, USERNAME3, PASSWORD3)
 
-    google_login_page = GenericPage(driver, url=GOOGLE_LOGIN_URL).open()
+    google_login_page = GenericPage(driver, url=GOOGLE_LOGIN_URL)
+    google_login_page.open()
     google_login_page.elements |= temp_selectors
 
     google_login_page.element_visible("google-email-field")
     google_login_page.click_on("google-email-field")
+    google_login_page.fill("google-email-field", USERNAME[:3], press_enter=False)
     autofill_popup.ensure_autofill_dropdown_visible()
 
     for expected_username in [USERNAME, USERNAME2, USERNAME3]:

--- a/tests/password_manager/test_password_manager_on_google_US.py
+++ b/tests/password_manager/test_password_manager_on_google_US.py
@@ -1,0 +1,99 @@
+import time
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import AutofillPopup
+from modules.page_object import AboutLogins, GenericPage
+
+GOOGLE_LOGIN_URL = "https://accounts.google.com/signin/v2/identifier?hl=ro&passive=true&continue=https%3A%2F%2Fwww.google.com%2F&flowName=GlifWebSignIn&flowEntry=ServiceLogin."
+GOOGLE_ORIGIN = "https://accounts.google.com"
+
+USERNAME = "username1@gmail.com"
+PASSWORD = "password1"
+USERNAME2 = "username2@gmail.com"
+PASSWORD2 = "password2"
+USERNAME3 = "username3@gmail.com"
+PASSWORD3 = "password3"
+
+DENIED_USERNAME = "not_saved@gmail.com"
+DENIED_PASSWORD = "not_saved_password"
+
+
+@pytest.fixture()
+def test_case():
+    return "2245444"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("signon.rememberSignons", True), ("signon.autofillForms", True)]
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "google-email-field": {
+            "selectorData": "identifierId",
+            "strategy": "id",
+            "groups": ["doNotCache"],
+        }
+    }
+
+
+@pytest.mark.headed
+def test_google_login_saved_credentials_dropdown(driver: Firefox, temp_selectors):
+    """
+    Verify saved Google login credentials are available from the password manager
+    autocomplete dropdown, while denied credentials are not saved.
+    """
+    about_logins = AboutLogins(driver)
+    autofill_popup = AutofillPopup(driver)
+
+    # 1. Access the Google login page
+    google_login_page = GenericPage(driver, url=GOOGLE_LOGIN_URL).open()
+    google_login_page.elements |= temp_selectors
+
+    # 2. Input one set of credentials and save them
+    about_logins.open()
+    about_logins.add_login(GOOGLE_ORIGIN, USERNAME, PASSWORD)
+
+    # 3. Refresh the login page and verify autofill works
+    google_login_page.open()
+    google_login_page.click_on("google-email-field")
+    autofill_popup.ensure_autofill_dropdown_visible()
+
+    first_credential = autofill_popup.get_nth_element("1")
+    assert autofill_popup.get_primary_value(first_credential) == USERNAME
+
+    # 4. Save a couple more credential sets and verify they are visible in about:logins
+    about_logins.open()
+    time.sleep(0.5)
+    about_logins.add_login(GOOGLE_ORIGIN, USERNAME2, PASSWORD2)
+    time.sleep(0.5)
+    about_logins.add_login(GOOGLE_ORIGIN, USERNAME3, PASSWORD3)
+
+    about_logins.open()
+    assert USERNAME3 in about_logins.get_element("login-list").text
+
+    # 5. Denied credentials are not saved
+    about_logins.open()
+    assert DENIED_USERNAME not in about_logins.get_element("login-list").text
+    assert DENIED_PASSWORD not in about_logins.get_element("login-list").text
+
+    # 6. Refresh login page again and click inside input box
+    driver.delete_all_cookies()
+    google_login_page.open()
+
+    email_field = google_login_page.get_element("google-email-field")
+    assert email_field.get_attribute("value") == ""
+
+    google_login_page.click_on("google-email-field")
+    autofill_popup.ensure_autofill_dropdown_visible()
+
+    for i, expected_username in enumerate([USERNAME, USERNAME2, USERNAME3], start=1):
+        credential = autofill_popup.get_nth_element(str(i))
+        assert autofill_popup.get_primary_value(credential) == expected_username
+
+    footer = autofill_popup.get_nth_element("5")
+    assert autofill_popup.get_primary_value(footer) == "Manage Passwords"

--- a/tests/password_manager/test_password_manager_on_google_US.py
+++ b/tests/password_manager/test_password_manager_on_google_US.py
@@ -60,6 +60,7 @@ def test_google_login_saved_credentials_dropdown(driver: Firefox, temp_selectors
     google_login_page = GenericPage(driver, url=GOOGLE_LOGIN_URL).open()
     google_login_page.elements |= temp_selectors
 
+    google_login_page.element_visible("google-email-field")
     google_login_page.click_on("google-email-field")
     autofill_popup.ensure_autofill_dropdown_visible()
 

--- a/tests/password_manager/test_password_manager_on_google_US.py
+++ b/tests/password_manager/test_password_manager_on_google_US.py
@@ -1,12 +1,10 @@
-import time
-
 import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import AutofillPopup
 from modules.page_object import AboutLogins, GenericPage
 
-GOOGLE_LOGIN_URL = "https://accounts.google.com/signin/v2/identifier?hl=ro&passive=true&continue=https%3A%2F%2Fwww.google.com%2F&flowName=GlifWebSignIn&flowEntry=ServiceLogin."
+GOOGLE_LOGIN_URL = "https://accounts.google.com/signin/v2/identifier?&passive=true&continue=https%3A%2F%2Fwww.google.com%2F&flowName=GlifWebSignIn&flowEntry=ServiceLogin"
 GOOGLE_ORIGIN = "https://accounts.google.com"
 
 USERNAME = "username1@gmail.com"
@@ -16,13 +14,10 @@ PASSWORD2 = "password2"
 USERNAME3 = "username3@gmail.com"
 PASSWORD3 = "password3"
 
-DENIED_USERNAME = "not_saved@gmail.com"
-DENIED_PASSWORD = "not_saved_password"
-
 
 @pytest.fixture()
 def test_case():
-    return "2245444"
+    return "NEW_TEST_CASE_ID"
 
 
 @pytest.fixture()
@@ -36,57 +31,34 @@ def temp_selectors():
         "google-email-field": {
             "selectorData": "identifierId",
             "strategy": "id",
-            "groups": ["doNotCache"],
+            "groups": [],
         }
     }
+
+
+def add_login_and_wait(about_logins, origin, username, password):
+    original_count = len(about_logins.get_elements("login-list-item"))
+    about_logins.add_login(origin, username, password)
+    about_logins.wait.until(
+        lambda _: len(about_logins.get_elements("login-list-item")) > original_count
+    )
 
 
 @pytest.mark.headed
 def test_google_login_saved_credentials_dropdown(driver: Firefox, temp_selectors):
     """
-    Verify saved Google login credentials are available from the password manager
-    autocomplete dropdown, while denied credentials are not saved.
+    Verify that saved Google credentials are displayed in the autofill dropdown.
     """
     about_logins = AboutLogins(driver)
     autofill_popup = AutofillPopup(driver)
 
-    # 1. Access the Google login page
+    about_logins.open()
+    add_login_and_wait(about_logins, GOOGLE_ORIGIN, USERNAME, PASSWORD)
+    add_login_and_wait(about_logins, GOOGLE_ORIGIN, USERNAME2, PASSWORD2)
+    add_login_and_wait(about_logins, GOOGLE_ORIGIN, USERNAME3, PASSWORD3)
+
     google_login_page = GenericPage(driver, url=GOOGLE_LOGIN_URL).open()
     google_login_page.elements |= temp_selectors
-
-    # 2. Input one set of credentials and save them
-    about_logins.open()
-    about_logins.add_login(GOOGLE_ORIGIN, USERNAME, PASSWORD)
-
-    # 3. Refresh the login page and verify autofill works
-    google_login_page.open()
-    google_login_page.click_on("google-email-field")
-    autofill_popup.ensure_autofill_dropdown_visible()
-
-    first_credential = autofill_popup.get_nth_element("1")
-    assert autofill_popup.get_primary_value(first_credential) == USERNAME
-
-    # 4. Save a couple more credential sets and verify they are visible in about:logins
-    about_logins.open()
-    time.sleep(0.5)
-    about_logins.add_login(GOOGLE_ORIGIN, USERNAME2, PASSWORD2)
-    time.sleep(0.5)
-    about_logins.add_login(GOOGLE_ORIGIN, USERNAME3, PASSWORD3)
-
-    about_logins.open()
-    assert USERNAME3 in about_logins.get_element("login-list").text
-
-    # 5. Denied credentials are not saved
-    about_logins.open()
-    assert DENIED_USERNAME not in about_logins.get_element("login-list").text
-    assert DENIED_PASSWORD not in about_logins.get_element("login-list").text
-
-    # 6. Refresh login page again and click inside input box
-    driver.delete_all_cookies()
-    google_login_page.open()
-
-    email_field = google_login_page.get_element("google-email-field")
-    assert email_field.get_attribute("value") == ""
 
     google_login_page.click_on("google-email-field")
     autofill_popup.ensure_autofill_dropdown_visible()
@@ -94,6 +66,9 @@ def test_google_login_saved_credentials_dropdown(driver: Firefox, temp_selectors
     for i, expected_username in enumerate([USERNAME, USERNAME2, USERNAME3], start=1):
         credential = autofill_popup.get_nth_element(str(i))
         assert autofill_popup.get_primary_value(credential) == expected_username
+
+    passkey = autofill_popup.get_nth_element("4")
+    assert autofill_popup.get_primary_value(passkey) == "Use a passkey"
 
     footer = autofill_popup.get_nth_element("5")
     assert autofill_popup.get_primary_value(footer) == "Manage Passwords"

--- a/tests/password_manager/test_password_manager_on_google_US.py
+++ b/tests/password_manager/test_password_manager_on_google_US.py
@@ -37,6 +37,7 @@ def temp_selectors():
 
 
 def add_login_and_wait(about_logins, origin, username, password):
+    about_logins.open()
     original_count = len(about_logins.get_elements("login-list-item"))
     about_logins.add_login(origin, username, password)
     about_logins.wait.until(
@@ -52,7 +53,6 @@ def test_google_login_saved_credentials_dropdown(driver: Firefox, temp_selectors
     about_logins = AboutLogins(driver)
     autofill_popup = AutofillPopup(driver)
 
-    about_logins.open()
     add_login_and_wait(about_logins, GOOGLE_ORIGIN, USERNAME, PASSWORD)
     add_login_and_wait(about_logins, GOOGLE_ORIGIN, USERNAME2, PASSWORD2)
     add_login_and_wait(about_logins, GOOGLE_ORIGIN, USERNAME3, PASSWORD3)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009989](https://bugzilla.mozilla.org/show_bug.cgi?id=2009989)
TestRail: [2245444](https://mozilla.testrail.io/index.php?/cases/view/2245444)

### Description of Code / Doc Changes

Test that saved Google credentials appear in the autofill dropdown, while non-saved ones don’t. 
Makes sure that Manage Password is the last entry (5th)
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

Thank you!
