### PR TITLE
Hani/ Test http lock icon connection state

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5249,3 +5249,17 @@ Description: "Privacy Settings" footer link in the Trust Panel
 Location: Trust Panel > footer section
 Path to .json: modules/data/trust_panel.components.json
 ```
+```
+Selector Name: trustpanel-connection-label-insecure
+Selector Data: "[data-l10n-id='trustpanel-connection-label-insecure']"
+Description: Connection status label shown in the Trustpanel when the connection is not secure ("Connection not secure")
+Location: Trustpanel - Connection protections tab
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: trustpanel-insecure-section-header
+Selector Data: "[data-l10n-id='trustpanel-insecure-section-header']"
+Description: Banner header label shown in the Trustpanel when the connection is insecure ("Your connection isn’t secure")
+Location: Trustpanel - Connection protections tab (insecure banner)
+Path to .json: modules/data/trust_panel.components.json
+```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1261,6 +1261,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_http_lock_icon_connection_state:
+    result: pass
+    splits:
+    - functional2
   test_https_enabled_private_browsing:
     result: pass
     splits:

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -170,5 +170,15 @@
         "selectorData": "trustpanel-privacy-link",
         "strategy": "id",
         "groups": []
+    },
+    "trustpanel-connection-label-insecure": {
+        "selectorData": "[data-l10n-id='trustpanel-connection-label-insecure']",
+        "strategy": "css",
+        "groups": []
+    },
+    "trustpanel-insecure-section-header": {
+        "selectorData": "[data-l10n-id='trustpanel-insecure-section-header']",
+        "strategy": "css",
+        "groups": []
     }
 }

--- a/tests/security_and_privacy/test_http_lock_icon_connection_state.py
+++ b/tests/security_and_privacy/test_http_lock_icon_connection_state.py
@@ -1,0 +1,32 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TrustPanel
+from modules.page_object import GenericPage
+
+HTTP_URL = "http://httpforever.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054027"
+
+
+def test_http_lock_icon_connection_state(driver: Firefox):
+    """
+    C3054027 - Lock icon and text correctly reflects the connection state (HTTP)
+    """
+
+    # Instantiate objects
+    test_page = GenericPage(driver, url=HTTP_URL)
+    trust_panel = TrustPanel(driver)
+
+    # Open test page and click on the shield icon
+    test_page.open()
+    trust_panel.open_panel()
+
+    # Top row shows "Connection not secure" text
+    trust_panel.element_visible("trustpanel-connection-label-insecure")
+
+    # "Your connection isn't' secure" text is displayed inside the banner
+    trust_panel.element_visible("trustpanel-insecure-section-header")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025815](https://bugzilla.mozilla.org/show_bug.cgi?id=2025815)
TestRail: [3054027](https://mozilla.testrail.io/index.php?/cases/view/3054027)

### Description of Code / Doc Changes

* Add test to verify lock icon and text correctly reflects the connection state (HTTP)

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
