### PR TITLE
enable 2 headed tests for ci

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -433,6 +433,7 @@ downloads:
     result: pass
     splits:
     - smoke
+    - ci
   test_download_pdf_from_context_menu:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2042660
     result: unstable
@@ -1560,6 +1561,7 @@ tabs:
     result: pass
     splits:
     - functional2
+    - ci
   test_display_customize_button:
     result: pass
     splits:


### PR DESCRIPTION
emergency PR