### PR TITLE
Make claude review optional

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   claude-code-review:
-    if: github.event.pull_request.draft == false
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-claude-review')
 
     concurrency:
       group: claude-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Description of Code / Doc Changes

- Make Claude code review optional (per request from Ben and team members)

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [x] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

 A label is created called "skip-claude-review", once added to a PR, then claude code review will be opted out:
 
   - Default: do nothing — Claude reviews every non-draft PR, same as today.
  - To silence Claude on a specific PR: add the skip-claude-review label (right sidebar of the PR page, "Labels" section).
  - The label must be added before the triggering event (PR open, new push, reopen, ready-for-review). Adding it later won't stop an already-running or already-completed review — but the next push to the PR will respect it.


### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
