### PR TITLE
Anca/ Fix user can manage pinned extensions on the sidebar test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1526,8 +1526,7 @@ sidebar:
     splits:
     - functional2
   test_user_can_manage_pinned_extensions_on_the_sidebar:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2041403
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_vertical_tab_pinned_unpinned_with_expand_on_hover_enabled:

--- a/modules/browser_object_sidebar.py
+++ b/modules/browser_object_sidebar.py
@@ -422,7 +422,7 @@ class Sidebar(BasePage):
                 "const cd = document.querySelector('browser#sidebar')?.contentDocument;"
                 "if (!cd || cd.readyState !== 'complete') return null;"
                 "function search(root) {"
-                "  const el = root.querySelector('a[data-l10n-id=\"sidebar-manage-extensions\"]');"
+                "  const el = root.querySelector('a[data-l10n-id=\"sidebar-manage-extensions2\"]');"
                 "  if (el) { el.click(); return true; }"
                 "  for (const host of root.querySelectorAll('*')) {"
                 "    if (host.shadowRoot && search(host.shadowRoot)) return true;"


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2043393](https://bugzilla.mozilla.org/show_bug.cgi?id=2043393)
TestRail: N/A

### Description of Code / Doc Changes

- Fix test user can manage pinned extensions on the sidebar by updating locator
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
