### PR TITLE
Hani/ Test cryptominers displayed in subpanel

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1151,6 +1151,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_cryptominers_displayed_subpanel:
+    result: pass
+    splits:
+    - functional2
   test_cryptominers_subpanel_display_when_not_blocked:
     result: pass
     splits:

--- a/tests/security_and_privacy/test_cryptominers_displayed_subpanel.py
+++ b/tests/security_and_privacy/test_cryptominers_displayed_subpanel.py
@@ -1,0 +1,47 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TrustPanel
+from modules.page_object import AboutPrefs, GenericPage
+
+CRYPTOMINERS_URL = (
+    "https://senglehardt.com/test/trackingprotection/test_pages/cryptomining.html"
+)
+DETECTED_CRYPTOMINER = "https://base-cryptomining-track-digest256.dummytracker.org"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054910"
+
+
+def test_cryptominers_displayed_subpanel(driver: Firefox):
+    """
+    C3054910 - Cryptominers are correctly displayed in the sub panel
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    tracking_page = GenericPage(driver, url=CRYPTOMINERS_URL)
+    trust_panel = TrustPanel(driver)
+
+    # In about:preferences#privacy select only the option "Cryptominers"
+    about_prefs.open()
+    about_prefs.select_trackers_to_block("cryptominers-checkbox")
+
+    # Open page and click on the shield icon
+    tracking_page.open()
+    trust_panel.open_panel()
+    trust_panel.wait_for_trackers()
+
+    # Click on "See All" button
+    trust_panel.click_see_all()
+
+    # Click on Cryptominers
+    trust_panel.open_detected_category("cryptominer")
+
+    # "Cryptominers Blocked" title is displayed in the subpanel
+    trust_panel.blocked_trackers_title_displayed_in_subpanel("cryptominers")
+
+    # The cryptominers blocked are displayed inside the subpanel
+    assert trust_panel.has_detected_tracking_sites(DETECTED_CRYPTOMINER)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025835](https://bugzilla.mozilla.org/show_bug.cgi?id=2025835)
TestRail: [3054910](https://mozilla.testrail.io/index.php?/cases/view/3054910)

### Description of Code / Doc Changes

* Add test to verify that cryptominers are correctly displayed in the sub panel

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
