### PR TITLE
Hani/ Fix test_https_first_mode_in_private_browsing

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1496,6 +1496,27 @@ Description: In Enhanced Tracking Protection, the standard radio section
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
+```
+Selector Name: doh-advanced-button
+Selector Data: "dohAdvancedButton"
+Description: Advanced settings button in the DNS over HTTPS (DoH) section
+Location: about:preferences#privacy
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-radio-custom
+Selector Data: "dohRadioCustom"
+Description: "Custom" DoH radio option host element (moz-radio) in the DNS over HTTPS section
+Location: about:preferences#privacy
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-radio-custom-input
+Selector Data: "input"
+Description: Inner <input type="radio"> inside the dohRadioCustom shadow root; used to actually click/select the "Custom" DoH option
+Location: about:preferences#privacy (shadow DOM of dohRadioCustom)
+Path to .json: modules/data/about_prefs.components.json
+```
 #### about_profiles
 ```
 Selector Name: profile-container

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -839,5 +839,21 @@
     "selectorData": "aiControlSidebarChatbotSelect",
     "strategy": "id",
     "groups": []
+  },
+  "doh-advanced-button": {
+    "selectorData": "dohAdvancedButton",
+    "strategy": "id",
+    "groups": []
+  },
+  "doh-radio-custom": {
+    "selectorData": "dohRadioCustom",
+    "strategy": "id",
+    "groups": []
+  },
+  "doh-radio-custom-input": {
+    "selectorData": "input",
+    "strategy": "id",
+    "groups": [],
+    "shadowParent": "doh-radio-custom"
   }
 }

--- a/tests/security_and_privacy/test_https_enabled_private_browsing.py
+++ b/tests/security_and_privacy/test_https_enabled_private_browsing.py
@@ -20,11 +20,12 @@ def test_https_first_mode_in_private_browsing(
     C1362731 Check that https First Mode is properly enabled and working in Private Browsing
     """
 
-    # Navigate to the HTTP Site in a Private Window
+    # In the about:preferences#privacy section, check the "Enable HTTPS-Only Mode in private windows only" checkbox.
     about_prefs_privacy.open()
-    about_prefs_privacy.select_https_only_setting(
-        about_prefs_privacy.HTTPS_ONLY_STATUS.HTTPS_ONLY_PRIVATE
-    )
+    about_prefs_privacy.click_on("doh-advanced-button")
+    about_prefs_privacy.click_on("doh-radio-custom-input")
+
+    # Navigate to the HTTP Site in a Private Window
     panel_ui.open_and_switch_to_new_window("private")
     driver.get("about:blank")
     driver.get(HTTP_SITE)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2042651](https://bugzilla.mozilla.org/show_bug.cgi?id=2042651)
TestRail: [1362731](https://mozilla.testrail.io/index.php?/cases/view/1362731)

### Description of Code / Doc Changes

* Fix test_https_first_mode_in_private_browsing
* I went with the short and quick fix for now, but this area should need to be restructured

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
