### PR TITLE
Hani/ tracking content subpanel display when not blocked

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5075,20 +5075,6 @@ Location: Trustpanel main view
 Path to .json: modules/data/trust_panel.components.json
 ```
 ```
-Selector Name: fingerprinters-detected-parent
-Selector Data: "[data-l10n-id='trustpanel-list-label-fingerprinter']"
-Description: Fingerprinters detected in the trust panel (Shadow parent)
-Location: Trustpanel main view
-Path to .json: modules/data/trust_panel.components.json
-```
-```
-Selector Name: fingerprinters-detected
-Selector Data: "main-button"
-Description: Fingerprinters detected in the trust panel
-Location: Trustpanel - Tracking protection view
-Path to .json: modules/data/trust_panel.components.json
-```
-```
 Selector Name: protections-popup-list-host-label
 Selector Data: ".protections-popup-list-host-label"
 Description: Sites trying to fingerprint
@@ -5096,23 +5082,16 @@ Location: Trustpanel - Not blocking fingerprinters view
 Path to .json: modules/data/trust_panel.components.json
 ```
 ```
-Selector Name: cryptominers-detected-parent
-Selector Data: "[data-l10n-id='trustpanel-list-label-cryptominers']"
-Description: Cryptominers detected in the trust panel (Shadow parent)
-Location: Trustpanel main view
-Path to .json: modules/data/trust_panel.components.json
-```
-```
-Selector Name: cryptominers-detected
-Selector Data: "main-button"
-Description: Cryptominers detected in the trust panel
-Location: Trustpanel - Tracking protection view
-Path to .json: modules/data/trust_panel.components.json
-```
-```
 Selector Name: not-blocking-category
 Selector Data: "panelview[title='Not Blocking {}']"
 Description: Not blocking tracker category title
 Location: Trustpanel - Not blocking category view
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: detected-category
+Selector Data: "[data-l10n-id='{}']"
+Description: Detected tracker category from the protections panel
+Location: Trustpanel - Detected tracker category from the protections panel
 Path to .json: modules/data/trust_panel.components.json
 ```

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1440,13 +1440,6 @@ Description: In Enhanced Tracking Protection, the standard radio section
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
-```
-Selector Name: cookies-from-unvisited-websites
-Selector Data: "[data-l10n-id='sitedata-option-block-unvisited']"
-Description: In Enhanced Tracking Protection, cookies from unvisited websites option
-Location: about:preferences#privacy
-Path to .json: modules/data/about_prefs.components.json
-```
 #### about_profiles
 ```
 Selector Name: profile-container

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5097,7 +5097,7 @@ Path to .json: modules/data/trust_panel.components.json
 ```
 ```
 Selector Name: detected-category
