### PR TITLE
Validate PyAutoGUI on Wayland relsre workers

### DIFF
--- a/scripts/setup-xauthority.sh
+++ b/scripts/setup-xauthority.sh
@@ -1,0 +1,52 @@
+# shellcheck shell=bash
+
+export DISPLAY="${DISPLAY:-:0}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+find_xauthority() {
+  for candidate in \
+    "${XDG_RUNTIME_DIR}/gdm/Xauthority" \
+    "${XDG_RUNTIME_DIR}"/.mutter-Xwaylandauth.* \
+    "${HOME}/.Xauthority"; do
+    if [ -r "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+}
+
+source_xauthority="${XAUTHORITY:-$(find_xauthority)}"
+if [ -n "$source_xauthority" ]; then
+  export XAUTHORITY="$source_xauthority"
+fi
+
+if [ -n "${XAUTHORITY:-}" ] && command -v xauth >/dev/null 2>&1; then
+  case "$-" in
+    *x*) restore_xtrace=1 ;;
+    *) restore_xtrace=0 ;;
+  esac
+
+  set +x
+  xauth_cookie="$(xauth -f "$XAUTHORITY" list 2>/dev/null | awk '/MIT-MAGIC-COOKIE-1/ { print $3; exit }')"
+  if [ -n "$xauth_cookie" ]; then
+    export XAUTHORITY="$HOME/.Xauthority"
+    touch "$XAUTHORITY"
+    chmod 600 "$XAUTHORITY"
+    xauth -f "$XAUTHORITY" add "$(hostname)/unix:0" MIT-MAGIC-COOKIE-1 "$xauth_cookie"
+  fi
+  unset xauth_cookie
+
+  if [ "$restore_xtrace" = "1" ]; then
+    set -x
+  fi
+fi
+
+echo "DISPLAY=${DISPLAY:-}"
+echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-}"
+echo "SOURCE_XAUTHORITY=${source_xauthority:-}"
+echo "XAUTHORITY=${XAUTHORITY:-}"
+
+if [ -n "${XAUTHORITY:-}" ]; then
+  ls -l "$XAUTHORITY" || true
+  xauth -f "$XAUTHORITY" list 2>&1 | sed -E 's/[0-9a-fA-F]{32,}/<redacted>/g' || true
+fi

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -25,4 +25,4 @@ workers:
       provisioner: '{trust-domain}-t'
       implementation: generic-worker
       os: linux
-      worker-type: 't-linux-2404-wayland'
+      worker-type: 't-linux-2404-wayland-relsre'

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -19,10 +19,28 @@ tasks:
         export PATH=$PATH:$HOME/.cargo/bin
         . "$HOME/.cargo/env"
         pipenv install;
+        export DISPLAY="${DISPLAY:-:0}"
+        export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+        if [ -z "${XAUTHORITY:-}" ]; then
+          for candidate in "$XDG_RUNTIME_DIR/gdm/Xauthority" "$XDG_RUNTIME_DIR"/.mutter-Xwaylandauth.* "$HOME/.Xauthority"; do
+            if [ -r "$candidate" ]; then
+              export XAUTHORITY="$candidate"
+              break
+            fi
+          done
+        fi
+        echo "DISPLAY=${DISPLAY:-}"
+        echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-}"
+        echo "XAUTHORITY=${XAUTHORITY:-}"
+        ls -la "$XDG_RUNTIME_DIR" "$XDG_RUNTIME_DIR/gdm" "$HOME/.Xauthority" 2>&1 || true
+        if [ -n "${XAUTHORITY:-}" ]; then
+          ls -l "$XAUTHORITY" || true
+        fi
         xeyes & echo "running xeyes";
-        pipenv run python3 -c 'import pyautogui'
+        PYAUTOGUI_IMPORT_EXIT_CODE=0
+        pipenv run python3 -c 'import pyautogui' || PYAUTOGUI_IMPORT_EXIT_CODE=$?
         pipenv run python3 -m ruff version;
         pipenv run python3 -m ruff format --check;
         export EXIT_CODE=$?;
         pipenv run python3 -m ruff check --select I;
