### PR TITLE
only run glean when glean is changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,6 +206,7 @@ jobs:
           git fetch origin main --depth 1
           $origin = (git merge-base origin/main HEAD)
           $gitdiff = (git --no-pager diff --name-only $origin) -join "`n"
+          Write-Host $gitdiff
           if ($gitdiff -notmatch "/glean/") {"SKIP_GLEAN=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append}
 
       - name: Run Telemetry Tests in Win
@@ -371,7 +372,9 @@ jobs:
         run: |
           git fetch origin main --depth 1
           export ORIGIN=$(git merge-base origin/main HEAD)
-          if ! [[ $(git --no-pager diff --name-only $ORIGIN) =~ "/glean/" ]]; then echo "SKIP_GLEAN=true" >> $GITHUB_ENV; fi
+          export DIFF=$(git --no-pager diff --name-only $ORIGIN)
+          echo "${DIFF}"
+          if ! [[ "${DIFF}" =~ "/glean/" ]]; then echo "SKIP_GLEAN=true" >> $GITHUB_ENV; fi
 
       - name: Run Telemetry Tests in MacOS
         if: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,6 @@ jobs:
           }}
         shell: pwsh
         run: |
-          git fetch origin main --depth 1
           $origin = (git merge-base origin/main HEAD)
           $gitdiff = (git --no-pager diff --name-only $origin) -join "`n"
           Write-Host $gitdiff
@@ -264,6 +263,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Dry-run notice
         if: ${{ inputs.dry_run == true }}
@@ -372,7 +373,6 @@ jobs:
             inputs.is_pull_request == true
           }}
         run: |