-Selector Data: "[data-l10n-id='{}']"
+Selector Data: "moz-button.moz-button-subviewbutton-nav[data-l10n-id='{}']"
 Description: Detected tracker category from the protections panel
 Location: Trustpanel - Detected tracker category from the protections panel
 Path to .json: modules/data/trust_panel.components.json

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1440,6 +1440,13 @@ Description: In Enhanced Tracking Protection, the standard radio section
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
+```
+Selector Name: cookies-from-unvisited-websites
+Selector Data: "[data-l10n-id='sitedata-option-block-unvisited']"
+Description: In Enhanced Tracking Protection, cookies from unvisited websites option
+Location: about:preferences#privacy
+Path to .json: modules/data/about_prefs.components.json
+```
 #### about_profiles
 ```
 Selector Name: profile-container

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1237,6 +1237,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_tracking_content_subpanel_display_when_not_blocked:
+    result: pass
+    splits:
+    - functional2
   test_undo_close_tab_private_browsing:
     result: pass
     splits:

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -162,7 +162,11 @@ class TrustPanel(BasePage):
         """
         canonical = category.strip().lower().replace(" ", "-")
 
-        self.js_click_on(
-            "detected-category", labels=[f"trustpanel-list-label-{canonical}"]
+        locator = (
+            "detected-category",
+            [f"trustpanel-list-label-{canonical}"],
         )
+
+        self.element_clickable(*locator)
+        self.js_click_on(*locator)
         return self

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -157,8 +157,13 @@ class TrustPanel(BasePage):
     def open_detected_category(self, category: str):
         """
         Open a detected tracker category from the protections panel.
+
+        Canonical input format: hyphenated singular (e.g. "tracking-content")
         """
+        canonical = category.strip().lower().replace(" ", "-")
+
         self.js_click_on(
-            "detected-category", labels=[f"trustpanel-list-label-{category}"]
+            "detected-category",
+            labels=[f"trustpanel-list-label-{canonical}"]
         )
         return self

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -143,3 +143,12 @@ class TrustPanel(BasePage):
                 return False
 
         return True
+
+    @BasePage.context_chrome
+    def title_displayed_in_subpanel(self, category: str):
+        """
+        Verify that the 'Not Blocking <Category>' title
+        is displayed in the subpanel.
+        """
+        self.element_visible("not-blocking-category", labels=[category.capitalize()])
+        return self

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -150,10 +150,7 @@ class TrustPanel(BasePage):
         Verify that the 'Not Blocking <Category>' title
         is displayed in the subpanel.
         """
-        self.element_visible(
-            "not-blocking-category",
-            labels=[category.title()]
-        )
+        self.element_visible("not-blocking-category", labels=[category.title()])
         return self
 
     @BasePage.context_chrome
@@ -162,7 +159,6 @@ class TrustPanel(BasePage):
         Open a detected tracker category from the protections panel.
         """
         self.js_click_on(
-            "detected-category",
-            labels=[f"trustpanel-list-label-{category}"]
+            "detected-category", labels=[f"trustpanel-list-label-{category}"]
         )
         return self

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -150,5 +150,19 @@ class TrustPanel(BasePage):
         Verify that the 'Not Blocking <Category>' title
         is displayed in the subpanel.
         """
-        self.element_visible("not-blocking-category", labels=[category.capitalize()])
+        self.element_visible(
+            "not-blocking-category",
+            labels=[category.title()]
+        )
+        return self
+
+    @BasePage.context_chrome
+    def open_detected_category(self, category: str):
+        """
+        Open a detected tracker category from the protections panel.
+        """
+        self.js_click_on(
+            "detected-category",
+            labels=[f"trustpanel-list-label-{category}"]
+        )
         return self

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -167,6 +167,6 @@ class TrustPanel(BasePage):
             [f"trustpanel-list-label-{canonical}"],
         )
 
-        self.element_clickable(*locator)
+        sleep(0.5)
         self.js_click_on(*locator)
         return self

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -163,7 +163,6 @@ class TrustPanel(BasePage):
         canonical = category.strip().lower().replace(" ", "-")
 
         self.js_click_on(
-            "detected-category",
-            labels=[f"trustpanel-list-label-{canonical}"]
+            "detected-category", labels=[f"trustpanel-list-label-{canonical}"]
         )
         return self

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -752,10 +752,5 @@
     "selectorData": "[data-l10n-id='sitedata-option-block-unvisited']",
     "strategy": "css",
     "groups": []
-  },
-  "not-blocking-category": {
-        "selectorData": "panelview[title='Not Blocking {}']",
-        "strategy": "css",
-        "groups": []
-    }
+  }
 }

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -747,10 +747,5 @@
     "selectorData": "standardRadio",
     "strategy": "id",
     "groups": []
-  },
-  "cookies-from-unvisited-websites": {
-    "selectorData": "[data-l10n-id='sitedata-option-block-unvisited']",
-    "strategy": "css",
-    "groups": []
   }
 }

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -747,5 +747,15 @@
     "selectorData": "standardRadio",
     "strategy": "id",
     "groups": []
-  }
+  },
+  "cookies-from-unvisited-websites": {
+    "selectorData": "[data-l10n-id='sitedata-option-block-unvisited']",
+    "strategy": "css",
+    "groups": []
+  },
+  "not-blocking-category": {
+        "selectorData": "panelview[title='Not Blocking {}']",
+        "strategy": "css",
+        "groups": []
+    }
 }

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -95,35 +95,18 @@
         "groups": [],
         "shadowParent": "see-all-trackers-parent"
     },
-    "fingerprinters-detected-parent": {
-        "selectorData": "[data-l10n-id='trustpanel-list-label-fingerprinter']",
-        "strategy": "css",
-        "groups": []
-    },
-    "fingerprinters-detected": {
-        "selectorData": "main-button",
-        "strategy": "id",
-        "groups": [],
-        "shadowParent": "fingerprinters-detected-parent"
-    },
     "protections-popup-list-host-label": {
         "selectorData": ".protections-popup-list-host-label",
         "strategy": "css",
         "groups": []
     },
-    "cryptominers-detected-parent": {
-        "selectorData": "[data-l10n-id='trustpanel-list-label-cryptominer']",
+    "not-blocking-category": {
+        "selectorData": "panelview[title='Not Blocking {}']",
         "strategy": "css",
         "groups": []
     },
-    "cryptominers-detected": {
-        "selectorData": "main-button",
-        "strategy": "id",
-        "groups": [],
-        "shadowParent": "cryptominers-detected-parent"
-    },
-    "not-blocking-category": {
-        "selectorData": "panelview[title='Not Blocking {}']",
+    "detected-category": {
+        "selectorData": "[data-l10n-id='{}']",
         "strategy": "css",
         "groups": []
     }

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -106,7 +106,7 @@
         "groups": []
     },
     "detected-category": {
-        "selectorData": "[data-l10n-id='{}']",
+        "selectorData": "moz-button.moz-button-subviewbutton-nav[data-l10n-id='{}']",
         "strategy": "css",
         "groups": []
     }

--- a/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_cryptominers_subpanel_display_when_not_blocked.py
@@ -46,7 +46,7 @@ def test_cryptominers_subpanel_display_when_not_blocked(driver: Firefox):
 
     # Click on "Cryptominers"
     trust_panel.wait_for_trackers()
-    trust_panel.js_click_on("cryptominers-detected")
+    trust_panel.open_detected_category("cryptominer")
 
     # "Not Blocking Cryptominers" title is displayed in the subpanel
     trust_panel.title_displayed_in_subpanel("cryptominers")

--- a/tests/security_and_privacy/test_fingerprinters_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_fingerprinters_subpanel_display_when_not_blocked.py
@@ -44,7 +44,7 @@ def test_fingerprinters_subpanel_display_when_not_blocked(driver: Firefox):
 
     # Click on "Fingerprinters"
     trust_panel.wait_for_trackers()
-    trust_panel.js_click_on("fingerprinters-detected")
+    trust_panel.open_detected_category("fingerprinter")
 
     # "Not Blocking Fingerprinters" title is displayed in the subpanel
     trust_panel.title_displayed_in_subpanel("fingerprinters")

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -54,4 +54,4 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
     trust_panel.title_displayed_in_subpanel("tracking content")
 
     # The allowed cross-site tracking cookies are displayed inside the subpanel
-    assert trust_panel.has_allowed_sites(DETECTED_TRACKING_CONTENT)
+    assert trust_panel.has_allowed_sites(*DETECTED_TRACKING_CONTENT)

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -7,6 +7,10 @@ from modules.page_object_prefs import AboutPrefs
 
 TRACKING_CONTENT_URL = "https://senglehardt.com/test/trackingprotection/test_pages/cryptomining_and_trackers"
 
+DETECTED_TRACKING_CONTENT = ("https://social-track-digest256.dummytracker.org,"
+                             "https://ads-track-digest256.dummytracker.org",
+                             "https://analytics-track-digest256.dummytracker.org")
+
 
 @pytest.fixture()
 def test_case():
@@ -44,10 +48,10 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
 
     # Click on "Cross-site tracking cookies"
     trust_panel.wait_for_trackers()
-    trust_panel.js_click_on("cryptominers-detected")
+    trust_panel.open_detected_category("tracking-content")
 
     # "Not Blocking Cross-site Tracking Cookies." title is displayed in the subpanel
     trust_panel.title_displayed_in_subpanel("tracking content")
 
     # The allowed cross-site tracking cookies are displayed inside the subpanel
-    # assert trust_panel.has_allowed_sites()
+    assert trust_panel.has_allowed_sites(DETECTED_TRACKING_CONTENT)

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -7,9 +7,11 @@ from modules.page_object_prefs import AboutPrefs
 
 TRACKING_CONTENT_URL = "https://senglehardt.com/test/trackingprotection/test_pages/cryptomining_and_trackers"
 
-DETECTED_TRACKING_CONTENT = ("https://social-track-digest256.dummytracker.org",
-                             "https://ads-track-digest256.dummytracker.org",
-                             "https://analytics-track-digest256.dummytracker.org")
+DETECTED_TRACKING_CONTENT = (
+    "https://social-track-digest256.dummytracker.org",
+    "https://ads-track-digest256.dummytracker.org",
+    "https://analytics-track-digest256.dummytracker.org",
+)
 
 
 @pytest.fixture()
@@ -35,7 +37,7 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
         "known-fingerprints-checkbox",
         "suspected-fingerprints-checkbox",
         "cryptominers-checkbox",
-        "cookies-from-unvisited-websites"
+        "cookies-from-unvisited-websites",
     )
 
     # Open page and click on the shield icon

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -53,6 +53,7 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
     trust_panel.open_detected_category("tracking content")
 
     # "Not Blocking Cross-site Tracking Cookies." title is displayed in the subpanel
+    trust_panel.wait_for_trackers()
     trust_panel.title_displayed_in_subpanel("tracking content")
 
     # The allowed cross-site tracking cookies are displayed inside the subpanel

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -50,4 +50,4 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
     trust_panel.title_displayed_in_subpanel("tracking content")
 
     # The allowed cross-site tracking cookies are displayed inside the subpanel
-    assert trust_panel.has_allowed_sites()
+    # assert trust_panel.has_allowed_sites()

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -35,7 +35,7 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
         "cookies-isolate-social-media-option",
         "known-fingerprints-checkbox",
         "suspected-fingerprints-checkbox",
-        "cryptominers-checkbox"
+        "cryptominers-checkbox",
     )
 
     # Open page and click on the shield icon

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -48,9 +48,9 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
     # Click on "See All" button
     trust_panel.click_see_all()
 
-    # Click on "Cross-site tracking cookies"
+    # Click on "Tracking content"
     trust_panel.wait_for_trackers()
-    trust_panel.open_detected_category("tracking-content")
+    trust_panel.open_detected_category("tracking content")
 
     # "Not Blocking Cross-site Tracking Cookies." title is displayed in the subpanel
     trust_panel.title_displayed_in_subpanel("tracking content")

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -16,12 +16,12 @@ DETECTED_TRACKING_CONTENT = (
 
 @pytest.fixture()
 def test_case():
-    return "3054914"
+    return "3054917"
 
 
 def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
     """
-    C3054914 - Cross-site tracking cookies are correctly displayed in the sub panel when they are not blocked
+    C3054917 - Tracking content is correctly displayed in the sub panel when they are not blocked
     """
 
     # Instantiate objects
@@ -29,15 +29,13 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
     tracking_page = GenericPage(driver, url=TRACKING_CONTENT_URL)
     trust_panel = TrustPanel(driver)
 
-    # In about:preferences#privacy deselect only the option "Tracking content"
-    # and from the Cookies section, select "Cookies from unvisited websites"
+    # In about:preferences#privacy deselect only the option "Tracking Content" in the Custom section
     about_prefs.open()
     about_prefs.select_trackers_to_block(
         "cookies-isolate-social-media-option",
         "known-fingerprints-checkbox",
         "suspected-fingerprints-checkbox",
-        "cryptominers-checkbox",
-        "cookies-from-unvisited-websites",
+        "cryptominers-checkbox"
     )
 
     # Open page and click on the shield icon
@@ -52,9 +50,9 @@ def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
     trust_panel.wait_for_trackers()
     trust_panel.open_detected_category("tracking content")
 
-    # "Not Blocking Cross-site Tracking Cookies." title is displayed in the subpanel
+    # "Not Blocking Tracking Content" title is displayed in the subpanel
     trust_panel.wait_for_trackers()
     trust_panel.title_displayed_in_subpanel("tracking content")
 
-    # The allowed cross-site tracking cookies are displayed inside the subpanel
+    # The allowed tracking content is displayed inside the subpanel
     assert trust_panel.has_allowed_sites(*DETECTED_TRACKING_CONTENT)

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -1,0 +1,53 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_trust_panel import TrustPanel
+from modules.page_object_generics import GenericPage
+from modules.page_object_prefs import AboutPrefs
+
+TRACKING_CONTENT_URL = "https://senglehardt.com/test/trackingprotection/test_pages/cryptomining_and_trackers"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054914"
+
+
+def test_tracking_content_subpanel_display_when_not_blocked(driver: Firefox):
+    """
+    C3054914 - Cross-site tracking cookies are correctly displayed in the sub panel when they are not blocked
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    tracking_page = GenericPage(driver, url=TRACKING_CONTENT_URL)
+    trust_panel = TrustPanel(driver)
+
+    # In about:preferences#privacy deselect only the option "Tracking content"
+    # and from the Cookies section, select "Cookies from unvisited websites"
+    about_prefs.open()
+    about_prefs.select_trackers_to_block(
+        "cookies-isolate-social-media-option",
+        "known-fingerprints-checkbox",
+        "suspected-fingerprints-checkbox",
+        "cryptominers-checkbox",
+        "cookies-from-unvisited-websites"
+    )
+
+    # Open page and click on the shield icon
+    tracking_page.open()
+    trust_panel.open_panel()
+    trust_panel.wait_for_trackers()
+
+    # Click on "See All" button
+    trust_panel.click_see_all()
+
+    # Click on "Cross-site tracking cookies"
+    trust_panel.wait_for_trackers()
+    trust_panel.js_click_on("cryptominers-detected")
+
+    # "Not Blocking Cross-site Tracking Cookies." title is displayed in the subpanel
+    trust_panel.title_displayed_in_subpanel("tracking content")
+
+    # The allowed cross-site tracking cookies are displayed inside the subpanel
+    assert trust_panel.has_allowed_sites()

--- a/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
+++ b/tests/security_and_privacy/test_tracking_content_subpanel_display_when_not_blocked.py
@@ -7,7 +7,7 @@ from modules.page_object_prefs import AboutPrefs
 
 TRACKING_CONTENT_URL = "https://senglehardt.com/test/trackingprotection/test_pages/cryptomining_and_trackers"
 
-DETECTED_TRACKING_CONTENT = ("https://social-track-digest256.dummytracker.org,"
+DETECTED_TRACKING_CONTENT = ("https://social-track-digest256.dummytracker.org",
                              "https://ads-track-digest256.dummytracker.org",
                              "https://analytics-track-digest256.dummytracker.org")
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025842](https://bugzilla.mozilla.org/show_bug.cgi?id=2025842)
TestRail: [3054917](https://mozilla.testrail.io/index.php?/cases/view/3054917)

### Description of Code / Doc Changes

* Add test to verify that cross-site tracking cookies are correctly displayed in the sub panel when they are not blocked
* Had to use sleep in the function, I couldn't find any other solution to avoid sleep. Without it the tests kept failing on linux.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