-        exit $(( $EXIT_CODE || $? ));
+        exit $(( $PYAUTOGUI_IMPORT_EXIT_CODE || $EXIT_CODE || $? ));

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -19,39 +19,7 @@ tasks:
         export PATH=$PATH:$HOME/.cargo/bin
         . "$HOME/.cargo/env"
         pipenv install;
-        export DISPLAY="${DISPLAY:-:0}"
-        export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-        if [ -z "${XAUTHORITY:-}" ]; then
-          for candidate in "$XDG_RUNTIME_DIR/gdm/Xauthority" "$XDG_RUNTIME_DIR"/.mutter-Xwaylandauth.* "$HOME/.Xauthority"; do
-            if [ -r "$candidate" ]; then
-              export XAUTHORITY="$candidate"
-              break
-            fi
-          done
-        fi
-        SOURCE_XAUTHORITY="${XAUTHORITY:-}"
-        if [ -n "$SOURCE_XAUTHORITY" ] && command -v xauth >/dev/null 2>&1; then
-          set +x
-          XAUTH_COOKIE="$(xauth -f "$SOURCE_XAUTHORITY" list 2>/dev/null | awk '/MIT-MAGIC-COOKIE-1/ { print $3; exit }')"
-          if [ -n "$XAUTH_COOKIE" ]; then
-            export XAUTHORITY="$HOME/.Xauthority"
-            touch "$XAUTHORITY"
-            chmod 600 "$XAUTHORITY"
-            xauth -f "$XAUTHORITY" add "$(hostname)/unix:0" MIT-MAGIC-COOKIE-1 "$XAUTH_COOKIE"
-          fi
-          unset XAUTH_COOKIE
-          set -x
-        fi
-        echo "DISPLAY=${DISPLAY:-}"
-        echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-}"
-        echo "SOURCE_XAUTHORITY=${SOURCE_XAUTHORITY:-}"
-        echo "XAUTHORITY=${XAUTHORITY:-}"
-        ls -la "$XDG_RUNTIME_DIR" "$XDG_RUNTIME_DIR/gdm" "$SOURCE_XAUTHORITY" "$HOME/.Xauthority" 2>&1 || true
-        if [ -n "${XAUTHORITY:-}" ]; then
-          ls -l "$XAUTHORITY" || true
-          command -v xauth || true
-          xauth -f "$XAUTHORITY" list 2>&1 | sed -E 's/[0-9a-fA-F]{32,}/<redacted>/g' || true
-        fi
+        . ./scripts/setup-xauthority.sh
         XEYES_EXIT_CODE=0
         timeout 5 xeyes || XEYES_EXIT_CODE=$?
         echo "XEYES_EXIT_CODE=$XEYES_EXIT_CODE"

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -31,6 +31,7 @@ tasks:
         fi
         SOURCE_XAUTHORITY="${XAUTHORITY:-}"
         if [ -n "$SOURCE_XAUTHORITY" ] && command -v xauth >/dev/null 2>&1; then
+          set +x
           XAUTH_COOKIE="$(xauth -f "$SOURCE_XAUTHORITY" list 2>/dev/null | awk '/MIT-MAGIC-COOKIE-1/ { print $3; exit }')"
           if [ -n "$XAUTH_COOKIE" ]; then
             export XAUTHORITY="$HOME/.Xauthority"
@@ -38,6 +39,8 @@ tasks:
             chmod 600 "$XAUTHORITY"
             xauth -f "$XAUTHORITY" add "$(hostname)/unix:0" MIT-MAGIC-COOKIE-1 "$XAUTH_COOKIE"
           fi
+          unset XAUTH_COOKIE
+          set -x
         fi
         echo "DISPLAY=${DISPLAY:-}"
         echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-}"

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -35,8 +35,12 @@ tasks:
         ls -la "$XDG_RUNTIME_DIR" "$XDG_RUNTIME_DIR/gdm" "$HOME/.Xauthority" 2>&1 || true
         if [ -n "${XAUTHORITY:-}" ]; then
           ls -l "$XAUTHORITY" || true
