### PR TITLE
Hani/ cross site tracking cookies displayed subpanel

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1147,6 +1147,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_cross_site_tracking_cookies_displayed_subpanel:
+    result: pass
+    splits:
+    - functional2
   test_cryptominers_blocked_and_shown_in_info_panel:
     result: pass
     splits:

--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -106,9 +106,9 @@ class Navigation(BasePage):
         awesome_bar.send_keys(Keys.END)
         awesome_bar.send_keys(text)
         self.wait.until(
-            lambda _: self.get_element("awesome-bar")
-            .get_attribute("value")
-            .endswith(text)
+            lambda _: (
+                self.get_element("awesome-bar").get_attribute("value").endswith(text)
+            )
         )
         awesome_bar.send_keys(Keys.ENTER)
         return self

--- a/tests/security_and_privacy/test_blocking_cryptominers.py
+++ b/tests/security_and_privacy/test_blocking_cryptominers.py
@@ -7,7 +7,7 @@ from modules.page_object import AboutPrefs, GenericPage
 
 @pytest.fixture()
 def test_case():
-    return "3054910"
+    return "446403"
 
 
 CRYPTOMINERS_URL = (

--- a/tests/security_and_privacy/test_cross_site_tracking_cookies_blocked.py
+++ b/tests/security_and_privacy/test_cross_site_tracking_cookies_blocked.py
@@ -7,7 +7,7 @@ from modules.page_object import AboutPrefs, GenericPage
 
 @pytest.fixture()
 def test_case():
-    return "3054909"
+    return "446402"
 
 
 FIRST_TRACKER_WEBSITE = (

--- a/tests/security_and_privacy/test_cross_site_tracking_cookies_displayed_subpanel.py
+++ b/tests/security_and_privacy/test_cross_site_tracking_cookies_displayed_subpanel.py
@@ -5,10 +5,11 @@ from modules.browser_object import TrustPanel
 from modules.page_object import AboutPrefs, GenericPage
 
 COOKIES_URL = "https://senglehardt.com/test/trackingprotection/test_pages/tracking_protection.html"
-DETECTED_COOKIES = ("https://social-track-digest256.dummytracker.org",
-                    "https://ads-track-digest256.dummytracker.org",
-                    "https://analytics-track-digest256.dummytracker.org"
-                    )
+DETECTED_COOKIES = (
+    "https://social-track-digest256.dummytracker.org",
+    "https://ads-track-digest256.dummytracker.org",
+    "https://analytics-track-digest256.dummytracker.org",
+)
 
 
 @pytest.fixture()

--- a/tests/security_and_privacy/test_cross_site_tracking_cookies_displayed_subpanel.py
+++ b/tests/security_and_privacy/test_cross_site_tracking_cookies_displayed_subpanel.py
@@ -1,0 +1,48 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TrustPanel
+from modules.page_object import AboutPrefs, GenericPage
+
+COOKIES_URL = "https://senglehardt.com/test/trackingprotection/test_pages/tracking_protection.html"
+DETECTED_COOKIES = ("https://social-track-digest256.dummytracker.org",
+                    "https://ads-track-digest256.dummytracker.org",
+                    "https://analytics-track-digest256.dummytracker.org"
+                    )
+
+
+@pytest.fixture()
+def test_case():
+    return "3054909"
+
+
+def test_cross_site_tracking_cookies_displayed_subpanel(driver: Firefox):
+    """
+    C3054909 - Cross-site tracking cookies are correctly displayed in the sub panel
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    tracking_page = GenericPage(driver, url=COOKIES_URL)
+    trust_panel = TrustPanel(driver)
+
+    # In about:preferences#privacy select only the option "Cross-site tracking cookies" in the Cookies section
+    about_prefs.open()
+    about_prefs.select_trackers_to_block("cookies-checkbox")
+
+    # Open page and click on the shield icon
+    tracking_page.open()
+    trust_panel.open_panel()
+    trust_panel.wait_for_trackers()
+
+    # Click on "See All" button
+    trust_panel.click_see_all()
+
+    # Click on Cross-site tracking cookies
+    trust_panel.open_detected_category("tracking cookies")
+
+    # "Third-Party Cookies Blocked" title is displayed in the subpanel
+    trust_panel.blocked_trackers_title_displayed_in_subpanel("third-party cookies")
+
+    # The blocked cross-site tracking cookies are displayed inside the subpanel
+    assert trust_panel.has_detected_tracking_sites(*DETECTED_COOKIES)

--- a/tests/security_and_privacy/test_cross_site_tracking_cookies_displayed_subpanel.py
+++ b/tests/security_and_privacy/test_cross_site_tracking_cookies_displayed_subpanel.py
@@ -39,7 +39,7 @@ def test_cross_site_tracking_cookies_displayed_subpanel(driver: Firefox):
     # Click on "See All" button
     trust_panel.click_see_all()
 
-    # Click on Cross-site tracking cookies
+    # Click on cross-site tracking cookies
     trust_panel.open_detected_category("tracking cookies")
 
     # "Third-Party Cookies Blocked" title is displayed in the subpanel


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025834](https://bugzilla.mozilla.org/show_bug.cgi?id=2025834)
TestRail: [3054909](https://mozilla.testrail.io/index.php?/cases/view/3054909)

### Description of Code / Doc Changes

* Add test to verify cross-site tracking cookies are correctly displayed in the sub panel

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
