### PR TITLE
Stabilize Autofill from Nova changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
           FX_EXECUTABLE: /Volumes/${{ steps.install-fx.outputs.app_name }}/${{ steps.install-fx.outputs.app_name }}.app/Contents/MacOS/firefox
         run: |
           "$FX_EXECUTABLE" --version
-          pipenv run pytest --fx-executable="$FX_EXECUTABLE"  $(cat selected_tests) || TEST_EXIT_CODE=$?
+          pipenv run pytest --fx-executable="$FX_EXECUTABLE"  tests/form_autofill || TEST_EXIT_CODE=$?
           mv artifacts artifacts-mac || true
           exit $TEST_EXIT_CODE
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
           FX_EXECUTABLE: /Volumes/${{ steps.install-fx.outputs.app_name }}/${{ steps.install-fx.outputs.app_name }}.app/Contents/MacOS/firefox
         run: |
           "$FX_EXECUTABLE" --version
-          pipenv run pytest --fx-executable="$FX_EXECUTABLE"  tests/form_autofill || TEST_EXIT_CODE=$?
+          pipenv run pytest --fx-executable="$FX_EXECUTABLE"  $(cat selected_tests) || TEST_EXIT_CODE=$?
           mv artifacts artifacts-mac || true
           exit $TEST_EXIT_CODE
 

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -734,6 +734,62 @@ Location: about:preferences#general as result of Import Data button click
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
+Selector Name: add-address
+Selector Data: "add-address-button"
+Description: Add autofill address
+Location: about:preferences#manageAddresses
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: edit-address
+Selector Data: "edit-address-button"
+Description: Edit autofill address
+Location: about:preferences#manageAddresses
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: saved-address-entry
+Selector Data: "[data-l10n-id='address-moz-box-item']"
+Description: Autofill address entry
+Location: about:preferences#manageAddresses
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: no-addresses
+Selector Data: "[data-l10n-id='addresses-no-addresses-stored-message']"
+Description: No addresses saved
+Location: about:preferences#manageAddresses
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: add-payment
+Selector Data: "add-payment-button"
+Description: Add autofill payment
+Location: about:preferences#managePayments
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: edit-payment
+Selector Data: "edit-payment-button"
+Description: Edit autofill payment
+Location: about:preferences#managePayments
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: saved-payment-entry
+Selector Data: "[data-l10n-id='payment-moz-box-item']"
+Description: Autofill payment entry
+Location: about:preferences#managePayments
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: no-payments
+Selector Data: "[data-l10n-id='payments-no-payments-stored-message']"
+Description: No payments saved
+Location: about:preferences#managePayments
+Path to .json: modules/data/about_prefs.components.json
+```
+```
 Selector Name: cc-saved-options
 Selector Data: "credit-cards"
 Description: The "Add card" modal, containing 4 fields

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -355,9 +355,9 @@ bookmarks_and_history:
   test_open_websites_from_history:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043402
     result:
+      linux: pass
       mac: unstable
       win: pass
-      linux: pass
     splits:
     - smoke
   test_opened_website_in_new_tab_present_in_hamburger_history_menu:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -353,7 +353,11 @@ bookmarks_and_history:
     splits:
     - smoke
   test_open_websites_from_history:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043402
+    result:
+      mac: unstable
+      win: pass
+      linux: pass
     splits:
     - smoke
   test_opened_website_in_new_tab_present_in_hamburger_history_menu:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -22,8 +22,13 @@
     "groups": []
   },
   "edit-payment": {
-    "selectorData": "edit-payment-button",
-    "strategy": "id",
+    "selectorData": "[data-l10n-id='payments-edit-payment-button-label']",
+    "strategy": "css",
+    "groups": []
+  },
+  "delete-payment": {
+    "selectorData": "[data-l10n-id='payments-delete-payment-button-label']",
+    "strategy": "css",
     "groups": []
   },
   "saved-payment-entry": {

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -16,6 +16,13 @@
       "doNotCache"
     ]
   },
+  "no-addresses": {
+    "selectorData": "[data-l10n-id='addresses-no-addresses-stored-message']",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ]
+  },
   "add-payment": {
     "selectorData": "add-payment-button",
     "strategy": "id",
@@ -33,6 +40,13 @@
   },
   "saved-payment-entry": {
     "selectorData": "[data-l10n-id='payment-moz-box-item']",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ]