+          command -v xauth || true
+          xauth -f "$XAUTHORITY" list 2>&1 | sed -E 's/[0-9a-fA-F]{32,}/<redacted>/g' || true
         fi
-        xeyes & echo "running xeyes";
+        XEYES_EXIT_CODE=0
+        timeout 5 xeyes || XEYES_EXIT_CODE=$?
+        echo "XEYES_EXIT_CODE=$XEYES_EXIT_CODE"
         PYAUTOGUI_IMPORT_EXIT_CODE=0
         pipenv run python3 -c 'import pyautogui' || PYAUTOGUI_IMPORT_EXIT_CODE=$?
         pipenv run python3 -m ruff version;

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -29,10 +29,21 @@ tasks:
             fi
           done
         fi
+        SOURCE_XAUTHORITY="${XAUTHORITY:-}"
+        if [ -n "$SOURCE_XAUTHORITY" ] && command -v xauth >/dev/null 2>&1; then
+          XAUTH_COOKIE="$(xauth -f "$SOURCE_XAUTHORITY" list 2>/dev/null | awk '/MIT-MAGIC-COOKIE-1/ { print $3; exit }')"
+          if [ -n "$XAUTH_COOKIE" ]; then
+            export XAUTHORITY="$HOME/.Xauthority"
+            touch "$XAUTHORITY"
+            chmod 600 "$XAUTHORITY"
+            xauth -f "$XAUTHORITY" add "$(hostname)/unix:0" MIT-MAGIC-COOKIE-1 "$XAUTH_COOKIE"
+          fi
+        fi
         echo "DISPLAY=${DISPLAY:-}"
         echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-}"
+        echo "SOURCE_XAUTHORITY=${SOURCE_XAUTHORITY:-}"
         echo "XAUTHORITY=${XAUTHORITY:-}"
-        ls -la "$XDG_RUNTIME_DIR" "$XDG_RUNTIME_DIR/gdm" "$HOME/.Xauthority" 2>&1 || true
+        ls -la "$XDG_RUNTIME_DIR" "$XDG_RUNTIME_DIR/gdm" "$SOURCE_XAUTHORITY" "$HOME/.Xauthority" 2>&1 || true
         if [ -n "${XAUTHORITY:-}" ]; then
           ls -l "$XAUTHORITY" || true
           command -v xauth || true

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -33,13 +33,48 @@ tasks:
         export PATH=$PATH:$HOME/.cargo/bin
         . "$HOME/.cargo/env"
         pipenv install;
+        export DISPLAY="${DISPLAY:-:0}"
+        export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+        if [ -z "${XAUTHORITY:-}" ]; then
+          for candidate in "$XDG_RUNTIME_DIR/gdm/Xauthority" "$XDG_RUNTIME_DIR"/.mutter-Xwaylandauth.* "$HOME/.Xauthority"; do
+            if [ -r "$candidate" ]; then
+              export XAUTHORITY="$candidate"
+              break
+            fi
+          done
+        fi
+        SOURCE_XAUTHORITY="${XAUTHORITY:-}"
+        if [ -n "$SOURCE_XAUTHORITY" ] && command -v xauth >/dev/null 2>&1; then
+          set +x
+          XAUTH_COOKIE="$(xauth -f "$SOURCE_XAUTHORITY" list 2>/dev/null | awk '/MIT-MAGIC-COOKIE-1/ { print $3; exit }')"
+          if [ -n "$XAUTH_COOKIE" ]; then
+            export XAUTHORITY="$HOME/.Xauthority"
+            touch "$XAUTHORITY"
+            chmod 600 "$XAUTHORITY"
+            xauth -f "$XAUTHORITY" add "$(hostname)/unix:0" MIT-MAGIC-COOKIE-1 "$XAUTH_COOKIE"
+          fi
+          unset XAUTH_COOKIE
+          set -x
+        fi
+        echo "DISPLAY=${DISPLAY:-}"
+        echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-}"
+        echo "SOURCE_XAUTHORITY=${SOURCE_XAUTHORITY:-}"
+        echo "XAUTHORITY=${XAUTHORITY:-}"
+        ls -la "$XDG_RUNTIME_DIR" "$XDG_RUNTIME_DIR/gdm" "$SOURCE_XAUTHORITY" "$HOME/.Xauthority" 2>&1 || true
+        if [ -n "${XAUTHORITY:-}" ]; then
+          ls -l "$XAUTHORITY" || true
+          command -v xauth || true
+          xauth -f "$XAUTHORITY" list 2>&1 | sed -E 's/[0-9a-fA-F]{32,}/<redacted>/g' || true
+        fi
+        PYAUTOGUI_IMPORT_EXIT_CODE=0
+        pipenv run python3 -c 'import pyautogui' || PYAUTOGUI_IMPORT_EXIT_CODE=$?
         ./scripts/collect_executables.sh;
         ./firefox/firefox --version;
         . ./scripts/keyring-unlock.sh
         if [[ ! $(python3 ./scripts/choose_test_type.py) =~ "starfox" ]]; then exit 0; fi;
         pipenv run python -m scripts.choose_test_split;
         pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
