### PR TITLE
Hani/ Test crypto subpanel display when not blocked

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5089,16 +5089,30 @@ Location: Trustpanel - Tracking protection view
 Path to .json: modules/data/trust_panel.components.json
 ```
 ```
-Selector Name: not-blocking-fingerprinters
-Selector Data: "panelview[title='Not Blocking Fingerprinters']"
-Description: Not blocking fingerprinters title
-Location: Trustpanel - Not blocking fingerprinters view
-Path to .json: modules/data/trust_panel.components.json
-```
-```
 Selector Name: protections-popup-list-host-label
 Selector Data: ".protections-popup-list-host-label"
 Description: Sites trying to fingerprint
 Location: Trustpanel - Not blocking fingerprinters view
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: cryptominers-detected-parent
+Selector Data: "[data-l10n-id='trustpanel-list-label-cryptominers']"
+Description: Cryptominers detected in the trust panel (Shadow parent)
+Location: Trustpanel main view
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: cryptominers-detected
+Selector Data: "main-button"
+Description: Cryptominers detected in the trust panel
+Location: Trustpanel - Tracking protection view
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: not-blocking-category
+Selector Data: "panelview[title='Not Blocking {}']"
+Description: Not blocking tracker category title
+Location: Trustpanel - Not blocking category view
 Path to .json: modules/data/trust_panel.components.json
 ```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1121,6 +1121,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_cryptominers_subpanel_display_when_not_blocked:
+    result: pass
+    splits:
+    - functional2
   test_custom_block_suspected_fingerprinters_in_all_windows:
     result: pass
     splits:

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -143,3 +143,15 @@ class TrustPanel(BasePage):
                 return False
 
         return True
+
+    @BasePage.context_chrome
+    def title_displayed_in_subpanel(self, category: str) -> bool:
+        """
+        Verify that the 'Not Blocking <Category>' title
+        is displayed in the subpanel.
+        """
+        self.element_visible(
+            "not-blocking-category",
+            labels=[category.capitalize()]
+        )
+        return True

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -145,7 +145,7 @@ class TrustPanel(BasePage):
         return True
 
     @BasePage.context_chrome
-    def title_displayed_in_subpanel(self, category: str) -> bool:
+    def title_displayed_in_subpanel(self, category: str):
         """
         Verify that the 'Not Blocking <Category>' title
         is displayed in the subpanel.

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -150,8 +150,5 @@ class TrustPanel(BasePage):
         Verify that the 'Not Blocking <Category>' title
         is displayed in the subpanel.
         """
-        self.element_visible(
-            "not-blocking-category",
-            labels=[category.capitalize()]
-        )
-        return True
+        self.element_visible("not-blocking-category", labels=[category.capitalize()])
+        return self

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -106,13 +106,24 @@
         "groups": [],
         "shadowParent": "fingerprinters-detected-parent"
     },
-    "not-blocking-fingerprinters": {
-        "selectorData": "panelview[title='Not Blocking Fingerprinters']",
+    "protections-popup-list-host-label": {
+        "selectorData": ".protections-popup-list-host-label",
         "strategy": "css",
         "groups": []
     },
-    "protections-popup-list-host-label": {
-        "selectorData": ".protections-popup-list-host-label",
+    "cryptominers-detected-parent": {
+        "selectorData": "[data-l10n-id='trustpanel-list-label-cryptominer']",
+        "strategy": "css",
+        "groups": []
+    },
+    "cryptominers-detected": {
+        "selectorData": "main-button",
+        "strategy": "id",
+        "groups": [],
+        "shadowParent": "cryptominers-detected-parent"
+    },
+    "not-blocking-category": {
+        "selectorData": "panelview[title='Not Blocking {}']",
         "strategy": "css",
         "groups": []
     }

--- a/tests/password_manager/test_password_manager_on_reddit.py
+++ b/tests/password_manager/test_password_manager_on_reddit.py
@@ -36,8 +36,9 @@ def add_login_and_wait(
     about_logins.add_login(origin, username, password)
 
     about_logins.expect(
-        lambda _: len(about_logins.get_elements("login-list-item"))
-        == initial_login_count + 1
+        lambda _: (
+            len(about_logins.get_elements("login-list-item")) == initial_login_count + 1
+        )
     )
 
 

--- a/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
@@ -1,0 +1,55 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_trust_panel import TrustPanel
+from modules.page_object_generics import GenericPage
+from modules.page_object_prefs import AboutPrefs
+
+CRYPTOMINERS_URL = (
+    "https://senglehardt.com/test/trackingprotection/test_pages/cryptomining.html"
+)
+
+DETECTED_TRACKER_URL = "https://base-cryptomining-track-digest256.dummytracker.org"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054916"
+
+
+def test_cryptominers_subpanel_display_when_not_blocked(driver: Firefox):
+    """
+    C3054915 - Cryptominers are correctly displayed in the sub panel when they are not blocked
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    tracking_page = GenericPage(driver, url=CRYPTOMINERS_URL)
+    trust_panel = TrustPanel(driver)
+
+    # In about:preferences#privacy deselect only the option "Cryptominers" in the Cookies section
+    about_prefs.open()
+    about_prefs.select_trackers_to_block(
+        "cookies-isolate-social-media-option",
+        "tracking-checkbox",
+        "known-fingerprints-checkbox",
+        "suspected-fingerprints-checkbox"
+    )
+
+    # Open page and click on the shield icon
+    tracking_page.open()
+    trust_panel.open_panel()
+    trust_panel.wait_for_trackers()
+
+    # Click on "See All" button
+    trust_panel.click_see_all()
+
+    # Click on "Fingerprinters"
+    trust_panel.wait_for_trackers()
+    trust_panel.js_click_on("cryptominers-detected")
+
+    # "Not Blocking Cryptominers" title is displayed in the subpanel
+    trust_panel.title_displayed_in_subpanel("cryptominers")
+
+    # The allowed cryptominers are displayed inside the subpanel
+    assert trust_panel.has_allowed_sites()

--- a/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
@@ -14,7 +14,7 @@ DETECTED_TRACKER_URL = "https://base-cryptomining-track-digest256.dummytracker.o
 
 @pytest.fixture()
 def test_case():
-    return "3054916"
+    return "3054915"
 
 
 def test_cryptominers_subpanel_display_when_not_blocked(driver: Firefox):

--- a/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
@@ -33,7 +33,7 @@ def test_cryptominers_subpanel_display_when_not_blocked(driver: Firefox):
         "cookies-isolate-social-media-option",
         "tracking-checkbox",
         "known-fingerprints-checkbox",
-        "suspected-fingerprints-checkbox"
+        "suspected-fingerprints-checkbox",
     )
 
     # Open page and click on the shield icon
@@ -44,7 +44,7 @@ def test_cryptominers_subpanel_display_when_not_blocked(driver: Firefox):
     # Click on "See All" button
     trust_panel.click_see_all()
 
-    # Click on "Fingerprinters"
+    # Click on "Cryptominers"
     trust_panel.wait_for_trackers()
     trust_panel.js_click_on("cryptominers-detected")
 

--- a/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
@@ -52,4 +52,4 @@ def test_cryptominers_subpanel_display_when_not_blocked(driver: Firefox):
     trust_panel.title_displayed_in_subpanel("cryptominers")
 
     # The allowed cryptominers are displayed inside the subpanel
-    assert trust_panel.has_allowed_sites()
+    assert trust_panel.has_allowed_sites(DETECTED_TRACKER_URL)

--- a/tests/security_and_privacy/test_fingerprinters_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_fingerprinters_subpanel_display_when_not_blocked.py
@@ -47,7 +47,7 @@ def test_fingerprinters_subpanel_display_when_not_blocked(driver: Firefox):
     trust_panel.js_click_on("fingerprinters-detected")
 
     # "Not Blocking Fingerprinters" title is displayed in the subpanel
-    trust_panel.element_visible("not-blocking-fingerprinters")
+    trust_panel.title_displayed_in_subpanel("fingerprinters")
 
     # The allowed fingerprinter is displayed inside the subpanel
     assert trust_panel.has_allowed_sites(DETECTED_TRACKER_URL)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025840](https://bugzilla.mozilla.org/show_bug.cgi?id=2025840)
TestRail: [3054915](https://mozilla.testrail.io/index.php?/cases/view/3054915)

### Description of Code / Doc Changes

* Add test to verify Cryptominers are correctly displayed in the sub panel when they are not blocked

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
