### PR TITLE
Hani/ Test trackers, crypto and fingerprinters blocked

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1222,6 +1222,10 @@ security_and_privacy:
     result: deprecated
     splits:
     - functional2
+  test_trackers_cryptominers_fingerprinters_blocked:
+    result: pass
+    splits:
+    - functional2
   test_tracking_content_custom_mode:
     result: pass
     splits:

--- a/tests/security_and_privacy/test_no_trackers_detected.py
+++ b/tests/security_and_privacy/test_no_trackers_detected.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import pytest
 from selenium.webdriver import Firefox
 
@@ -18,6 +20,7 @@ def test_no_trackers_detected(driver: Firefox, trust_panel: TrustPanel):
     """
     # access url
     driver.get(NOTRACKERS_URL)
+    sleep(111111)
     # verify that no trackers are detected
     trust_panel.open_panel()
     trust_panel.assert_no_trackers()

--- a/tests/security_and_privacy/test_no_trackers_detected.py
+++ b/tests/security_and_privacy/test_no_trackers_detected.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 import pytest
 from selenium.webdriver import Firefox
 
@@ -20,7 +18,6 @@ def test_no_trackers_detected(driver: Firefox, trust_panel: TrustPanel):
     """
     # access url
     driver.get(NOTRACKERS_URL)
-    sleep(111111)
     # verify that no trackers are detected
     trust_panel.open_panel()
     trust_panel.assert_no_trackers()

--- a/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
+++ b/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
@@ -2,8 +2,7 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import Navigation, TrustPanel
-from modules.page_object import GenericPage
-from modules.page_object_prefs import AboutPrefs
+from modules.page_object import AboutPrefs, GenericPage
 
 
 @pytest.fixture()
@@ -11,13 +10,11 @@ def test_case():
     return "3054906"
 
 
-TRACKER_URL = (
-    "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting_and_cryptomining_and_cookies.html"
-)
+TRACKER_URL = "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting_and_cryptomining_and_cookies.html"
 
 
 def test_trackers_cryptominers_fingerprinters_blocked(
-    driver: Firefox, trust_panel: TrustPanel, nav: Navigation
+    driver: Firefox, trust_panel: TrustPanel
 ):
     """
     C3054906 - The ETP panel is correctly displayed when the cross-site trackers, cryptominers and fingerprinters are blocked
@@ -38,5 +35,5 @@ def test_trackers_cryptominers_fingerprinters_blocked(
     # The Tracking Content is NOT blocked
     trust_panel.trackers_detected("tracking-content")
 
-    # The Cross-Site Tracking Cookies, Fingerpinters and Cryptominers are displayed "Blocked"
+    # The Cross-Site Tracking Cookies, Fingerprinters and Cryptominers are displayed "Blocked"
     trust_panel.trackers_blocked("tracking-cookies", "cryptominer", "fingerprinter")

--- a/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
+++ b/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
@@ -1,0 +1,42 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation, TrustPanel
+from modules.page_object import GenericPage
+from modules.page_object_prefs import AboutPrefs
+
+
+@pytest.fixture()
+def test_case():
+    return "3054906"
+
+
+TRACKER_URL = (
+    "https://senglehardt.com/test/trackingprotection/test_pages/fingerprinting_and_cryptomining_and_cookies.html"
+)
+
+
+def test_trackers_cryptominers_fingerprinters_blocked(
+    driver: Firefox, trust_panel: TrustPanel, nav: Navigation
+):
+    """
+    C3054906 - The ETP panel is correctly displayed when the cross-site trackers, cryptominers and fingerprinters are blocked
+    """
+    # Instantiate objects
+    tracker_page = GenericPage(driver, url=TRACKER_URL)
+    about_prefs = AboutPrefs(driver, category="privacy")
+
+    # Make sure that the "Standard" option is selected from the ETP section in about:preferences#privacy
+    about_prefs.open()
+    about_prefs.click_on("standard-radio")
+
+    # wait for the shield icon
+    tracker_page.open()
+    trust_panel.open_panel()
+    trust_panel.wait_for_trackers()
+
+    # The Tracking Content is NOT blocked
+    trust_panel.trackers_detected("tracking-content")
+
+    # The Cross-Site Tracking Cookies, Fingerpinters and Cryptominers are displayed "Blocked"
+    trust_panel.trackers_blocked("tracking-cookies", "cryptominer", "fingerprinter")

--- a/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
+++ b/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import Navigation, TrustPanel
+from modules.browser_object import TrustPanel
 from modules.page_object import AboutPrefs, GenericPage
 
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025831](https://bugzilla.mozilla.org/show_bug.cgi?id=2025831)
TestRail: [3054906](https://mozilla.testrail.io/index.php?/cases/view/3054906)

### Description of Code / Doc Changes

* Add test to verify that the ETP panel is correctly displayed when the cross-site trackers, cryptominers and fingerprinters are blocked
* I noticed a similar test to this bug with few different steps (C446393) which is marked as deprecated.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
