### PR TITLE
Bug 1941642 - Use t-linux-2404-wayland-alpha worker-type

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -25,4 +25,4 @@ workers:
       provisioner: '{trust-domain}-t'
       implementation: generic-worker
       os: linux
-      worker-type: 't-linux-2404-wayland-relsre'
+      worker-type: 't-linux-2404-wayland-alpha'


### PR DESCRIPTION
## Summary

mozilla-releng/fxci-config#998 renames `t-linux-2404-wayland-relsre` to `t-linux-2404-wayland-alpha`. This PR updates the worker-type in `taskcluster/config.yml` so testing continues to work once that fxci-config change lands.

Targets `ben/general-pyautogui` so it merges directly into #1318.

## Test plan

- [ ] Merge after mozilla-releng/fxci-config#998 lands.
- [ ] Confirm tasks on #1318 schedule onto `mozilla-t/t-linux-2404-wayland-alpha`.