### PR TITLE
Anca/ Add cloudflare as default doh provider test

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -81,6 +81,13 @@ Description: Text entry field when editing a str value of a config
 Location: Line item config in about:config page
 Path to .json: modules/data/about_config.components.json
 ```
+```
+Selector Name: pref-cell-value
+Selector Data: "td.cell-value"
+Description: The cell displaying the current value of a preference
+Location: Line item config in about:config page
+Path to .json: modules/data/about_config.components.json
+```
 #### about_downloads
 ```
 Selector Name: no-downloads-label
@@ -1319,6 +1326,41 @@ Selector Name: doh-resolver
 Selector Data: "dohResolver"
 Description: The name of the DoH provider
 Location: Inside the first frame of the DoH section in about:preferences#general
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-default-radio
+Selector Data: "dohDefaultRadio"
+Description: Radio button for Default Protection DoH mode
+Location: about:preferences#privacy - DNS over HTTPS section
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-increased-protection-radio
+Selector Data: "dohEnabledRadio"
+Description: Radio button for Increased Protection DoH mode
+Location: about:preferences#privacy - DNS over HTTPS section
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-max-protection-radio
+Selector Data: "dohStrictRadio"
+Description: Radio button for Max Protection DoH mode
+Location: about:preferences#privacy - DNS over HTTPS section
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-off-radio
+Selector Data: "dohOffRadio"
+Description: Radio button to turn DoH off
+Location: about:preferences#privacy - DNS over HTTPS section
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-enabled-resolver
+Selector Data: "dohEnabledResolverChoices"
+Description: Provider dropdown for the Increased Protection DoH mode
+Location: about:preferences#privacy - DNS over HTTPS section
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -655,6 +655,10 @@ meta:
     result: pass
     splits: []
 networking:
+  test_cloudflare_as_default_doh_provider:
+    result: pass
+    splits:
+    - functional1
   test_default_dns_protection:
     result:
       linux: pass
@@ -959,11 +963,11 @@ pdf_viewer:
     result: pass
     splits:
     - functional1
-  test_pdf_copy_paste_functionality_numerical:
+  test_pdf_copy_paste_functionality:
     result: pass
     splits:
     - functional1
-  test_pdf_copy_paste_functionality:
+  test_pdf_copy_paste_functionality_numerical:
     result: pass
     splits:
     - functional1

--- a/modules/data/about_config.components.json
+++ b/modules/data/about_config.components.json
@@ -16,6 +16,11 @@
         "strategy": "class",
         "groups": []
     },
+    "pref-cell-value": {
+        "selectorData": "td.cell-value",
+        "strategy": "css",
+        "groups": []
+    },
     "value-edit-field": {
         "selectorData": "#form-edit > input:nth-child(1)",
         "strategy": "css",

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -642,6 +642,31 @@
     "strategy": "id",
     "groups": []
   },