+  },
+  "no-payments": {
+    "selectorData": "[data-l10n-id='payments-no-payments-stored-message']",
     "strategy": "css",
     "groups": [
       "doNotCache"

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -393,6 +393,19 @@ class BasePage(Page):
         )
 
     @context_of_model
+    def element_does_not_have_attribute(
+        self, reference: str | tuple | WebElement, attr: str, labels=None
+    ):
+        """Expect helper: wait until attribute does not exist in element."""
+
+        def _element_does_not_have_attribute(_):
+            el = self.fetch(reference, labels=labels)
+            return el and (el.get_attribute(attr) is None)
+
+        self.expect(_element_does_not_have_attribute)
+        return self
+
+    @context_of_model
     def get_attribute_value(
         self, reference: str | tuple | WebElement, attr: str, labels=None
     ):

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -594,17 +594,31 @@ class AboutPrefs(BasePage):
         """Click the edit button on a given payment"""
         self._edit_tile("payment", idx)
 
+    def _get_autofill_profiles(self, tile_type: str) -> List[WebElement]:
+        """Gets any type of autofill profile"""
+        self.element_visible(f"saved-{tile_type}-entry")
+        return self.get_elements(f"saved-{tile_type}-entry")
+
     def get_all_saved_cc_profiles(self) -> List[WebElement]:
         """Gets the saved credit card profiles in the cc panel"""
-        return self.get_elements("saved-payment-entry")
+        return self._get_autofill_profiles("payment")
 
     def get_all_saved_address_profiles(self) -> List[WebElement]:
         """Gets the saved credit card profiles in the cc panel"""
-        self.switch_to_saved_addresses_popup_iframe()
-        select_el = self.get_element("address-saved-options")
-        if len(select_el.get_attribute("innerHTML")) > 1:
-            return Select(select_el).options
-        return []
+        return self._get_autofill_profiles("address")
+
+    def _confirm_n_profiles(self, tile_type: str, n: int) -> BasePage:
+        """Confirm that _n_ profiles of a type exist"""
+        self.expect(lambda _: len(self._get_autofill_profiles(tile_type)) == n)
+        return self
+
+    def confirm_n_addresses(self, n: int) -> BasePage:
+        """Confirm that _n_ addresses exist"""
+        return self._confirm_n_profiles("address", n)
+
+    def confirm_n_payments(self, n: int) -> BasePage:
+        """Confirm that _n_ payments exist"""
+        return self._confirm_n_profiles("payment", n)
 
     def extract_address_data_from_saved_addresses_entry(
         self, util: Utilities, region: str = "US"

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -503,7 +503,7 @@ class AboutPrefs(BasePage):
             value_field.click()
             option = next(
                 el
-                for el in self.driver.find_elements(By.TAG_NAME, "option")
+                for el in value_field.find_elements(By.TAG_NAME, "option")
                 if el.text == str(value)
             )
             option.click()
@@ -579,7 +579,7 @@ class AboutPrefs(BasePage):
         self._edit_tile("payment", idx)
 
     def _get_autofill_profiles(self, tile_type: str) -> List[WebElement]:
-        """Gets any type of autofill profile"""
+        """Gets any type of autofill profile, do not use against n=0"""
         self.element_visible(f"saved-{tile_type}-entry")
         return self.get_elements(f"saved-{tile_type}-entry")
 
@@ -592,16 +592,16 @@ class AboutPrefs(BasePage):
         return self._get_autofill_profiles("address")
 
     def _confirm_n_profiles(self, tile_type: str, n: int) -> BasePage:
-        """Confirm that _n_ profiles of a type exist"""
+        """Confirm that _n_ profiles of a type exist, where n>0"""
         self.expect(lambda _: len(self._get_autofill_profiles(tile_type)) == n)
         return self
 
     def confirm_n_addresses(self, n: int) -> BasePage:
-        """Confirm that _n_ addresses exist"""
+        """Confirm that _n_ addresses exist where n>0"""
         return self._confirm_n_profiles("address", n)
 
     def confirm_n_payments(self, n: int) -> BasePage:
-        """Confirm that _n_ payments exist"""
+        """Confirm that _n_ payments exist where n>0"""
         return self._confirm_n_profiles("payment", n)
 
     def extract_address_data_from_saved_addresses_entry(
@@ -662,7 +662,7 @@ class AboutPrefs(BasePage):
         """
         Switch to form iframe to edit saved payments.
         """
-        self.switch_to_default_frame
+        self.switch_to_default_frame()
         self.switch_to_iframe_context(self.get_element("browser-popup"))
         return self
 

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from time import sleep
 from typing import List, Literal
 
@@ -342,7 +343,7 @@ class AboutPrefs(BasePage):
         menulist_popup.select_by_value(option)
         return self
 
-    # Payment and Address Management
+    # ---- Payment and Address Management ---------------------------------------------------------
     def verify_cc_json(
         self, cc_info_json: dict, credit_card_fill_obj: CreditCardBase
     ) -> BasePage:
@@ -362,6 +363,7 @@ class AboutPrefs(BasePage):
         assert cc_info_json["cardNumber"][-4:] == credit_card_fill_obj.card_number[-4:]
         _, year = cc_info_json["expDate"].split("/")
         # Compare two digit year to four-digit
+        logging.warning(f"{year} {credit_card_fill_obj.expiration_year}")
         assert int(year) == int(credit_card_fill_obj.expiration_year) + 2000
         return self
 
@@ -503,18 +505,26 @@ class AboutPrefs(BasePage):
             "expiration_year": "cc-exp-year",
             "name": "cc-name",
         }
+        self.switch_to_iframe_context(self.get_element("browser-popup"))
         if field_name not in fields.keys():
             raise ValueError(
                 f"{field_name} is not a valid field name for the cc dialog form."
             )
-        self.switch_to_edit_saved_payments_popup_iframe()
         value_field = self.find_element(By.ID, fields[field_name])
         if value.isdigit():
             value = int(value)
         if field_name == "expiration_year":
-            value -= (datetime.datetime.now().year % 100) + 1
+            if int(value) < 100:  # new exp years are all 4-digit
+                value = int(value) + 2000
+            value_field.click()
+            option = next(
+                el
+                for el in self.driver.find_elements(By.TAG_NAME, "option")
+                if el.text == str(value)
+            )
+            option.click()
 
-        if value_field.tag_name == "select":
+        elif value_field.tag_name == "select":
             Select(value_field).select_by_index(value)
         else:
             value_field.clear()
@@ -571,11 +581,22 @@ class AboutPrefs(BasePage):
         """Get data-l10n-args from the saved payment card"""
         return self._get_tile_data("payment", idx)
 
+    def _edit_tile(self, tile_type: str, idx=0):
+        """Open the edit view of payment or address"""
+        tiles = self.get_elements(f"edit-{tile_type}")
+        tiles[idx].click()
+
+    def edit_address(self, idx=0):
+        """Click the edit button on a given address"""
+        self._edit_tile("address", idx)
+
+    def edit_payment(self, idx=0):
+        """Click the edit button on a given payment"""
+        self._edit_tile("payment", idx)
+
     def get_all_saved_cc_profiles(self) -> List[WebElement]:
         """Gets the saved credit card profiles in the cc panel"""
-        self.switch_to_saved_payments_popup_iframe()
-        element = Select(self.get_element("cc-saved-options"))
-        return element.options
+        return self.get_elements("saved-payment-entry")
 
     def get_all_saved_address_profiles(self) -> List[WebElement]:
         """Gets the saved credit card profiles in the cc panel"""
@@ -643,8 +664,8 @@ class AboutPrefs(BasePage):
         """
         Switch to form iframe to edit saved payments.
         """
-        self.switch_to_default_frame()
-        self.switch_to_iframe(2)
+        self.switch_to_default_frame
+        self.switch_to_iframe_context(self.get_element("browser-popup"))
         return self
 
     def press_button_get_popup_dialog_iframe(self, button_label: str) -> WebElement:

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1,6 +1,4 @@
-import datetime
 import json
-import logging
 from time import sleep
 from typing import List, Literal
 
@@ -363,7 +361,6 @@ class AboutPrefs(BasePage):
         assert cc_info_json["cardNumber"][-4:] == credit_card_fill_obj.card_number[-4:]
         _, year = cc_info_json["expDate"].split("/")
         # Compare two digit year to four-digit
-        logging.warning(f"{year} {credit_card_fill_obj.expiration_year}")
         assert int(year) == int(credit_card_fill_obj.expiration_year) + 2000
         return self
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 generate_report_on_test = false
 addopts = "-vs --html=report.html"
 log_cli = true
-log_cli_level = "warn"
+log_cli_level = "info"
 markers = [
     "audio: test is reliant on audio",
     "headed: test must run in headed mode (e.g. uses pynput)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 generate_report_on_test = false
 addopts = "-vs --html=report.html"
 log_cli = true
-log_cli_level = "info"
+log_cli_level = "warn"
 markers = [
     "audio: test is reliant on audio",
     "headed: test must run in headed mode (e.g. uses pynput)",

--- a/tests/form_autofill/conftest.py
+++ b/tests/form_autofill/conftest.py
@@ -52,6 +52,11 @@ def util():
 
 
 @pytest.fixture()
+def prefs_category():
+    return ""
+
+
+@pytest.fixture()
 def about_prefs_privacy(driver):
     yield AboutPrefs(driver, category="privacy")
 
@@ -67,8 +72,8 @@ def about_prefs_payments(driver):
 
 
 @pytest.fixture()
-def about_prefs(driver):
-    yield AboutPrefs(driver)
+def about_prefs(driver, prefs_category):
+    yield AboutPrefs(driver, category=prefs_category)
 
 
 @pytest.fixture()

--- a/tests/form_autofill/test_address_autofill_attribute.py
+++ b/tests/form_autofill/test_address_autofill_attribute.py
@@ -1,9 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object_autofill import AddressFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import AddressFill
 
 
 @pytest.fixture()
@@ -15,17 +14,15 @@ def test_address_attribute_selection(
     driver: Firefox,
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
-    util: Utilities,
     region: str,
 ):
     """
-    C122359 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
-    item in the dropdown ensures that the actual value matches the expected value.
+    C122359 - This test verifies: after filling the autofill fields and saving the data, hovering
+    over the first item in the dropdown ensures that the actual value matches the expected value.
 
     Arguments:
         address_autofill: AddressFill instance
         autofill_popup: AutofillPopup instance
-        util: Utilities instance
         region: country code in use
     """
     # open the navigation page
@@ -44,8 +41,8 @@ def test_address_attribute_selection(
     first_item = autofill_popup.get_nth_element(1)
     actual_value = autofill_popup.hover(first_item).get_primary_value(first_item)
 
-    # Get the primary value (street address) from the first item in the dropdown and assert that the actual value
-    # matches the expected value
+    # Get the primary value (street address) from the first item in the dropdown and assert that the
+    # actual value matches the expected value
     expected_street_address = autofill_sample_data.street_address
     assert expected_street_address == actual_value, (
         f"Expected {expected_street_address}, but got {actual_value}"

--- a/tests/form_autofill/test_autofill_cc_cvv.py
+++ b/tests/form_autofill/test_autofill_cc_cvv.py
@@ -1,11 +1,8 @@
-import json
-
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object_autofill import CreditCardFill
-from modules.page_object_prefs import AboutPrefs
+from modules.browser_object import AutofillPopup
+from modules.page_object import AboutPrefs, CreditCardFill
 from modules.util import Utilities
 
 
@@ -19,13 +16,13 @@ def test_autofill_cc_cvv(
     credit_card_autofill: CreditCardFill,
     autofill_popup: AutofillPopup,
     util: Utilities,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs_payments: AboutPrefs,
 ):
     """
     C122399, Test form autofill CC CVV number
 
     Arguments:
-        about_prefs_privacy: AboutPrefs instance (privacy category)
+        about_prefs_payments: AboutPrefs instance (payments category)
         credit_card_autofill: CreditCardFill instance
         autofill_popup: AutofillPopup instance
         util: Utilities instance
@@ -41,19 +38,16 @@ def test_autofill_cc_cvv(
     credit_card_sample_data = credit_card_autofill.fill_and_save()
 
     # Navigate to prefs
-    about_prefs_privacy.open()
-    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
+    about_prefs_payments.open()
 
     # Get the saved CC data (first entry)
-    cc_profile = about_prefs_privacy.get_all_saved_cc_profiles()[0]
-    cc_info_json = json.loads(cc_profile.get_dom_attribute("data-l10n-args"))
+    cc_info_json = about_prefs_payments.get_data_from_saved_payment()
 
     # Compare input CC data with saved CC data
-    about_prefs_privacy.verify_cc_json(cc_info_json, credit_card_sample_data)
+    about_prefs_payments.verify_cc_json(cc_info_json, credit_card_sample_data)
 
     # Click on saved address and edit
-    cc_profile.click()
-    about_prefs_privacy.click_edit_on_dialog_element()
+    about_prefs_payments.click_on("edit-payment")
 
     # Verify that CVV number is not saved under CC profile but the rest of the data is saved
-    about_prefs_privacy.verify_cc_edit_saved_payments_profile(credit_card_sample_data)
+    about_prefs_payments.verify_cc_edit_saved_payments_profile(credit_card_sample_data)

--- a/tests/form_autofill/test_autofill_cc_cvv.py
+++ b/tests/form_autofill/test_autofill_cc_cvv.py
@@ -3,7 +3,6 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import AutofillPopup
 from modules.page_object import AboutPrefs, CreditCardFill
-from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -15,7 +14,6 @@ def test_autofill_cc_cvv(
     driver: Firefox,
     credit_card_autofill: CreditCardFill,
     autofill_popup: AutofillPopup,
-    util: Utilities,
     about_prefs_payments: AboutPrefs,
 ):
     """
@@ -25,7 +23,6 @@ def test_autofill_cc_cvv(
         about_prefs_payments: AboutPrefs instance (payments category)
         credit_card_autofill: CreditCardFill instance
         autofill_popup: AutofillPopup instance
-        util: Utilities instance
     """
 
     # Open credit card autofill page

--- a/tests/form_autofill/test_autofill_credit_card.py
+++ b/tests/form_autofill/test_autofill_credit_card.py
@@ -1,9 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object_autofill import CreditCardFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import CreditCardFill
 
 
 @pytest.fixture()
@@ -13,7 +12,6 @@ def test_case():
 
 def test_autofill_credit_card(
     driver: Firefox,
-    util: Utilities,
     credit_card_autofill: CreditCardFill,
     autofill_popup: AutofillPopup,
     region: str,
@@ -24,7 +22,6 @@ def test_autofill_credit_card(
     Arguments:
         credit_card_autofill: CreditCardFill instance
         autofill_popup: AutofillPopup instance
-        util: Utilities instance
         region: region being tested
     """
 

--- a/tests/form_autofill/test_autofill_credit_card_doorhanger.py
+++ b/tests/form_autofill/test_autofill_credit_card_doorhanger.py
@@ -3,7 +3,6 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import AutofillPopup
 from modules.page_object import AboutPrefs, CreditCardFill
-from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -21,7 +20,6 @@ def test_autofill_credit_card_door_hanger(
     about_prefs: AboutPrefs,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
-    util: Utilities,
 ):
     """
     C122392, ensures that pressing not now > never save cards toggles off the setting
@@ -30,7 +28,6 @@ def test_autofill_credit_card_door_hanger(
         about_prefs_privacy: AboutPrefs instance (privacy category)
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
-        util: Utilities instance
     """
     # navigate to page
     credit_card_autofill.open()

--- a/tests/form_autofill/test_autofill_credit_card_doorhanger.py
+++ b/tests/form_autofill/test_autofill_credit_card_doorhanger.py
@@ -1,9 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutPrefs
-from modules.page_object_autofill import CreditCardFill
+from modules.browser_object import AutofillPopup
+from modules.page_object import AboutPrefs, CreditCardFill
 from modules.util import Utilities
 
 
@@ -12,9 +11,14 @@ def test_case():
     return "122392"
 
 
+@pytest.fixture()
+def prefs_category():
+    return "passwordsAutofill"
+
+
 def test_autofill_credit_card_door_hanger(
     driver: Firefox,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs: AboutPrefs,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
     util: Utilities,
@@ -42,7 +46,7 @@ def test_autofill_credit_card_door_hanger(
     autofill_popup.click_doorhanger_button("dropdown-never-save-cards")
 
     # ensure that the checked attribute is off
-    about_prefs_privacy.open()
-    payment_checkbox = about_prefs_privacy.get_element("save-and-fill-payment-methods")
-    checked_attr = payment_checkbox.get_attribute("checked")
-    assert checked_attr is None
+    about_prefs.open()
+    about_prefs.element_does_not_have_attribute(
+        "save-and-fill-payment-methods", "checked"
+    )

--- a/tests/form_autofill/test_autofill_credit_card_enable.py
+++ b/tests/form_autofill/test_autofill_credit_card_enable.py
@@ -12,9 +12,14 @@ def test_case():
     return "122388"
 
 
+@pytest.fixture()
+def prefs_category():
+    return "passwordsAutofill"
+
+
 def test_enable_disable_form_autofill_cc(
     driver: Firefox,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs: AboutPrefs,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
     util: Utilities,
@@ -24,7 +29,7 @@ def test_enable_disable_form_autofill_cc(
     cards box the dropdown does not appear.
 
     Arguments:
-        about_prefs_privacy: AboutPrefs instance (privacy category)
+        about_prefs: AboutPrefs instance
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
         util: Utilities instance
@@ -40,10 +45,10 @@ def test_enable_disable_form_autofill_cc(
     credit_card_autofill.fill_and_save()
 
     # navigate to prefs
-    about_prefs_privacy.open()
+    about_prefs.open()
 
     # toggle autofill cc option
-    about_prefs_privacy.get_element("save-and-fill-payment-methods").click()
+    about_prefs.click_on("save-and-fill-payment-methods")
 
     # open credit card autofill page and select field
     credit_card_autofill.open()

--- a/tests/form_autofill/test_autofill_credit_card_enable.py
+++ b/tests/form_autofill/test_autofill_credit_card_enable.py
@@ -1,10 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutPrefs
-from modules.page_object_autofill import CreditCardFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import AboutPrefs, CreditCardFill
 
 
 @pytest.fixture()
@@ -22,7 +20,6 @@ def test_enable_disable_form_autofill_cc(
     about_prefs: AboutPrefs,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
-    util: Utilities,
 ):
     """
     C122388, tests that after saving cc information and toggling the autofill credit
@@ -32,7 +29,6 @@ def test_enable_disable_form_autofill_cc(
         about_prefs: AboutPrefs instance
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
-        util: Utilities instance
     """
 
     # open credit card autofill page

--- a/tests/form_autofill/test_autofill_credit_card_four_fields.py
+++ b/tests/form_autofill/test_autofill_credit_card_four_fields.py
@@ -1,9 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object_autofill import CreditCardFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import CreditCardFill
 
 
 @pytest.fixture()
@@ -15,7 +14,6 @@ def test_autofill_four_fields(
     driver: Firefox,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
-    util: Utilities,
 ):
     """
     C122404, tests that the form fields are filled corrected after saving a profile.
@@ -23,7 +21,6 @@ def test_autofill_four_fields(
     Arguments:
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
-        util: Utilities instance
     """
     # navigate to credit card autofill page
     credit_card_autofill.open()

--- a/tests/form_autofill/test_cc_clear_form.py
+++ b/tests/form_autofill/test_cc_clear_form.py
@@ -1,9 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object_autofill import CreditCardFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import CreditCardFill
 
 
 @pytest.fixture()
@@ -15,7 +14,6 @@ def test_clear_form_credit_card(
     driver: Firefox,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
-    util: Utilities,
 ):
     """
     C122581, Test clear form credit card
@@ -23,7 +21,6 @@ def test_clear_form_credit_card(
     Arguments:
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
-        util: Utilities instance
     """
     # navigate to credit card autofill page
     credit_card_autofill.open()

--- a/tests/form_autofill/test_clear_form.py
+++ b/tests/form_autofill/test_clear_form.py
@@ -1,9 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object_autofill import AddressFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import AddressFill
 
 
 @pytest.fixture()
@@ -15,15 +14,14 @@ def test_clear_form(
     driver: Firefox,
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
-    util: Utilities,
     region: str,
 ):
     """
     C122574, test clear autofill form
 
     Arguments:
+        address_autofill: AddressFill instance
         autofill_popup: AutofillPopup instance
-        util: Utilities instance
         region: country code in use
     """
     # open address page

--- a/tests/form_autofill/test_create_new_cc_profile.py
+++ b/tests/form_autofill/test_create_new_cc_profile.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from selenium.webdriver import Firefox
 

--- a/tests/form_autofill/test_delete_cc_profile.py
+++ b/tests/form_autofill/test_delete_cc_profile.py
@@ -39,12 +39,10 @@ def test_delete_cc_profile(
     about_prefs_payments.open()
 
     # verify there are 2 profiles at first
-    cc_profiles = about_prefs_payments.get_all_saved_cc_profiles()
-    about_prefs_payments.wait.until(lambda _: len(cc_profiles) == 2)
+    about_prefs_payments.confirm_n_payments(2)
 
     # delete a profile and verify there is only 1 left
     about_prefs_payments.click_on("delete-payment")
     alert = about_prefs_payments.get_alert()
     alert.accept()
-    cc_profiles = about_prefs_payments.get_all_saved_cc_profiles()
-    about_prefs_payments.wait.until(lambda _: len(cc_profiles) == 1)
+    about_prefs_payments.confirm_n_payments(1)

--- a/tests/form_autofill/test_delete_cc_profile.py
+++ b/tests/form_autofill/test_delete_cc_profile.py
@@ -14,8 +14,7 @@ def test_case():
 
 def test_delete_cc_profile(
     driver: Firefox,
-    about_prefs: AboutPrefs,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs_payments: AboutPrefs,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
     util: Utilities,
@@ -25,7 +24,7 @@ def test_delete_cc_profile(
 
     Arguments:
         about_prefs: AboutPrefs instance
-        about_prefs_privacy: AboutPrefs instance (privacy category)
+        about_prefs_payments: AboutPrefs instance (privacy category)
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
         util: Utilities instance
@@ -41,15 +40,15 @@ def test_delete_cc_profile(
     credit_card_autofill.fill_and_save()
 
     # navigate to prefs
-    about_prefs_privacy.open()
-    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
+    about_prefs_payments.open()
 
     # verify there are 2 profiles at first
-    cc_profiles = about_prefs.get_all_saved_cc_profiles()
-    assert len(cc_profiles) == 2
+    cc_profiles = about_prefs_payments.get_all_saved_cc_profiles()
+    about_prefs_payments.wait.until(lambda _: len(cc_profiles) == 2)
 
     # delete a profile and verify there is only 1 left
-    cc_profiles[0].click()
-    about_prefs.click_popup_panel_button("autofill-manage-remove-button")
-    cc_profiles = about_prefs.get_all_saved_cc_profiles()
-    assert len(cc_profiles) == 1
+    about_prefs_payments.click_on("delete-payment")
+    alert = about_prefs_payments.get_alert()
+    alert.accept()
+    cc_profiles = about_prefs_payments.get_all_saved_cc_profiles()
+    about_prefs_payments.wait.until(lambda _: len(cc_profiles) == 1)

--- a/tests/form_autofill/test_delete_cc_profile.py
+++ b/tests/form_autofill/test_delete_cc_profile.py
@@ -1,10 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutPrefs
-from modules.page_object_autofill import CreditCardFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import AboutPrefs, CreditCardFill
 
 
 @pytest.fixture()
@@ -17,7 +15,6 @@ def test_delete_cc_profile(
     about_prefs_payments: AboutPrefs,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
-    util: Utilities,
 ):
     """
     C122391, Ensuring that deleting cc profiles will make it so CC does not show up in the grid
@@ -27,7 +24,6 @@ def test_delete_cc_profile(
         about_prefs_payments: AboutPrefs instance (privacy category)
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
-        util: Utilities instance
     """
     # instantiate objects
     credit_card_autofill.open()

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -1,13 +1,8 @@
-import json
-import logging
-from time import sleep
-
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutPrefs
-from modules.page_object_autofill import CreditCardFill
+from modules.browser_object import AutofillPopup
+from modules.page_object import AboutPrefs, CreditCardFill
 from modules.util import Utilities
 
 
@@ -55,7 +50,6 @@ def test_edit_credit_card_profile(
 
     # Fill in fake data
     original_cc_data = credit_card_autofill.fill_and_save()
-    logging.warning(f"old {original_cc_data}")
 
     # navigate to about:prefs and select the saved payment methods
     about_prefs_payments.open()
@@ -68,17 +62,14 @@ def test_edit_credit_card_profile(
 
     # update cc field
     updated_value = getattr(credit_card_sample_data_new, field)
-    logging.warning(f"new: {updated_value}")
     about_prefs_payments.update_cc_field_panel(field, updated_value)
     about_prefs_payments.open()  # reopen payment prefs to reset
 
     # get new json object for the updated field
 
     cc_info_json_new = about_prefs_payments.get_data_from_saved_payment()
-    logging.warning(f"borrowed {cc_info_json_new}")
     # replace required field value from original cc data
     setattr(original_cc_data, field, updated_value)
-    logging.warning(f"blue {original_cc_data}")
 
     # verify that field is changed
     about_prefs_payments.verify_cc_json(cc_info_json_new, original_cc_data)

--- a/tests/form_autofill/test_edit_credit_card.py
+++ b/tests/form_autofill/test_edit_credit_card.py
@@ -1,4 +1,6 @@
 import json
+import logging
+from time import sleep
 
 import pytest
 from selenium.webdriver import Firefox
@@ -25,7 +27,7 @@ fields = ["expiration_year", "name", "expiration_month", "card_number"]
 @pytest.mark.parametrize("field", fields)
 def test_edit_credit_card_profile(
     driver: Firefox,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs_payments: AboutPrefs,
     util: Utilities,
     credit_card_autofill: CreditCardFill,
     autofill_popup: AutofillPopup,
@@ -37,7 +39,7 @@ def test_edit_credit_card_profile(
     has the correct behaviour
 
     Arguments:
-        about_prefs_privacy: AboutPrefs instance (privacy category)
+        about_prefs_payments: AboutPrefs instance (privacy category)
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
         util: Utilities instance
@@ -53,30 +55,30 @@ def test_edit_credit_card_profile(
 
     # Fill in fake data
     original_cc_data = credit_card_autofill.fill_and_save()
+    logging.warning(f"old {original_cc_data}")
 
     # navigate to about:prefs and select the saved payment methods
-    about_prefs_privacy.open()
-    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
+    about_prefs_payments.open()
 
     # fetch the saved cc profile and select edit
-    saved_profile = about_prefs_privacy.get_all_saved_cc_profiles()
-    saved_profile[0].click()
-    about_prefs_privacy.click_edit_on_dialog_element()
+    about_prefs_payments.edit_payment()
 
     # ensure the same year or month is not generated
     credit_card_sample_data_new = util.fake_credit_card_data(region, original_cc_data)
 
     # update cc field
     updated_value = getattr(credit_card_sample_data_new, field)
-    about_prefs_privacy.update_cc_field_panel(field, updated_value)
+    logging.warning(f"new: {updated_value}")
+    about_prefs_payments.update_cc_field_panel(field, updated_value)
+    about_prefs_payments.open()  # reopen payment prefs to reset
 
-    ## get new json object for the updated field
-    saved_profile = about_prefs_privacy.get_all_saved_cc_profiles()
-    saved_profile[0].click()
-    cc_info_json_new = json.loads(saved_profile[0].get_attribute("data-l10n-args"))
+    # get new json object for the updated field
 
+    cc_info_json_new = about_prefs_payments.get_data_from_saved_payment()
+    logging.warning(f"borrowed {cc_info_json_new}")
     # replace required field value from original cc data
     setattr(original_cc_data, field, updated_value)
+    logging.warning(f"blue {original_cc_data}")
 
     # verify that field is changed
-    about_prefs_privacy.verify_cc_json(cc_info_json_new, original_cc_data)
+    about_prefs_payments.verify_cc_json(cc_info_json_new, original_cc_data)

--- a/tests/form_autofill/test_enable_disable_autofill.py
+++ b/tests/form_autofill/test_enable_disable_autofill.py
@@ -1,10 +1,13 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutPrefs
-from modules.page_object_autofill import AddressFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import AboutPrefs, AddressFill
+
+
+@pytest.fixture()
+def prefs_category():
+    return "passwordsAutofill"
 
 
 @pytest.fixture()
@@ -14,10 +17,9 @@ def test_case():
 
 def test_enable_disable_autofill(
     driver: Firefox,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs: AboutPrefs,
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
-    util: Utilities,
     region: str,
 ):
     """
@@ -25,9 +27,8 @@ def test_enable_disable_autofill(
     the autofill popups do not appear.
 
     Arguments:
-        about_prefs_privacy: AboutPrefs instance (privacy category)
+        about_prefs: AboutPrefs instance (privacy category)
         autofill_popup: AutofillPopup instance
-        util: Utilities instance
     """
     address_autofill.open()
 
@@ -40,8 +41,8 @@ def test_enable_disable_autofill(
     # create fake data, fill it in and press submit and save on the doorhanger
     address_autofill.fill_and_save()
 
-    about_prefs_privacy.open()
-    about_prefs_privacy.get_element("save-and-fill-addresses").click()
+    about_prefs.open()
+    about_prefs.get_element("save-and-fill-addresses").click()
 
     address_autofill.open()
 

--- a/tests/form_autofill/test_form_autofill_suggestions.py
+++ b/tests/form_autofill/test_form_autofill_suggestions.py
@@ -3,7 +3,6 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import AutofillPopup
 from modules.page_object_autofill import CreditCardFill
-from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -15,7 +14,6 @@ def test_form_autofill_suggestions(
     driver: Firefox,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
-    util: Utilities,
 ):
     """
     C122401, checks that the corresponding autofill suggestion autofills the fields correctly
@@ -23,7 +21,6 @@ def test_form_autofill_suggestions(
     Arguments:
         autofill_popup: AutofillPopup instance
         credit_card_autofill: CreditCardFill instance
-        util: Utilities instance
     """
     credit_card_autofill.open()
 

--- a/tests/form_autofill/test_name_autofill_attribute.py
+++ b/tests/form_autofill/test_name_autofill_attribute.py
@@ -3,7 +3,6 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object_autofill import AddressFill
-from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -15,18 +14,16 @@ def test_name_attribute_selection(
     driver: Firefox,
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
-    util: Utilities,
     region: str,
 ):
     """
-    C122356 - This test verifies that after filling the autofill fields and saving the data, hovering over the first
-    item in the dropdown ensures that the actual value matches the expected value.
+    C122356 - This test verifies: after filling the autofill fields and saving the data, hovering
+    over the first item in the dropdown ensures that the actual value matches the expected value.
     Verifies name attribute.
 
     Arguments:
         address_autofill: AddressFill instance
         autofill_popup: AutofillPopup instance
-        util: Utilities instance
         region: country code in use
     """
     # open the navigation page
@@ -45,8 +42,8 @@ def test_name_attribute_selection(
     first_item = autofill_popup.get_nth_element(1)
     actual_value = autofill_popup.hover(first_item).get_primary_value(first_item)
 
-    # Get the primary value (street address) from the first item in the dropdown and assert that the actual value
-    # matches the expected value
+    # Get the primary value (street address) from the first item in the dropdown and assert
+    # that the actual value matches the expected value
     expected_name = autofill_sample_data.name
     assert expected_name == actual_value, (
         f"Expected {expected_name}, but got {actual_value}"

--- a/tests/form_autofill/test_private_mode_info_not_saved.py
+++ b/tests/form_autofill/test_private_mode_info_not_saved.py
@@ -4,7 +4,6 @@ from selenium.webdriver import Firefox
 from modules.browser_object import AutofillPopup
 from modules.page_object import AboutPrefs
 from modules.page_object_autofill import AddressFill
-from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -24,10 +23,9 @@ def add_to_prefs_list():
 
 def test_private_mode_info_not_saved(
     driver: Firefox,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs_addresses: AboutPrefs,
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
-    util: Utilities,
     region: str,
 ):
     """
@@ -35,10 +33,9 @@ def test_private_mode_info_not_saved(
     This only tests the last part of the written TC - case should be divided
 
     Arguments:
-        about_prefs_privacy: AboutPrefs instance (privacy category)
+        about_prefs_addresses: AboutPrefs instance
         address_autofill: AddressFill instance
         autofill_popup: AutofillPopup instance
-        util: Utilities instance
         region: country code in use
     """
     # navigate to address form page
@@ -49,11 +46,7 @@ def test_private_mode_info_not_saved(
     autofill_popup.ensure_autofill_dropdown_not_visible()
 
     # open about:prefs#privacy and switch to saved addresses dialog panel
-    about_prefs_privacy.open()
-    about_prefs_privacy.open_and_switch_to_saved_addresses_popup()
+    about_prefs_addresses.open()
 
-    # Get all saved addresses items and filter out any false data.
-    saved_address_profiles = about_prefs_privacy.get_all_saved_address_profiles()
-    assert len(saved_address_profiles) == 0, (
-        f"Expected 0 saved address, but found {len(saved_address_profiles)}."
-    )
+    # Confirm no saved addresses
+    about_prefs_addresses.element_visible("no-addresses")

--- a/tests/form_autofill/test_updating_address.py
+++ b/tests/form_autofill/test_updating_address.py
@@ -4,7 +4,6 @@ from selenium.webdriver import Firefox
 from modules.browser_object_autofill_popup import AutofillPopup
 from modules.page_object import AboutPrefs
 from modules.page_object_autofill import AddressFill
-from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -14,20 +13,19 @@ def test_case():
 
 def test_update_address(
     driver: Firefox,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs_addresses: AboutPrefs,
     address_autofill: AddressFill,
     autofill_popup: AutofillPopup,
-    util: Utilities,
     region: str,
 ):
     """
-    C122354 - This test verifies that after updating and saving the autofill name field, the updated value appears in the Saved Addresses section.
+    C122354 - This test verifies that after updating and saving the autofill name field,
+    the updated value appears in the Saved Addresses section.
 
     Arguments:
-        about_prefs_privacy: AboutPrefs instance (privacy category)
+        about_prefs_addresses: AboutPrefs instance
         address_autofill: AddressFill instance
         autofill_popup: AutofillPopup instance
-        util: Utilities instance
         region: country code in use
     """
     address_autofill.open()
@@ -47,19 +45,10 @@ def test_update_address(
     address_autofill.update_form_data(sample_data, "name", new_name_value, region)
 
     # Navigate to settings
-    about_prefs_privacy.open()
-    about_prefs_privacy.open_and_switch_to_saved_addresses_popup()
+    about_prefs_addresses.open()
 
     # Verify no dupe is saved
-    saved_addresses = about_prefs_privacy.get_all_saved_address_profiles()
-    assert len(saved_addresses) == 1, (
-        f"Expected 1 saved address, but found {len(saved_addresses)}."
-    )
+    about_prefs_addresses.confirm_n_addresses(1)
 
     # Assert that "Doe" is present in updated entry
-    found_updated_address = any(
-        new_name_value in element.text for element in saved_addresses
-    )
-    assert found_updated_address, (
-        "The new name was not found in any of the address entries."
-    )
+    about_prefs_addresses.element_has_text("saved-address-entry", new_name_value)

--- a/tests/form_autofill/test_updating_credit_card.py
+++ b/tests/form_autofill/test_updating_credit_card.py
@@ -4,10 +4,8 @@ import logging
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_autofill_popup import AutofillPopup
-from modules.page_object import AboutPrefs
-from modules.page_object_autofill import CreditCardFill
-from modules.util import Utilities
+from modules.browser_object import AutofillPopup
+from modules.page_object import AboutPrefs, CreditCardFill
 
 
 @pytest.fixture()
@@ -21,22 +19,20 @@ fields = ["cc-name", "cc-exp-month", "cc-exp-year", "cc-number"]
 @pytest.mark.parametrize("field", fields)
 def test_update_cc_no_dupe_name(
     driver: Firefox,
-    about_prefs_privacy: AboutPrefs,
+    about_prefs_payments: AboutPrefs,
     autofill_popup: AutofillPopup,
     credit_card_autofill: CreditCardFill,
-    util: Utilities,
     field: str,
     region: str,
 ):
     """
-    C122406, ensures that updating the credit card saves the correct information with no dupe profile for the name and expiry dates
-    for cvv, must create a new profile
+    C122406, ensures that updating the credit card saves the correct information with
+    no dupe profile for the name and expiry dates. For cvv, must create a new profile.
 
     Arguments:
-        about_prefs_privacy: AboutPrefs instance (privacy category)
-        autofill_popup: AutofillPopup instance
+        about_prefs_payments: AboutPrefs instance (privacy category)
+        autofill_popup: AutofillPopup instance:
         credit_card_autofill: CreditCardFill instance
-        util: Utilities instance
         field: credit card field being checked
         region: region being tested.
     """
@@ -61,17 +57,18 @@ def test_update_cc_no_dupe_name(
     )
 
     # navigate to settings
-    about_prefs_privacy.open()
-    about_prefs_privacy.open_and_switch_to_saved_payments_popup()
+    about_prefs_payments.open()
 
     # assert no dupe profile is saved
-    saved_cc = about_prefs_privacy.get_all_saved_cc_profiles()
-    assert len(saved_cc) == 1 if field != "cc-number" else len(saved_cc) == 2
+    if field == "cc-number":
+        about_prefs_payments.confirm_n_payments(2)
+    else:
+        about_prefs_payments.confirm_n_payments(1)
 
     # preprocessing for validations
-    cc_info_json = json.loads(saved_cc[0].get_dom_attribute("data-l10n-args"))
+    cc_info_json = about_prefs_payments.get_data_from_saved_payment(0)
     logging.info(f"The extracted JSON: {cc_info_json}")
     logging.info(f"The extracted cc data: {credit_card_sample_data}")
 
     # verify the items in the JSON vs the sample data
-    about_prefs_privacy.verify_cc_json(cc_info_json, credit_card_sample_data)
+    about_prefs_payments.verify_cc_json(cc_info_json, credit_card_sample_data)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=2042919)

### Description of Code / Doc Changes

* Update BasePage with a new method
* Update Form Autofill conftest with new fixtures for AboutPrefs
* Update AboutPrefs POM with new methods
* Update tests to use new methods
* selectors

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs

### Screenshots or Explanations

Lots of stuff moved! This is also a partial refactor, as FormAutofill was quite crufty.

### Comments or Future Work

Full refactor.

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
