### PR TITLE
Hani/ Test etp panel displayed when protection off

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5130,3 +5130,24 @@ Description: Blocking tracker category title
 Location: Trustpanel - Blocking category view
 Path to .json: modules/data/trust_panel.components.json
 ```
+```
+Selector Name: trustpanel-toggle-parent
+Selector Data: "trustpanel-toggle"
+Description: Trust toggle button parent
+Location: Trustpanel
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: trustpanel-toggle-button
+Selector Data: "input"
+Description: Trustpanel toggle button
+Location: Trustpanel
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: trustpanel-etp-off
+Selector Data: "//*[@id='trustpanel-header' and text()='You turned off protections']"
+Description: Trust Panel ETP status
+Location: Trustpanel
+Path to .json: modules/data/trust_panel.components.json
+```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1195,6 +1195,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_etp_panel_displayed_when_protection_off:
+    result: pass
+    splits:
+    - functional2
   test_fingerprinters_blocked_and_shown_in_panel_and_preferences:
     result: pass
     splits:

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -175,3 +175,27 @@ class TrustPanel(BasePage):
         """Verify that the subpanel title for the blocked tracker category is visible."""
         self.element_visible("blocked-trackers-title", labels=[category.title()])
         return self
+
+    @BasePage.context_chrome
+    def trustpanel_toggle_on_off(self):
+        """Trust panel toggle button"""
+        self.js_click_on("trustpanel-toggle-button")
+        return self
+
+    @BasePage.context_chrome
+    def trustpanel_status(self, status: str):
+        """
+        Verify Trust Panel ETP status.
+        status: "on" | "off"
+        """
+
+        mapping = {
+            "on": "trustpanel-etp-on",
+            "off": "trustpanel-etp-off",
+        }
+
+        if status not in mapping:
+            raise ValueError("status must be 'on' or 'off'")
+
+        self.element_visible(mapping[status])
+        return self

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -114,5 +114,21 @@
         "selectorData": "panelview[title='{} Blocked']",
         "strategy": "css",
         "groups": []
+    },
+    "trustpanel-toggle-parent": {
+        "selectorData": "trustpanel-toggle",
+        "strategy": "id",
+        "groups": []
+    },
+    "trustpanel-toggle-button": {
+        "selectorData": "input",
+        "strategy": "id",
+        "groups": [],
+        "shadowParent": "trustpanel-toggle-parent"
+    },
+    "trustpanel-etp-off": {
+        "selectorData": "//*[@id='trustpanel-header' and text()='You turned off protections']",
+        "strategy": "xpath",
+        "groups": []
     }
 }

--- a/tests/security_and_privacy/test_etp_panel_displayed_when_protection_off.py
+++ b/tests/security_and_privacy/test_etp_panel_displayed_when_protection_off.py
@@ -1,0 +1,36 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TrustPanel
+from modules.page_object import AboutPrefs, GenericPage
+
+TEST_WEBSITE = "https://www.youtube.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054907"
+
+
+def test_etp_panel_displayed_when_protection_off(driver: Firefox):
+    """
+    C3054907 - The ETP panel is correctly displayed when protection if turned off
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    test_page = GenericPage(driver, url=TEST_WEBSITE)
+    trust_panel = TrustPanel(driver)
+
+    # Make sure that the "Standard" option is selected from the ETP section in about:preferences#privacy
+    about_prefs.open()
+    about_prefs.click_on("standard-radio")
+
+    # Click on the shield icon and turn off the Enhanced Tracking Protection
+    test_page.open()
+    trust_panel.open_panel()
+    trust_panel.trustpanel_toggle_on_off()
+    trust_panel.open_panel()
+
+    # The message "You turned off protections" is displayed inside the banner
+    trust_panel.trustpanel_status("off")

--- a/tests/security_and_privacy/test_etp_panel_displayed_when_protection_off.py
+++ b/tests/security_and_privacy/test_etp_panel_displayed_when_protection_off.py
@@ -4,7 +4,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object import TrustPanel
 from modules.page_object import AboutPrefs, GenericPage
 
-TEST_WEBSITE = "https://www.youtube.com/"
+YOUTUBE_URL = "https://www.youtube.com/"
 
 
 @pytest.fixture()
@@ -19,7 +19,7 @@ def test_etp_panel_displayed_when_protection_off(driver: Firefox):
 
     # Instantiate objects
     about_prefs = AboutPrefs(driver, category="privacy")
-    test_page = GenericPage(driver, url=TEST_WEBSITE)
+    test_page = GenericPage(driver, url=YOUTUBE_URL)
     trust_panel = TrustPanel(driver)
 
     # Make sure that the "Standard" option is selected from the ETP section in about:preferences#privacy


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025832](https://bugzilla.mozilla.org/show_bug.cgi?id=2025832)
TestRail: [3054907](https://mozilla.testrail.io/index.php?/cases/view/3054907)

### Description of Code / Doc Changes

* Add test to verify that ETP panel is correctly displayed when protection if turned off

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