+  "doh-default-radio": {
+    "selectorData": "dohDefaultRadio",
+    "strategy": "id",
+    "groups": []
+  },
+  "doh-increased-protection-radio": {
+    "selectorData": "dohEnabledRadio",
+    "strategy": "id",
+    "groups": []
+  },
+  "doh-max-protection-radio": {
+    "selectorData": "dohStrictRadio",
+    "strategy": "id",
+    "groups": []
+  },
+  "doh-off-radio": {
+    "selectorData": "dohOffRadio",
+    "strategy": "id",
+    "groups": []
+  },
+  "doh-enabled-resolver": {
+    "selectorData": "dohEnabledResolverChoices",
+    "strategy": "id",
+    "groups": []
+  },
   "mlb-allow-audio-video-settings": {
     "selectorData": "richlistitem[origin='https://www.mlb.com'] menulist[label='Allow Audio and Video']",
     "strategy": "css",

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -92,7 +92,7 @@ class AboutConfig(BasePage):
     def get_pref_value(self, term: str):
         """Return the current value string for a preference from about:config."""
         self.search_pref(term)
-        return self.get_element("pref-cell-value").text
+        return self.get_element("pref-cell-value").text.strip()
 
     def toggle_config_value(self, term: str, value) -> BasePage:
         """

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -89,6 +89,11 @@ class AboutConfig(BasePage):
         pref_edit_button.click()
         return self
 
+    def get_pref_value(self, term: str):
+        """Return the current value string for a preference from about:config."""
+        self.search_pref(term)
+        return self.get_element("pref-cell-value").text
+
     def toggle_config_value(self, term: str, value) -> BasePage:
         """
         Main method to toggle a config's value in about:config

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -68,6 +68,13 @@ class AboutPrefs(BasePage):
 
     HTTPS_ONLY_STATUS = HttpsOnlyStatus()
 
+    DOH_RADIO_IDS = {
+        "default-protection": "doh-default-radio",
+        "increased-protection": "doh-increased-protection-radio",
+        "max-protection": "doh-max-protection-radio",
+        "off": "doh-off-radio",
+    }
+
     # Function Organization
     # Search and Settings
 
@@ -216,6 +223,14 @@ class AboutPrefs(BasePage):
         )
 
         self.get_element("language-settings-ok").click()
+        return self
+
+    def select_doh_protection_level(self, level: str) -> BasePage:
+        """
+        Select a DNS over HTTPS protection level in about:preferences#privacy.
+        level: 'default-protection' | 'increased-protection' | 'max-protection' | 'off'
+        """
+        self.click_on(self.DOH_RADIO_IDS[level])
         return self
 
     def select_https_only_setting(self, option_id: HttpsOnlyStatus) -> BasePage:

--- a/tests/networking/test_cloudflare_as_default_doh_provider.py
+++ b/tests/networking/test_cloudflare_as_default_doh_provider.py
@@ -1,0 +1,38 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutConfig, AboutPrefs
+
+CLOUDFLARE_URL = "https://mozilla.cloudflare-dns.com/dns-query"
+TRR_PREF = "network.trr.default_provider_uri"
+
+
+@pytest.fixture()
+def test_case():
+    return "545741"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("browser.search.region", "US"),
+        ("browser.aboutConfig.showWarning", False),
+    ]
+
+
+def test_cloudflare_default_doh_provider(driver: Firefox):
+    """
+    C545741 - Verify that Cloudflare set as default DoH provider
+    """
+    # Instantiate objects
+    prefs = AboutPrefs(driver, category="privacy")
+    about_config = AboutConfig(driver)
+
+    # Select Increased Protection in about:preferences#privacy
+    prefs.open()
+    prefs.select_doh_protection_level("increased-protection")
+    prefs.element_has_attribute("doh-increased-protection-radio", "selected")
+    prefs.element_attribute_is("doh-enabled-resolver", "label", "Cloudflare (Default)")
+
+    # Verify network.trr.default_provider_uri in about:config
+    assert about_config.get_pref_value(TRR_PREF) == CLOUDFLARE_URL

--- a/tests/networking/test_cloudflare_as_default_doh_provider.py
+++ b/tests/networking/test_cloudflare_as_default_doh_provider.py
@@ -31,7 +31,7 @@ def test_cloudflare_default_doh_provider(driver: Firefox):
     # Select Increased Protection in about:preferences#privacy
     prefs.open()
     prefs.select_doh_protection_level("increased-protection")
-    prefs.element_has_attribute("doh-increased-protection-radio", "selected")
+    prefs.element_attribute_is("doh-increased-protection-radio", "selected", "true")
     prefs.element_attribute_is("doh-enabled-resolver", "label", "Cloudflare (Default)")
 
     # Verify network.trr.default_provider_uri in about:config


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2011140](https://bugzilla.mozilla.org/show_bug.cgi?id=2011140)
TestRail: [545741](https://mozilla.testrail.io/index.php?/cases/view/545741)

### Description of Code / Doc Changes
- Add cloudflare as default doh provider test
- Add 2 new methods and locators that we'll be used in networking further tests

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
