### PR TITLE
always set REPORTABLE when Glean runs on non-PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,6 +224,8 @@ jobs:
           $env:TEST_EXIT_CODE = $LASTEXITCODE
           mv artifacts artifacts-win || true
           exit $env:TEST_EXIT_CODE
+        env:
+          REPORTABLE: ${{ !inputs.is_pull_request }}
 
       - name: Run Tests in Win (Headed)
         if: ${{ steps.setup.conclusion == 'success' && always() && inputs.dry_run != true }}
@@ -386,6 +388,7 @@ jobs:
           }}
         env:
           FX_EXECUTABLE: /Volumes/${{ steps.install-fx.outputs.app_name }}/${{ steps.install-fx.outputs.app_name }}.app/Contents/MacOS/firefox
+          REPORTABLE: ${{ !inputs.is_pull_request }}
         run: |
           "$FX_EXECUTABLE" --version
           split="${STARFOX_SPLIT:-smoke}"


### PR DESCRIPTION
### Relevant Links

no bug

### Description of Code / Doc Changes

Set `REPORTABLE` to `true` when "Run Telemetry Tests" is selected on Win or MacOS and not a PR. Otherwise, set false on PRs, and it doesn't matter in other cases.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes scheduled Beta / DevEdition / RC

### Screenshots or Explanations

We were still requiring a confirmation of reportable in order to report Glean on scheduled smoke. This isn't good, because we generally expected reportable=false after the main headless tests run (this is why we set `REPORTABLE=true` for the headed set). Now we explicitly set `REPORTABLE` to be `false` if PR, `true` if not.


### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
