### PR TITLE
Hani/ Test privacy settings footer link opens correct page

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5263,3 +5263,10 @@ Description: 'You are securely connected to this site.' message is displayed in 
 Location: Trustpanel - Connection protections tab
 Path to .json: modules/data/trust_panel.components.json
 ```
+```
+Selector Name: trustpanel-privacy-link
+Selector Data: "#trustpanel-privacy-link"
+Description: "Privacy Settings" footer link in the Trust Panel
+Location: Trust Panel > footer section
+Path to .json: modules/data/trust_panel.components.json
+```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1280,6 +1280,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_privacy_settings_footer_link_opens_correct_page:
+    result: pass
+    splits:
+    - functional2
   test_private_browser_password_doorhanger:
     result: pass
     splits:

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -231,3 +231,10 @@ class TrustPanel(BasePage):
         """
         self.element_visible("connection-secure")
         return self
+
+    @BasePage.context_chrome
+    def click_privacy_settings_link(self):
+        """Click the 'Privacy Settings' footer link in the Trust Panel."""
+        self.element_visible("trustpanel-privacy-link")
+        self.js_click_on("trustpanel-privacy-link")
+        return self

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -160,5 +160,10 @@
         "selectorData": "#trustpanel-securityInformationView[title*='Connection protections for']",
         "strategy": "css",
         "groups": []
+    },
+    "trustpanel-privacy-link": {
+        "selectorData": "trustpanel-privacy-link",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/security_and_privacy/test_privacy_settings_footer_link_opens_correct_page.py
+++ b/tests/security_and_privacy/test_privacy_settings_footer_link_opens_correct_page.py
@@ -1,0 +1,38 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_navigation import Navigation
+from modules.browser_object_tabbar import TabBar
+from modules.browser_object_trust_panel import TrustPanel
+from modules.page_object_generics import GenericPage
+
+YOUTUBE_URL = "https://www.youtube.com"
+PREFERENCES_URL = "about:preferences#privacy"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054036"
+
+
+def test_privacy_settings_footer_link_opens_correct_page(driver: Firefox):
+    """
+    C3054036 - “Privacy settings” footer link opens the correct page
+    """
+
+    # Instantiate objects
+    test_page = GenericPage(driver, url=YOUTUBE_URL)
+    trust_panel = TrustPanel(driver)
+    tabs = TabBar(driver)
+    nav = Navigation(driver)
+
+    # Open test page and click on the shield icon
+    test_page.open()
+    trust_panel.open_panel()
+
+    # Click on the “Privacy settings” footer link
+    trust_panel.click_privacy_settings_link()
+
+    # "about:preferences#privacy" is opened in a new tab
+    tabs.switch_to_new_tab()
+    nav.url_contains(PREFERENCES_URL)

--- a/tests/security_and_privacy/test_privacy_settings_footer_link_opens_correct_page.py
+++ b/tests/security_and_privacy/test_privacy_settings_footer_link_opens_correct_page.py
@@ -1,10 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_navigation import Navigation
-from modules.browser_object_tabbar import TabBar
-from modules.browser_object_trust_panel import TrustPanel
-from modules.page_object_generics import GenericPage
+from modules.browser_object import Navigation, TabBar, TrustPanel
+from modules.page_object import GenericPage
 
 YOUTUBE_URL = "https://www.youtube.com"
 PREFERENCES_URL = "about:preferences#privacy"


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025822](https://bugzilla.mozilla.org/show_bug.cgi?id=2025822)
TestRail: [3054036](https://mozilla.testrail.io/index.php?/cases/view/3054036)

### Description of Code / Doc Changes

* Add test to verify that “Privacy settings” footer link opens the correct page

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
