### PR TITLE
Hani/ Mark test_serp_impression unstable on mac

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -603,7 +603,7 @@ geolocation:
     - functional1
 glean:
   test_serp_impression:
-    comment:
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2042155
     result:
       linux: pass
       mac: unstable

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -603,7 +603,11 @@ geolocation:
     - functional1
 glean:
   test_serp_impression:
-    result: pass
+    comment:
+    result:
+      linux: pass
+      mac: unstable
+      win: pass
     splits:
     - glean
 language_packs:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2042155](https://bugzilla.mozilla.org/show_bug.cgi?id=2042155)

### Description of Code / Doc Changes

* Mark tests/glean/serp_impression/test_serp_impression.py unstable on mac

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
