### PR TITLE
Anca/ Fix language pack tests

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1070,31 +1070,24 @@ Location: about:preferences#privacy History subsection
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: language-dropdown
-Selector Data: "primaryBrowserLocale"
-Description: Language local menu list
-Location: about:preferences#general Language subsection
+Selector Name: browser-language-preferred
+Selector Data: "browserLanguagePreferred"
+Description: Preferred language moz-select on the Languages pane
+Location: about:preferences#paneLanguages Browser language section
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: language-set-alternative-button
-Selector Data: "[data-l10n-id='manage-browser-languages-button']"
-Description: Set Alternatives… button
-Location: about:preferences#general Language subsection
+Selector Name: browser-language-preferred-select
+Selector Data: "select"
+Description: Inner native <select> inside the Preferred language moz-select shadow DOM (shadowParent: browser-language-preferred)
+Location: about:preferences#paneLanguages Browser language section
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: language-settings-dialog
-Selector Data: "BrowserLanguagesDialog"
-Description: The Language Set Alternatives dialog
-Location: about:preferences#general Language subsection
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: language-settings-select
-Selector Data: "[data-l10n-id='browser-languages-select-language']"
-Description: In the Language Set Alternatives dialog, the Select a language to add button
-Location: about:preferences#general Language subsection
+Selector Name: browser-language-heading
+Selector Data: "moz-fieldset[data-l10n-id='browser-language-heading']"
+Description: Browser language card heading (label attribute is locale-translated, used to verify language switch)
+Location: about:preferences#paneLanguages Browser language section
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
@@ -1102,41 +1095,6 @@ Selector Name: search-suggestion-in-private-windows
 Selector Data: "showSearchSuggestionsPrivateWindowsCheckbox"
 Description: Show search suggestions in Private Windows
 Location: about:preferences#search
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: language-settings-search
-Selector Data: "menuitem[value='search']"
-Description: In the Language Set Alternatives dialog, the Select a language to add, Search for more languages… option
-Location: about:preferences#general Language subsection
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: language-option-by-code
-Selector Data: "menuitem[value='{}']"
-Description: In the Language Set Alternatives dialog, Select a language by language code
-Location: about:preferences#general Language subsection
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: language-added-list
-Selector Data: "selectedLocales"
-Description: In the Language Set Alternatives dialog, List of added languages
-Location: about:preferences#general Language subsection
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: language-settings-add-button
-Selector Data: "button[data-l10n-id='languages-customize-add']"
-Description: In the Language Set Alternatives dialog, Add button
-Location: about:preferences#general Language subsection
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: language-settings-ok
-Selector Data: "button[dlgtype='accept']"
-Description: In the Language Set Alternatives dialog, OK button
-Location: about:preferences#general Language subsection
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -615,8 +615,7 @@ language_packs:
     splits:
     - functional1
   test_language_pack_install_preferences:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2042655
-    result: unstable
+    result: pass
     splits:
     - smoke
 menus:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -457,55 +457,25 @@
     "strategy": "id",
     "groups": []
   },