-        export FAILURE=${?};
+        export FAILURE=$((PYAUTOGUI_IMPORT_EXIT_CODE | ${?}));
         pipenv run pytest --fx-executable ./firefox/firefox tests/glean;
         export FAILURE=$((FAILURE | ${?}));
         mv ./config/ci_pyproject_headed.toml ./pyproject.toml;

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -35,39 +35,7 @@ tasks:
         export PATH=$PATH:$HOME/.cargo/bin
         . "$HOME/.cargo/env"
         pipenv install;
-        export DISPLAY="${DISPLAY:-:0}"
-        export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-        if [ -z "${XAUTHORITY:-}" ]; then
-          for candidate in "$XDG_RUNTIME_DIR/gdm/Xauthority" "$XDG_RUNTIME_DIR"/.mutter-Xwaylandauth.* "$HOME/.Xauthority"; do
-            if [ -r "$candidate" ]; then
-              export XAUTHORITY="$candidate"
-              break
-            fi
-          done
-        fi
-        SOURCE_XAUTHORITY="${XAUTHORITY:-}"
-        if [ -n "$SOURCE_XAUTHORITY" ] && command -v xauth >/dev/null 2>&1; then
-          set +x
-          XAUTH_COOKIE="$(xauth -f "$SOURCE_XAUTHORITY" list 2>/dev/null | awk '/MIT-MAGIC-COOKIE-1/ { print $3; exit }')"
-          if [ -n "$XAUTH_COOKIE" ]; then
-            export XAUTHORITY="$HOME/.Xauthority"
-            touch "$XAUTHORITY"
-            chmod 600 "$XAUTHORITY"
-            xauth -f "$XAUTHORITY" add "$(hostname)/unix:0" MIT-MAGIC-COOKIE-1 "$XAUTH_COOKIE"
-          fi
-          unset XAUTH_COOKIE
-          set -x
-        fi
-        echo "DISPLAY=${DISPLAY:-}"
-        echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-}"
-        echo "SOURCE_XAUTHORITY=${SOURCE_XAUTHORITY:-}"
-        echo "XAUTHORITY=${XAUTHORITY:-}"
-        ls -la "$XDG_RUNTIME_DIR" "$XDG_RUNTIME_DIR/gdm" "$SOURCE_XAUTHORITY" "$HOME/.Xauthority" 2>&1 || true
-        if [ -n "${XAUTHORITY:-}" ]; then
-          ls -l "$XAUTHORITY" || true
-          command -v xauth || true
-          xauth -f "$XAUTHORITY" list 2>&1 | sed -E 's/[0-9a-fA-F]{32,}/<redacted>/g' || true
-        fi
+        . ./scripts/setup-xauthority.sh
         PYAUTOGUI_IMPORT_EXIT_CODE=0
         pipenv run python3 -c 'import pyautogui; print("pyautogui import ok")' || PYAUTOGUI_IMPORT_EXIT_CODE=$?
         if [ "${PYAUTOGUI_WAYLAND_PROBE_ONLY:-0}" = "1" ]; then

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -9,6 +9,8 @@ task-defaults:
   worker:
     taskcluster-proxy: true
     max-run-time: 3600
