### PR TITLE
Hani/ Test fingerprinters blocked and shown in panel and preferences

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1419,6 +1419,20 @@ Description: Remove button to remove the primary password
 Location: about:preferences#privacy Primary Password popup
 Path to .json: modules/data/about_prefs.components.json
 ```
+```
+Selector Name: standard-radio
+Selector Data: "standardRadiocontentBlockingOptionStandard"
+Description: In Enhanced Tracking Protection, the standard radio button
+Location: about:preferences#privacy
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: standard-section
+Selector Data: "standardRadio"
+Description: In Enhanced Tracking Protection, the standard radio section
+Location: about:preferences#privacy
+Path to .json: modules/data/about_prefs.components.json
+```
 #### about_profiles
 ```
 Selector Name: profile-container

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1428,7 +1428,7 @@ Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: standard-section
-Selector Data: "standardRadio"
+Selector Data: "contentBlockingOptionStandard"
 Description: In Enhanced Tracking Protection, the standard radio section
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1421,7 +1421,7 @@ Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: standard-radio
-Selector Data: "standardRadiocontentBlockingOptionStandard"
+Selector Data: "standardRadio"
 Description: In Enhanced Tracking Protection, the standard radio button
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1145,6 +1145,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_fingerprinters_blocked_and_shown_in_panel_and_preferences:
+    result: pass
+    splits:
+    - functional2
   test_https_enabled_private_browsing:
     result: pass
     splits:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -737,5 +737,15 @@
     "strategy": "css",
     "shadowParent": "remove-primary-password-box",
     "groups": []
+  },
+  "standard-section": {
+    "selectorData": "contentBlockingOptionStandard",
+    "strategy": "id",
+    "groups": []
+  },
+  "standard-radio": {
+    "selectorData": "standardRadio",
+    "strategy": "id",
+    "groups": []
   }
 }

--- a/tests/security_and_privacy/test_fingerprinters_blocked_and_shown_in_panel_and_preferences.py
+++ b/tests/security_and_privacy/test_fingerprinters_blocked_and_shown_in_panel_and_preferences.py
@@ -1,9 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_trust_panel import TrustPanel
-from modules.page_object_generics import GenericPage
-from modules.page_object_prefs import AboutPrefs
+from modules.browser_object import TrustPanel
+from modules.page_object import AboutPrefs, GenericPage
 
 FINGERPRINTERS_URL = (
     "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting.html"
@@ -12,7 +11,7 @@ FINGERPRINTERS_URL = (
 
 @pytest.fixture()
 def test_case():
-    return "450232"
+    return "387363"
 
 
 def test_fingerprinters_blocked_and_shown_in_panel_and_preferences(driver: Firefox):

--- a/tests/security_and_privacy/test_fingerprinters_blocked_and_shown_in_panel_and_preferences.py
+++ b/tests/security_and_privacy/test_fingerprinters_blocked_and_shown_in_panel_and_preferences.py
@@ -1,0 +1,44 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_trust_panel import TrustPanel
+from modules.page_object_generics import GenericPage
+from modules.page_object_prefs import AboutPrefs
+
+FINGERPRINTERS_URL = (
+    "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting.html"
+)
+
+
+@pytest.fixture()
+def test_case():
+    return "450232"
+
+
+def test_fingerprinters_blocked_and_shown_in_panel_and_preferences(driver: Firefox):
+    """
+    C387363 - Fingerprinters are blocked and shown correctly (Control Center and Preferences)
+    """
+
+    # Instantiate objects
+    tracking_page = GenericPage(driver, url=FINGERPRINTERS_URL)
+    trust_panel = TrustPanel(driver)
+    about_prefs = AboutPrefs(driver, category="privacy")
+
+    # Open page and check the Information panel
+    tracking_page.open()
+    trust_panel.open_panel()
+    trust_panel.wait_for_trackers()
+
+    # The "Blocked" string is displayed under the Fingerprinters section
+    trust_panel.trackers_blocked("fingerprinter")
+
+    # Navigate to about:preferences#privacy
+    about_prefs.open()
+
+    # Check Standard section
+    about_prefs.click_on("standard-radio")
+
+    # Check Standard section contains "Fingerprinters"
+    standard_section = about_prefs.get_element("standard-section")
+    assert "Fingerprinters" in standard_section.text


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2015752](https://bugzilla.mozilla.org/show_bug.cgi?id=2015752)
TestRail: [387363](https://mozilla.testrail.io/index.php?/cases/view/387363)

### Description of Code / Doc Changes

* Add test to verify that fingerprinters are blocked and shown correctly (Control Center and Preferences).

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