-  "language-dropdown": {
-    "selectorData": "primaryBrowserLocale",
+  "browser-language-preferred": {
+    "selectorData": "browserLanguagePreferred",
     "strategy": "id",
     "groups": []
   },
-  "language-set-alternative-button": {
-    "selectorData": "[data-l10n-id='manage-browser-languages-button']",
+  "browser-language-preferred-select": {
+    "selectorData": "select",
     "strategy": "css",
+    "shadowParent": "browser-language-preferred",
     "groups": []
   },
-  "language-settings-dialog": {
-    "selectorData": "BrowserLanguagesDialog",
-    "strategy": "id",
+  "browser-language-heading": {
+    "selectorData": "moz-fieldset[data-l10n-id='browser-language-heading']",
+    "strategy": "css",
     "groups": []
   },
   "search-suggestion-in-private-windows": {
     "selectorData": "showSearchSuggestionsPrivateWindowsCheckbox",
     "strategy": "id",
-    "groups": []
-  },
-  "language-settings-select": {
-    "selectorData": "[data-l10n-id='browser-languages-select-language']",
-    "strategy": "css",
-    "groups": []
-  },
-  "language-settings-search": {
-    "selectorData": "menuitem[value='search']",
-    "strategy": "css",
-    "groups": []
-  },
-  "language-option-by-code": {
-    "selectorData": "menuitem[value='{}']",
-    "strategy": "css",
-    "groups": []
-  },
-  "language-added-list": {
-    "selectorData": "selectedLocales",
-    "strategy": "id",
-    "groups": []
-  },
-  "language-settings-add-button": {
-    "selectorData": "button[data-l10n-id='languages-customize-add']",
-    "strategy": "css",
-    "groups": []
-  },
-  "language-settings-ok": {
-    "selectorData": "button[dlgtype='accept']",
-    "strategy": "css",
-    "shadowParent": "language-settings-dialog",
     "groups": []
   },
   "history_menulist": {

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -202,27 +202,15 @@ class AboutPrefs(BasePage):
         assert is_checked, "Expected clipboardSuggestion checkbox to be checked"
 
     def set_alternative_language(self, lang_code: str) -> BasePage:
-        """Changes the browser language"""
-        self.get_element("language-set-alternative-button").click()
-        self.driver.switch_to.frame(self.get_iframe())
+        """Sets the browser language via the Preferred language moz-select.
 
-        # Download the language options
-        select_language = self.get_element("language-settings-select")
-        select_language.click()
-        search_languages = self.get_element("language-settings-search")
-        search_languages.click()
-        select_language.click()
-
-        # Select the language, add, and make sure it appears
-        select_language.click()
-        self.get_element("language-option-by-code", labels=[lang_code]).click()
-        select_language.click()
-        self.get_element("language-settings-add-button").click()
-        self.element_attribute_contains(
-            "language-added-list", "last-selected", f"locale-{lang_code}"
+        Firefox applies the locale live once the dropdown value changes.
+        """
+        Select(self.get_element("browser-language-preferred-select")).select_by_value(
+            lang_code
         )
-
-        self.get_element("language-settings-ok").click()
+        moz_select = self.get_element("browser-language-preferred")
+        self.wait.until(lambda _: moz_select.get_attribute("value") == lang_code)
         return self
 
     def select_doh_protection_level(self, level: str) -> BasePage:

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -209,8 +209,7 @@ class AboutPrefs(BasePage):
         Select(self.get_element("browser-language-preferred-select")).select_by_value(
             lang_code
         )
-        moz_select = self.get_element("browser-language-preferred")
-        self.wait.until(lambda _: moz_select.get_attribute("value") == lang_code)
+        self.element_attribute_is("browser-language-preferred", "value", lang_code)
         return self
 
     def select_doh_protection_level(self, level: str) -> BasePage:

--- a/tests/language_packs/conftest.py
+++ b/tests/language_packs/conftest.py
@@ -1,7 +1,5 @@
 import pytest
 
-from modules.page_object import AboutAddons, AboutPrefs, AmoLanguages
-
 
 @pytest.fixture()
 def suite_id():
@@ -23,18 +21,3 @@ def prefs_list(add_to_prefs_list: dict):
 @pytest.fixture()
 def add_to_prefs_list():
     return []
-
-
-@pytest.fixture()
-def amo_languages(driver):
-    return AmoLanguages(driver)
-
-
-@pytest.fixture()
-def about_addons(driver):
-    return AboutAddons(driver)
-
-
-@pytest.fixture()
-def about_prefs(driver):
-    return AboutPrefs(driver, category="general")

--- a/tests/language_packs/test_language_pack_install_addons.py
+++ b/tests/language_packs/test_language_pack_install_addons.py
@@ -1,7 +1,6 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.components.dropdown import Dropdown
 from modules.page_object import AboutAddons, AboutPrefs, AmoLanguages
 
 
@@ -12,26 +11,26 @@ def test_case():
 
 LANGUAGES = [
     (
-        "Italiano",
         "LanguageTools-table-row LanguageTools-lang-it",
         "it",
     )
 ]
 
 
-@pytest.mark.parametrize("drop_down_name, language_label, shortform", LANGUAGES)
+@pytest.mark.parametrize("language_label, shortform", LANGUAGES)
 def test_language_pack_install_from_addons(
     driver: Firefox,
-    amo_languages: AmoLanguages,
-    about_addons: AboutAddons,
-    about_prefs: AboutPrefs,
-    drop_down_name: str,
     language_label: str,
     shortform: str,
 ):
     """
     C1549408: verify that installing a language pack from about:addons will correctly change the locale
     """
+    # Instantiate objects
+    amo_languages = AmoLanguages(driver)
+    about_addons = AboutAddons(driver)
+    about_prefs = AboutPrefs(driver, category="paneLanguages")
+
     amo_languages.open()
 
     # ensuring the page was loaded
@@ -51,18 +50,6 @@ def test_language_pack_install_from_addons(
     # making sure that 1 language was installed
     assert len(addon_language_cards) == 1
 
-    # perform language changing and assertions in about_prefs
+    # perform language changing in about_prefs (helper waits for value to propagate)
     about_prefs.open()
-    language_dropdown = about_prefs.get_element("language-dropdown")
-
-    dropdown = Dropdown(page=about_prefs, root=language_dropdown)
-    # prefs-html-root[lang] and language-set-alternative-button[label] checks were removed
-    # as they were flaky on macOS; wait_for_selection with expected_root_value is used instead
-    assert dropdown.select_option(
-        drop_down_name,
-        double_click=False,
-        wait_for_selection=True,
-        expected_root_value=shortform,
-    ), f"Language option '{drop_down_name}' not found in dropdown"
-
-    assert language_dropdown.get_attribute("label") == drop_down_name
+    about_prefs.set_alternative_language(shortform)

--- a/tests/language_packs/test_language_pack_install_addons.py
+++ b/tests/language_packs/test_language_pack_install_addons.py
@@ -13,15 +13,17 @@ LANGUAGES = [
     (
         "LanguageTools-table-row LanguageTools-lang-it",
         "it",
+        "Lingua",
     )
 ]
 
 
-@pytest.mark.parametrize("language_label, shortform", LANGUAGES)
+@pytest.mark.parametrize("language_label, shortform, localized_text", LANGUAGES)
 def test_language_pack_install_from_addons(
     driver: Firefox,
     language_label: str,
     shortform: str,
+    localized_text: str,
 ):
     """
     C1549408: verify that installing a language pack from about:addons will correctly change the locale
@@ -33,23 +35,28 @@ def test_language_pack_install_from_addons(
 
     amo_languages.open()
 
-    # ensuring the page was loaded
+    # Ensuring the page was loaded
     amo_languages.wait_for_language_page_to_load()
 
-    # grab the appropriate link and wait until the page is loaded
+    # Grab the appropriate link and wait until the page is loaded
     amo_languages.find_language_row_and_navigate(language_label)
     amo_languages.click_on("language-addons-subpage-add-to-firefox")
 
     amo_languages.confirm_language_install_popup()
 
-    # ensure that the about:addons has the language listed
+    # Ensure that the about:addons has the language listed
     about_addons.open()
     about_addons.choose_sidebar_option("locale")
     addon_language_cards = about_addons.get_language_addon_list()
 
-    # making sure that 1 language was installed
+    # Making sure that 1 language was installed
     assert len(addon_language_cards) == 1
 
-    # perform language changing in about_prefs (helper waits for value to propagate)
+    # Perform language changing and locale-applied assertion in about_prefs
     about_prefs.open()
     about_prefs.set_alternative_language(shortform)
+
+    about_prefs.open()
+    about_prefs.element_attribute_contains(
+        "browser-language-heading", "label", localized_text
+    )

--- a/tests/language_packs/test_language_pack_install_preferences.py
+++ b/tests/language_packs/test_language_pack_install_preferences.py
@@ -9,20 +9,23 @@ def test_case():
     return "1549409"
 
 
-LANGUAGES = [("it", "Imposta alternative")]
+LANGUAGES = [("it", "Lingua")]
 
 
 @pytest.mark.parametrize("shortform, localized_text", LANGUAGES)
 def test_language_pack_install_about_preferences(
-    driver: Firefox, about_prefs: AboutPrefs, shortform: str, localized_text: str
+    driver: Firefox, shortform: str, localized_text: str
 ):
     """
     C1549409: language packs can be installed from about:preferences and firefox is correctly localized
     """
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="paneLanguages")
+
     about_prefs.open()
     about_prefs.set_alternative_language(shortform)
 
     about_prefs.open()
     about_prefs.element_attribute_contains(
-        "language-set-alternative-button", "label", localized_text
+        "browser-language-heading", "label", localized_text
     )

--- a/tests/preferences/test_lang_pack_changed_from_about_prefs.py
+++ b/tests/preferences/test_lang_pack_changed_from_about_prefs.py
@@ -45,18 +45,20 @@ def temp_selectors():
 
 def test_lang_pack_changed_from_about_prefs(
     driver: Firefox,
-    nav: Navigation,
-    about_prefs: AboutPrefs,
-    panel_ui: PanelUi,
-    tabs: TabBar,
     test_url: str,
-    generic_page: GenericPage,
     temp_selectors,
 ):
     """
     C1771617 - The language can be changed in about:preferences.
     We choose to set a pref rather than use a non-US local build.
     """
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="paneLanguages")
+    nav = Navigation(driver)
+    panel_ui = PanelUi(driver)
+    tabs = TabBar(driver)
+    generic_page = GenericPage(driver, url=test_url)
+
     # Skip Developer Edition since modifying menus, messages, and notifications language is blocked and defaults to
     # English
     try:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2042655](https://bugzilla.mozilla.org/show_bug.cgi?id=2042655)
TestRail: N./A

### Description of Code / Doc Changes
- Fix 3 language pack test to match the new UI
   - tests/language_packs/test_language_pack_install_preferences.py
   - test_lang_pack_changed_from_about_prefs.py
   - test_language_pack_install_addons.py

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
