### PR TITLE
Hani/ Test secure domain certificate messaging panel

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5193,3 +5193,10 @@ Description: Trust Panel ETP status
 Location: Trustpanel
 Path to .json: modules/data/trust_panel.components.json
 ```
+```
+Selector Name: connection-secure
+Selector Data: "//*[@class='identity-popup-connection-secure security-view' and text()='You are securely connected to this site.']"
+Description: 'You are securely connected to this site.' message is displayed in the connection subpanel
+Location: Trustpanel - Connection protections tab
+Path to .json: modules/data/trust_panel.components.json
+```

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5208,9 +5208,16 @@ Location: Trustpanel - Connection protections tab
 Path to .json: modules/data/trust_panel.components.json
 ```
 ```
-Selector Name: connection-subvie
+Selector Name: connection-subview
 Selector Data: "Selector Data: .identity-popup-security-connection.identity-popup-section"
 Description: Connection subview panel
 Location: Trustpanel - Connection panel
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: trustpanel-connection-button
+Selector Data: trustpanel-connection-label
+Description: Trustpanel connection security button
+Location: trustpanel main top right
 Path to .json: modules/data/trust_panel.components.json
 ```

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5207,3 +5207,10 @@ Description: 'You are securely connected to this site.' message is displayed in 
 Location: Trustpanel - Connection protections tab
 Path to .json: modules/data/trust_panel.components.json
 ```
+```
+Selector Name: connection-subvie
+Selector Data: "panel-subview-body"
+Description: Connection subview panel
+Location: Trustpanel - Connection panel
+Path to .json: modules/data/trust_panel.components.json
+```

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5209,7 +5209,7 @@ Path to .json: modules/data/trust_panel.components.json
 ```
 ```
 Selector Name: connection-subview
-Selector Data: "Selector Data: .identity-popup-security-connection.identity-popup-section"
+Selector Data: ".identity-popup-security-connection.identity-popup-section"
 Description: Connection subview panel
 Location: Trustpanel - Connection panel
 Path to .json: modules/data/trust_panel.components.json

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5202,7 +5202,7 @@ Path to .json: modules/data/trust_panel.components.json
 ```
 ```
 Selector Name: connection-secure
-Selector Data: "//*[@class='identity-popup-connection-secure security-view' and text()='You are securely connected to this site.']"
+Selector Data: "identity-connection-verified"
 Description: 'You are securely connected to this site.' message is displayed in the connection subpanel
 Location: Trustpanel - Connection protections tab
 Path to .json: modules/data/trust_panel.components.json

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5209,7 +5209,7 @@ Path to .json: modules/data/trust_panel.components.json
 ```
 ```
 Selector Name: connection-subvie
-Selector Data: "panel-subview-body"
+Selector Data: "Selector Data: .identity-popup-security-connection.identity-popup-section"
 Description: Connection subview panel
 Location: Trustpanel - Connection panel
 Path to .json: modules/data/trust_panel.components.json

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1275,6 +1275,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_secure_domain_certificate_messaging_panel:
+    result: pass
+    splits:
+    - functional2
   test_sidebar_removed_on_end_private_session:
     result: pass
     splits:

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -203,13 +203,13 @@ class TrustPanel(BasePage):
     @BasePage.context_chrome
     def click_connection_button(self):
         """Click the connection section button from the Trust Panel."""
-        self.click_on("trustpanel-connection-button")
+        self.click_on("trustpanel-connect-button")
         return self
 
     @BasePage.context_chrome
     def connection_secure_message_displayed(self):
         """
-        Verify the 'You are not securely connected to this site.'
+        Verify the 'You are securely connected to this site.'
         message is displayed in the connection subpanel.
         """
         self.element_visible("connection-secure")

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -2,6 +2,7 @@ import json
 import logging
 from time import sleep
 
+from selenium.common import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
@@ -203,7 +204,14 @@ class TrustPanel(BasePage):
     @BasePage.context_chrome
     def click_connection_button(self):
         """Click the connection section button from the Trust Panel."""
+        self.element_visible("trustpanel-connect-button")
         self.click_on("trustpanel-connect-button")
+        # Wait for the subview to actually render
+        try:
+            self.element_visible("connection-subview")
+        except TimeoutException:
+            # Retry click
+            self.click_on("trustpanel-connect-button")
         return self
 
     @BasePage.context_chrome

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -204,14 +204,14 @@ class TrustPanel(BasePage):
     @BasePage.context_chrome
     def click_connection_button(self):
         """Click the connection section button from the Trust Panel."""
-        self.element_visible("trustpanel-connect-button")
-        self.click_on("trustpanel-connect-button")
+        self.element_visible("trustpanel-connection-button")
+        self.click_on("trustpanel-connection-button")
         # Wait for the subview to actually render
         try:
             self.element_visible("connection-subview")
         except TimeoutException:
             # Retry click
-            self.click_on("trustpanel-connect-button")
+            self.click_on("trustpanel-connection-button")
         return self
 
     @BasePage.context_chrome

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -199,3 +199,18 @@ class TrustPanel(BasePage):
 
         self.element_visible(mapping[status])
         return self
+
+    @BasePage.context_chrome
+    def click_connection_button(self):
+        """Click the connection section button from the Trust Panel."""
+        self.click_on("trustpanel-connection-button")
+        return self
+
+    @BasePage.context_chrome
+    def connection_secure_message_displayed(self):
+        """
+        Verify the 'You are not securely connected to this site.'
+        message is displayed in the connection subpanel.
+        """
+        self.element_visible("connection-secure")
+        return self

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -140,5 +140,10 @@
         "selectorData": "//*[@class='identity-popup-connection-secure security-view' and text()='You are securely connected to this site.']",
         "strategy": "xpath",
         "groups": []
+    },
+    "connection-subview": {
+        "selectorData": "panel-subview-body",
+        "strategy": "css",
+        "groups": []
     }
 }

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -130,5 +130,15 @@
         "selectorData": "//*[@id='trustpanel-header' and text()='You turned off protections']",
         "strategy": "xpath",
         "groups": []
+    },
+    "trustpanel-connection-button": {
+        "selectorData": "trustpanel-connection-label",
+        "strategy": "id",
+        "groups": []
+    },
+    "connection-secure": {
+        "selectorData": "//*[@class='identity-popup-connection-secure security-view' and text()='You are securely connected to this site.']",
+        "strategy": "xpath",
+        "groups": []
     }
 }

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -136,11 +136,6 @@
         "strategy": "xpath",
         "groups": []
     },
-    "trustpanel-connection-button": {
-        "selectorData": "trustpanel-connection-label",
-        "strategy": "id",
-        "groups": []
-    },
     "connection-secure": {
         "selectorData": "//*[@class='identity-popup-connection-secure security-view' and text()='You are securely connected to this site.']",
         "strategy": "xpath",

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -137,8 +137,8 @@
         "groups": []
     },
     "connection-secure": {
-        "selectorData": "//*[@class='identity-popup-connection-secure security-view' and text()='You are securely connected to this site.']",
-        "strategy": "xpath",
+        "selectorData": "[data-l10n-id='identity-connection-verified']",
+        "strategy": "css",
         "groups": []
     },
     "connection-subview": {

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -145,5 +145,10 @@
         "selectorData": ".identity-popup-security-connection.identity-popup-section",
         "strategy": "css",
         "groups": []
+    },
+    "trustpanel-connection-button": {
+        "selectorData": "trustpanel-connection-label",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -142,7 +142,7 @@
         "groups": []
     },
     "connection-subview": {
-        "selectorData": "panel-subview-body",
+        "selectorData": ".identity-popup-security-connection.identity-popup-section",
         "strategy": "css",
         "groups": []
     }

--- a/tests/security_and_privacy/test_secure_domain_certificate_messaging_panel.py
+++ b/tests/security_and_privacy/test_secure_domain_certificate_messaging_panel.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 import pytest
 from selenium.webdriver import Firefox
 

--- a/tests/security_and_privacy/test_secure_domain_certificate_messaging_panel.py
+++ b/tests/security_and_privacy/test_secure_domain_certificate_messaging_panel.py
@@ -1,0 +1,32 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_trust_panel import TrustPanel
+from modules.page_object_generics import GenericPage
+
+YOUTUBE_URL = "https://youtube.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054041"
+
+
+def test_secure_domain_certificate_messaging_panel(driver: Firefox):
+    """
+    C3054041 - Secure Domain Validate certificate messaging is correctly displayed in the panel
+    """
+
+    # Instantiate objects
+    test_page = GenericPage(driver, url=YOUTUBE_URL)
+    trust_panel = TrustPanel(driver)
+
+    # Open test page and click on the shield icon
+    test_page.open()
+    trust_panel.open_panel()
+
+    # Click the lock text row (or dedicated “Connection secure” arrow)
+    trust_panel.click_connection_button()
+
+    # The text is displayed: “You are securely connected to this site” plus “Verified by: GlobalSign nv-sa”
+    trust_panel.connection_secure_message_displayed()

--- a/tests/security_and_privacy/test_secure_domain_certificate_messaging_panel.py
+++ b/tests/security_and_privacy/test_secure_domain_certificate_messaging_panel.py
@@ -1,8 +1,10 @@
+from time import sleep
+
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_trust_panel import TrustPanel
-from modules.page_object_generics import GenericPage
+from modules.browser_object import TrustPanel
+from modules.page_object import GenericPage
 
 YOUTUBE_URL = "https://youtube.com/"
 
@@ -28,5 +30,5 @@ def test_secure_domain_certificate_messaging_panel(driver: Firefox):
     # Click the lock text row (or dedicated “Connection secure” arrow)
     trust_panel.click_connection_button()
 
-    # The text is displayed: “You are securely connected to this site” plus “Verified by: GlobalSign nv-sa”
+    # The text is displayed: “You are securely connected to this site”
     trust_panel.connection_secure_message_displayed()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025824](https://bugzilla.mozilla.org/show_bug.cgi?id=2025824)
TestRail: [3054041](https://mozilla.testrail.io/index.php?/cases/view/3054041)

### Description of Code / Doc Changes

* Add test to verify that Secure Domain Validate certificate messaging is correctly displayed in the panel

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
