### PR TITLE
vs/add test for contextual menus in pdf forms

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -959,11 +959,15 @@ pdf_viewer:
     result: pass
     splits:
     - functional1
-  test_pdf_copy_paste_functionality_numerical:
+  test_pdf_contextual_menu_actions:
     result: pass
     splits:
     - functional1
   test_pdf_copy_paste_functionality:
+    result: pass
+    splits:
+    - functional1
+  test_pdf_copy_paste_functionality_numerical:
     result: pass
     splits:
     - functional1

--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -228,6 +228,16 @@
         "strategy": "id",
         "groups": []
     },
+    "context-menu-cut": {
+    "selectorData": "context-cut",
+    "strategy": "id",
+    "groups": []
+    },
+    "context-menu-delete-in-form": {
+    "selectorData": "context-delete",
+    "strategy": "id",
+    "groups": []
+    },
     "context-menu-suggest-strong-password": {
         "selectorData": "fill-login-generated-password",
         "strategy": "id",

--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -229,14 +229,14 @@
         "groups": []
     },
     "context-menu-cut": {
-    "selectorData": "context-cut",
-    "strategy": "id",
-    "groups": []
+        "selectorData": "context-cut",
+        "strategy": "id",
+        "groups": []
     },
     "context-menu-delete-in-form": {
-    "selectorData": "context-delete",
-    "strategy": "id",
-    "groups": []
+        "selectorData": "context-delete",
+        "strategy": "id",
+        "groups": []
     },
     "context-menu-suggest-strong-password": {
         "selectorData": "fill-login-generated-password",

--- a/tests/pdf_viewer/test_pdf_contextual_menu_actions.py
+++ b/tests/pdf_viewer/test_pdf_contextual_menu_actions.py
@@ -1,0 +1,103 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import ContextMenu
+from modules.page_object import GenericPdf
+from modules.util import Utilities
+
+PDF_FILE_NAME = "i-9.pdf"
+NUMERIC_TEXT = "12345"
+TEXT_FIELD = "first-name-field"
+NUMERIC_FIELD = "zipcode-field"
+
+
+@pytest.fixture()
+def test_case():
+    return "1017607"
+
+
+@pytest.fixture()
+def hard_quit():
+    return True
+
+
+@pytest.fixture()
+def file_name():
+    return PDF_FILE_NAME
+
+
+def test_pdf_context_menu_actions(driver: Firefox, pdf_viewer: GenericPdf):
+    """
+    C1017607: Verify that context menu actions apply to PDF form input fields
+    """
+    context_menu = ContextMenu(driver)
+    util = Utilities()
+    random_text = util.generate_random_text("word")
+
+    # Step 1: PDF form with text and numeric fields is opened by the pdf_viewer fixture.
+    pdf_viewer.element_visible(TEXT_FIELD)
+    pdf_viewer.element_visible(NUMERIC_FIELD)
+
+    # Step 2: Enter text in the text field.
+    pdf_viewer.fill(TEXT_FIELD, random_text, press_enter=False)
+    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", random_text)
+
+    # Step 3: Use the context menu copy and paste actions on the text field.
+    pdf_viewer.triple_click(TEXT_FIELD)
+    pdf_viewer.context_click(TEXT_FIELD)
+    context_menu.click_and_hide_menu("context-menu-copy")
+
+    pdf_viewer.get_element(TEXT_FIELD).clear()
+    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", "")
+
+    pdf_viewer.context_click(TEXT_FIELD)
+    context_menu.click_and_hide_menu("context-menu-paste")
+    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", random_text)
+
+    # Step 4: Use the context menu cut and paste actions on the text field.
+    pdf_viewer.triple_click(TEXT_FIELD)
+    pdf_viewer.context_click(TEXT_FIELD)
+    context_menu.click_and_hide_menu("context-menu-cut")
+    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", "")
+
+    pdf_viewer.context_click(TEXT_FIELD)
+    context_menu.click_and_hide_menu("context-menu-paste")
+    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", random_text)
+
+    # Step 5: Use the context menu delete action on the text field.
+    pdf_viewer.triple_click(TEXT_FIELD)
+    pdf_viewer.context_click(TEXT_FIELD)
+    context_menu.click_and_hide_menu("context-menu-delete-in-form")
+    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", "")
+
+    # Step 6: Enter numbers in the numeric field.
+    pdf_viewer.fill_element(NUMERIC_FIELD, NUMERIC_TEXT)
+    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", NUMERIC_TEXT)
+
+    # Step 7: Use the context menu copy and paste actions on the numeric field.
+    pdf_viewer.triple_click(NUMERIC_FIELD)
+    pdf_viewer.context_click(NUMERIC_FIELD)
+    context_menu.click_and_hide_menu("context-menu-copy")
+
+    pdf_viewer.get_element(NUMERIC_FIELD).clear()
+    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", "")
+
+    pdf_viewer.context_click(NUMERIC_FIELD)
+    context_menu.click_and_hide_menu("context-menu-paste")
+    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", NUMERIC_TEXT)
+
+    # Step 8: Use the context menu cut and paste actions on the numeric field.
+    pdf_viewer.triple_click(NUMERIC_FIELD)
+    pdf_viewer.context_click(NUMERIC_FIELD)
+    context_menu.click_and_hide_menu("context-menu-cut")
+    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", "")
+
+    pdf_viewer.context_click(NUMERIC_FIELD)
+    context_menu.click_and_hide_menu("context-menu-paste")
+    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", NUMERIC_TEXT)
+
+    # Step 9: Use the context menu delete action on the numeric field.
+    pdf_viewer.triple_click(NUMERIC_FIELD)
+    pdf_viewer.context_click(NUMERIC_FIELD)
+    context_menu.click_and_hide_menu("context-menu-delete-in-form")
+    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", "")

--- a/tests/pdf_viewer/test_pdf_contextual_menu_actions.py
+++ b/tests/pdf_viewer/test_pdf_contextual_menu_actions.py
@@ -26,7 +26,45 @@ def file_name():
     return PDF_FILE_NAME
 
 
-def test_pdf_context_menu_actions(driver: Firefox, pdf_viewer: GenericPdf):
+def _verify_context_menu_actions(
+    pdf_viewer: GenericPdf,
+    context_menu: ContextMenu,
+    field: str,
+    value: str,
+):
+    pdf_viewer.fill(field, value, press_enter=False)
+    pdf_viewer.element_attribute_is(field, "value", value)
+
+    # Verify context menu copy and paste.
+    pdf_viewer.triple_click(field)
+    pdf_viewer.context_click(field)
+    context_menu.click_and_hide_menu("context-menu-copy")
+
+    pdf_viewer.get_element(field).clear()
+    pdf_viewer.element_attribute_is(field, "value", "")
+
+    pdf_viewer.context_click(field)
+    context_menu.click_and_hide_menu("context-menu-paste")
+    pdf_viewer.element_attribute_is(field, "value", value)
+
+    # Verify context menu cut and paste.
+    pdf_viewer.triple_click(field)
+    pdf_viewer.context_click(field)
+    context_menu.click_and_hide_menu("context-menu-cut")
+    pdf_viewer.element_attribute_is(field, "value", "")
+
+    pdf_viewer.context_click(field)
+    context_menu.click_and_hide_menu("context-menu-paste")
+    pdf_viewer.element_attribute_is(field, "value", value)
+
+    # Verify context menu delete.
+    pdf_viewer.triple_click(field)
+    pdf_viewer.context_click(field)
+    context_menu.click_and_hide_menu("context-menu-delete-in-form")
+    pdf_viewer.element_attribute_is(field, "value", "")
+
+
+def test_pdf_contextual_menu_actions(driver: Firefox, pdf_viewer: GenericPdf):
     """
     C1017607: Verify that context menu actions apply to PDF form input fields
     """
@@ -38,66 +76,6 @@ def test_pdf_context_menu_actions(driver: Firefox, pdf_viewer: GenericPdf):
     pdf_viewer.element_visible(TEXT_FIELD)
     pdf_viewer.element_visible(NUMERIC_FIELD)
 
-    # Step 2: Enter text in the text field.
-    pdf_viewer.fill(TEXT_FIELD, random_text, press_enter=False)
-    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", random_text)
-
-    # Step 3: Use the context menu copy and paste actions on the text field.
-    pdf_viewer.triple_click(TEXT_FIELD)
-    pdf_viewer.context_click(TEXT_FIELD)
-    context_menu.click_and_hide_menu("context-menu-copy")
-
-    pdf_viewer.get_element(TEXT_FIELD).clear()
-    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", "")
-
-    pdf_viewer.context_click(TEXT_FIELD)
-    context_menu.click_and_hide_menu("context-menu-paste")
-    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", random_text)
-
-    # Step 4: Use the context menu cut and paste actions on the text field.
-    pdf_viewer.triple_click(TEXT_FIELD)
-    pdf_viewer.context_click(TEXT_FIELD)
-    context_menu.click_and_hide_menu("context-menu-cut")
-    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", "")
-
-    pdf_viewer.context_click(TEXT_FIELD)
-    context_menu.click_and_hide_menu("context-menu-paste")
-    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", random_text)
-
-    # Step 5: Use the context menu delete action on the text field.
-    pdf_viewer.triple_click(TEXT_FIELD)
-    pdf_viewer.context_click(TEXT_FIELD)
-    context_menu.click_and_hide_menu("context-menu-delete-in-form")
-    pdf_viewer.element_attribute_is(TEXT_FIELD, "value", "")
-
-    # Step 6: Enter numbers in the numeric field.
-    pdf_viewer.fill_element(NUMERIC_FIELD, NUMERIC_TEXT)
-    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", NUMERIC_TEXT)
-
-    # Step 7: Use the context menu copy and paste actions on the numeric field.
-    pdf_viewer.triple_click(NUMERIC_FIELD)
-    pdf_viewer.context_click(NUMERIC_FIELD)
-    context_menu.click_and_hide_menu("context-menu-copy")
-
-    pdf_viewer.get_element(NUMERIC_FIELD).clear()
-    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", "")
-
-    pdf_viewer.context_click(NUMERIC_FIELD)
-    context_menu.click_and_hide_menu("context-menu-paste")
-    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", NUMERIC_TEXT)
-
-    # Step 8: Use the context menu cut and paste actions on the numeric field.
-    pdf_viewer.triple_click(NUMERIC_FIELD)
-    pdf_viewer.context_click(NUMERIC_FIELD)
-    context_menu.click_and_hide_menu("context-menu-cut")
-    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", "")
-
-    pdf_viewer.context_click(NUMERIC_FIELD)
-    context_menu.click_and_hide_menu("context-menu-paste")
-    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", NUMERIC_TEXT)
-
-    # Step 9: Use the context menu delete action on the numeric field.
-    pdf_viewer.triple_click(NUMERIC_FIELD)
-    pdf_viewer.context_click(NUMERIC_FIELD)
-    context_menu.click_and_hide_menu("context-menu-delete-in-form")
-    pdf_viewer.element_attribute_is(NUMERIC_FIELD, "value", "")
+    # Step 2: Enter text and numbers in both text and numeric fields.
+    _verify_context_menu_actions(pdf_viewer, context_menu, TEXT_FIELD, random_text)
+    _verify_context_menu_actions(pdf_viewer, context_menu, NUMERIC_FIELD, NUMERIC_TEXT)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009698](https://bugzilla.mozilla.org/show_bug.cgi?id=2009698)
TestRail: [1017607](https://mozilla.testrail.io/index.php?/cases/view/1017607)

### Description of Code / Doc Changes

Add a test for checking the contextual menus action inside the pdf forms. 
Add 2 objects for CUT and DELETE. 

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations


Thank you!
