### PR TITLE
Anca/ Glean stabilization on Windows

### DIFF
--- a/modules/components/dropdown.py
+++ b/modules/components/dropdown.py
@@ -81,6 +81,8 @@ class Dropdown(Region):
         if double_click:
             self.page.double_click(reference=target_option)
         else:
+            if self.is_search_dropdown:
+                self.page.scroll_to_element(target_option)
             target_option.click()
 
         if wait_for_selection:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2036878](https://bugzilla.mozilla.org/show_bug.cgi?id=2036878)
TestRail: N/A

### Description of Code / Doc Changes

- On Windows CI, a few SERP impression cases were failing while selecting the search engine from about:preferences. The failure happened before the actual search was performed and before any Glean telemetry was checked. Marionette was not always able to click the target <panel-item> from the search engine dropdown and failed with: ElementNotInteractableException: Element <panel-item> could not be scrolled into view
- The fix is to scroll the target search dropdown option into view before clicking it. This reuses the existing scroll_to_element helper and keeps the change limited to the search dropdown path.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
