### PR TITLE
Hani/ Test etp panel disaplayed when no trackers detected

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1203,6 +1203,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_etp_panel_displayed_when_no_trackers_detected:
+    result: pass
+    splits:
+    - functional2
   test_etp_panel_displayed_when_protection_off:
     result: pass
     splits:

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -130,5 +130,10 @@
         "selectorData": "//*[@id='trustpanel-header' and text()='You turned off protections']",
         "strategy": "xpath",
         "groups": []
+    },
+    "trustpanel-etp-on": {
+        "selectorData": "//*[@id='trustpanel-header' and text()='Firefox is on guard']",
+        "strategy": "xpath",
+        "groups": []
     }
 }

--- a/tests/security_and_privacy/test_etp_panel_displayed_when_no_trackers_detected.py
+++ b/tests/security_and_privacy/test_etp_panel_displayed_when_no_trackers_detected.py
@@ -1,0 +1,34 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TrustPanel
+from modules.page_object import AboutPrefs, GenericPage
+
+YOUTUBE_URL = "https://www.youtube.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054904"
+
+
+def test_etp_panel_displayed_when_no_trackers_detected(driver: Firefox):
+    """
+    C3054904 - The ETP panel is correctly displayed when no trackers are detected
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    test_page = GenericPage(driver, url=YOUTUBE_URL)
+    trust_panel = TrustPanel(driver)
+
+    # Make sure that the "Standard" option is selected from the ETP section in about:preferences#privacy
+    about_prefs.open()
+    about_prefs.click_on("standard-radio")
+
+    # Click on the shield icon
+    test_page.open()
+    trust_panel.open_panel()
+
+    # The Tracking Protection Panel is correctly displayed
+    trust_panel.trustpanel_status("on")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025829](https://bugzilla.mozilla.org/show_bug.cgi?id=2025829)
TestRail: [3054904](https://mozilla.testrail.io/index.php?/cases/view/3054904)

### Description of Code / Doc Changes

* Add test to verify that ETP panel is correctly displayed when no trackers are detected

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