+    env:
+      PYAUTOGUI_WAYLAND_PROBE_ONLY: "1"
     artifacts:
       - name: public/results
         path: checkouts/vcs/artifacts
@@ -67,7 +69,10 @@ tasks:
           xauth -f "$XAUTHORITY" list 2>&1 | sed -E 's/[0-9a-fA-F]{32,}/<redacted>/g' || true
         fi
         PYAUTOGUI_IMPORT_EXIT_CODE=0
-        pipenv run python3 -c 'import pyautogui' || PYAUTOGUI_IMPORT_EXIT_CODE=$?
+        pipenv run python3 -c 'import pyautogui; print("pyautogui import ok")' || PYAUTOGUI_IMPORT_EXIT_CODE=$?
+        if [ "${PYAUTOGUI_WAYLAND_PROBE_ONLY:-0}" = "1" ]; then
+          exit "$PYAUTOGUI_IMPORT_EXIT_CODE"
+        fi
         ./scripts/collect_executables.sh;
         ./firefox/firefox --version;
         . ./scripts/keyring-unlock.sh


### PR DESCRIPTION
## Summary

This branch validates Ben's PyAutoGUI work from `ben/general-pyautogui` on the Ubuntu 24.04 Wayland relsre worker pool.

It points the `t-linux-wayland` Taskcluster alias at `mozilla-t/t-linux-2404-wayland-relsre`, which is backed by the refreshed Wayland GUI alpha image from:

- mozilla-platform-ops/worker-images#773
- mozilla-releng/fxci-config#989

## What We Found

PyAutoGUI works on the refreshed Wayland image when the task user gets a usable Xauthority file for Xwayland.

There were two separate blockers:

1. The base image needed `python3-tk` and `python3-dev` so PyAutoGUI's import path could load its MouseInfo/tkinter dependency from the task virtualenv. mozilla-platform-ops/worker-images#773 adds those packages, and relsre validation confirms that part is fixed.
2. The task user needed an Xauthority file that Python Xlib can use. GDM/Mutter creates a readable Xwayland auth file under `$XDG_RUNTIME_DIR/.mutter-Xwaylandauth.*`, but exporting that file directly was not enough for Python Xlib. Rewriting the cookie into `$HOME/.Xauthority` with the expected `$(hostname)/unix:0` entry fixes the Xlib auth failure.

So the package change worked, and the remaining required task-side setup is the Xauthority rewrite. That setup now lives in `scripts/setup-xauthority.sh` and is sourced by both lint and smoke, instead of being duplicated inline in each Taskcluster job.

## Validation

Latest validation commit: `8665d9c1`

- Decision Task: passed, https://firefox-ci-tc.services.mozilla.com/tasks/bSRtweBSQT-FQUHW3UcfLg
- CI Smoke Tests: passed on `mozilla-t/t-linux-2404-wayland-relsre`, https://firefox-ci-tc.services.mozilla.com/tasks/H0Hn7e_yRri3VxAnwVadtA
- lint-linux: passed on `mozilla-t/t-linux-2404-wayland-relsre`, https://firefox-ci-tc.services.mozilla.com/tasks/XNj0bbIBR2a_COHQy81exA

The smoke log confirms the worker found `/run/user/1004/.mutter-Xwaylandauth.*`, wrote `$HOME/.Xauthority`, and printed `pyautogui import ok`. The lint task also ran `xeyes` under timeout and completed successfully, which confirms Xwayland was reachable.

## Notes

The smoke task is intentionally scoped to the PyAutoGUI/Wayland probe on this validation branch. The broader Starfox smoke selection exposed unrelated Firefox UI test failures on this worker, which would mask the worker-image/Xauthority signal this branch is meant to test.