-          git fetch origin main --depth 1
           export ORIGIN=$(git merge-base origin/main HEAD)
           export DIFF=$(git --no-pager diff --name-only $ORIGIN)
           echo "${DIFF}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Dry-run notice
         if: ${{ inputs.dry_run == true }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,6 +194,20 @@ jobs:
           mv artifacts artifacts-win || true
           exit $env:TEST_EXIT_CODE
 
+      - name: Skip Telemetry for most PRs
+        if: |
+          ${{
+            steps.setup.conclusion == 'success' &&
+            inputs.dry_run != true &&
+            inputs.is_pull_request == true
+          }}
+        shell: pwsh
+        run: |
+          git fetch origin main --depth 1
+          $origin = (git merge-base origin/main HEAD)
+          $gitdiff = (git --no-pager diff --name-only $origin) -join "`n"
+          if ($gitdiff -notmatch "/glean/") {"SKIP_GLEAN=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append}
+
       - name: Run Telemetry Tests in Win
         if: |
           ${{
@@ -203,7 +217,7 @@ jobs:
         shell: pwsh
         run: |
           $split = if ($env:STARFOX_SPLIT) { $env:STARFOX_SPLIT } else { "smoke" }
-          if ($split -ne "smoke") {exit 0}
+          if ($split -ne "smoke" -or $env:SKIP_GLEAN -eq "true") {exit 0}
           pipenv run pytest tests/glean --geckodriver=geckodriver.exe
           $env:TEST_EXIT_CODE = $LASTEXITCODE
           mv artifacts artifacts-win || true
@@ -347,6 +361,18 @@ jobs:
           mv artifacts artifacts-mac || true
           exit $TEST_EXIT_CODE
 
+      - name: Skip Telemetry for most PRs
+        if: |
+          ${{
+            steps.setup.conclusion == 'success' &&
+            inputs.dry_run != true &&
+            inputs.is_pull_request == true
+          }}
+        run: |
+          git fetch origin main --depth 1
+          export ORIGIN=$(git merge-base origin/main HEAD)
+          if ! [[ $(git --no-pager diff --name-only $ORIGIN) =~ "/glean/" ]]; then echo "SKIP_GLEAN=true" >> $GITHUB_ENV; fi
+
       - name: Run Telemetry Tests in MacOS
         if: |
           ${{
@@ -358,7 +384,7 @@ jobs:
         run: |
           "$FX_EXECUTABLE" --version
           split="${STARFOX_SPLIT:-smoke}"
-          if ! [[ $split = "smoke" ]]; then exit 0; fi
+          if [[ $split != "smoke" || $SKIP_GLEAN = "true" ]]; then exit 0; fi
           pipenv run pytest --fx-executable="$FX_EXECUTABLE" tests/glean || TEST_EXIT_CODE=$?
           mv artifacts artifacts-mac || true
           exit $TEST_EXIT_CODE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -258,7 +258,7 @@ jobs:
 
   Test-MacOS:
     if: ${{ inputs.job_to_run == 'Test-MacOS' || inputs.mac_installer_link }}
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Checkout repository

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1494,16 +1494,16 @@ tabs:
     splits:
     - functional2
   test_close_pinned_tab_via_mouse:
-    result: pass
-    splits:
-    - smoke
-    - ci
-  test_close_tab_through_middle_mouse_click:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2041834
     result:
       linux: pass
       mac: unstable
       win: pass
+    splits:
+    - smoke
+    - ci
+  test_close_tab_through_middle_mouse_click:
+    result: pass
     splits:
     - functional2
   test_display_customize_button:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -488,8 +488,7 @@ drag_and_drop:
     splits:
     - functional1
   test_paste_image_text:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2034562 (Win), https://bugzilla.mozilla.org/show_bug.cgi?id=2041389
-      (All)
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2034562 (Win), https://bugzilla.mozilla.org/show_bug.cgi?id=2041389 (All)
     result: unstable
     splits:
     - functional1

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1497,7 +1497,7 @@ tabs:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2041834
     result:
       linux: pass
-      mac: unstable
+      mac: pass
       win: pass
     splits:
     - smoke

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1501,9 +1501,9 @@ tabs:
   test_close_tab_through_middle_mouse_click:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2041834
     result:
+      linux: pass
       mac: unstable
       win: pass
-      linux: pass
     splits:
     - functional2
   test_display_customize_button:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1499,7 +1499,11 @@ tabs:
     - smoke
     - ci
   test_close_tab_through_middle_mouse_click:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2041834
+    result:
+      mac: unstable
+      win: pass
+      linux: pass
     splits:
     - functional2
   test_display_customize_button:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -488,7 +488,8 @@ drag_and_drop:
     splits:
     - functional1
   test_paste_image_text:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2034562 (Win), https://bugzilla.mozilla.org/show_bug.cgi?id=2041389 (All)
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2034562 (Win), https://bugzilla.mozilla.org/show_bug.cgi?id=2041389
+      (All)
     result: unstable
     splits:
     - functional1

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -37,7 +37,7 @@ tasks:
         pipenv run python -m scripts.choose_test_split;
         pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
         export FAILURE=${?};
-        git fetch origin main --depth 1
+        git fetch origin main --depth 2
         export ORIGIN=$(git merge-base origin/main HEAD)
         export GIT_DIFF=$(git --no-pager diff --name-only $ORIGIN)
         if [[ $GIT_DIFF =~ "/glean/" ]]; then pipenv run pytest --fx-executable ./firefox/firefox tests/glean; export FAILURE=$((FAILURE | ${?})); fi;

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -37,8 +37,10 @@ tasks:
         pipenv run python -m scripts.choose_test_split;
         pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
         export FAILURE=${?};
-        pipenv run pytest --fx-executable ./firefox/firefox tests/glean;
-        export FAILURE=$((FAILURE | ${?}));
+        git fetch origin main --depth 1
+        export ORIGIN=$(git merge-base origin/main HEAD)
+        export GIT_DIFF=$(git --no-pager diff --name-only $ORIGIN)
+        if [[ $GIT_DIFF =~ "/glean/" ]]; then pipenv run pytest --fx-executable ./firefox/firefox tests/glean; export FAILURE=$((FAILURE | ${?})); fi;
         mv ./config/ci_pyproject_headed.toml ./pyproject.toml;
         pipenv run python -m scripts.choose_test_split;
         pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);

--- a/tests/glean/conftest.py
+++ b/tests/glean/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+# bump
 @pytest.fixture()
 def suite_id():
     return "S70197", "Glean Telemetry"

--- a/tests/glean/conftest.py
+++ b/tests/glean/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-# bump
 @pytest.fixture()
 def suite_id():
     return "S70197", "Glean Telemetry"


### PR DESCRIPTION
### Relevant Links

Bugzilla: 

### Description of Code / Doc Changes

* Given: we are in PR
  * When: glean tests have been changed
    * Then: run glean tests
  * When: glean tests have not been changed
    * Then: do not run glean tests

This is accomplished by comparing against the git diff and setting an env var (in GHA) or just using `if/then` (in TC)

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes CI flow

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
