### PR TITLE
Hani/ Fix passwords about preferences tests

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1211,7 +1211,7 @@ Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: use-primary-password
-Selector Data: "useMasterPassword"
+Selector Data: "addPrimaryPassword"
 Description: Checkbox for using primary password
 Location: about:preferences#privacy Passwords subsection
 Path to .json: modules/data/about_prefs.components.json
@@ -1463,14 +1463,14 @@ Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: saved-passwords
-Selector Data: "showPasswords"
+Selector Data: "manageSavedPasswords"
 Description: Saved passwords button in about:preferences#privacy
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: change-primary-password
-Selector Data: "changeMasterPassword"
+Selector Data: "changePrimaryPassword"
 Description: Change primary password button in about:preferences#privacy
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
@@ -1536,6 +1536,13 @@ Selector Name: doh-radio-custom-input
 Selector Data: "input"
 Description: Inner <input type="radio"> inside the dohRadioCustom shadow root; used to actually click/select the "Custom" DoH option
 Location: about:preferences#privacy (shadow DOM of dohRadioCustom)
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: turn-off-primary-password
+Selector Data: "turnOffPrimaryPassword"
+Description: "Turn off Primary Password" / remove button in the Remove Primary Password dialog, used to confirm clearing the primary password
+Location: about:preferences#privacy (Remove Primary Password dialog)
 Path to .json: modules/data/about_prefs.components.json
 ```
 #### about_profiles

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -744,8 +744,7 @@ notifications:
     - functional1
 password_manager:
   test_about_logins_copy_prompts_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_about_logins_direct_navigation:
@@ -753,13 +752,11 @@ password_manager:
     splits:
     - functional1
   test_about_logins_edit_prompts_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_about_logins_navigation_from_about_preferences:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_about_logins_navigation_from_about_protections:
@@ -807,8 +804,7 @@ password_manager:
     splits:
     - smoke
   test_add_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_add_username_via_doorhanger:
@@ -824,8 +820,7 @@ password_manager:
     splits:
     - functional2
   test_can_view_password_when_PP_enabled:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_changes_made_in_edit_mode_are_saved:
@@ -841,13 +836,11 @@ password_manager:
     splits:
     - smoke
   test_delete_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_edit_autofill_after_pp_dismissed:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_edit_generated_password_triggers_autosave:
@@ -855,8 +848,7 @@ password_manager:
     splits:
     - functional2
   test_edit_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_facebook_login_autofill_dropdown:
@@ -881,8 +873,7 @@ password_manager:
     splits:
     - smoke
   test_no_generated_password_options_with_pp_and_no_credentials:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_password_csv_correctness:
@@ -926,8 +917,7 @@ password_manager:
     splits:
     - functional2
   test_primary_password_triggered_on_about_logins_access:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043373
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_private_browsing_dismiss_doorhanger_credentials:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -543,7 +543,7 @@
     "groups": []
   },
   "use-primary-password": {
-    "selectorData": "useMasterPassword",
+    "selectorData": "addPrimaryPassword",
     "strategy": "id",
     "groups": []
   },
@@ -745,7 +745,7 @@
     "groups": []
   },
   "saved-passwords": {
-    "selectorData": "showPasswords",
+    "selectorData": "manageSavedPasswords",
     "strategy": "id",
     "groups": []
   },
@@ -761,7 +761,7 @@
     "shadowParent": "show-sidebar-checkbox"
   },
   "change-primary-password": {
-    "selectorData": "changeMasterPassword",
+    "selectorData": "changePrimaryPassword",
     "strategy": "id",
     "groups": [
       "doNotCache"
@@ -853,5 +853,10 @@
     "strategy": "id",
     "groups": [],
     "shadowParent": "doh-radio-custom"
+  },
+  "turn-off-primary-password": {
+    "selectorData": "turnOffPrimaryPassword",
+    "strategy": "id",
+    "groups": []
   }
 }

--- a/tests/password_manager/test_about_logins_copy_prompts_primary_password.py
+++ b/tests/password_manager/test_about_logins_copy_prompts_primary_password.py
@@ -24,7 +24,7 @@ def test_about_logins_copy_prompts_primary_password(driver: Firefox):
 
     # Instantiate objects
     about_logins = AboutLogins(driver)
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
     nav = Navigation(driver)
 

--- a/tests/password_manager/test_about_logins_edit_prompts_primary_password.py
+++ b/tests/password_manager/test_about_logins_edit_prompts_primary_password.py
@@ -25,7 +25,7 @@ def test_about_logins_edit_prompts_primary_password(driver: Firefox):
 
     # Instantiate objects
     about_logins = AboutLogins(driver)
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
 
     # Have a Primary Password set

--- a/tests/password_manager/test_about_logins_navigation_from_about_preferences.py
+++ b/tests/password_manager/test_about_logins_navigation_from_about_preferences.py
@@ -12,6 +12,11 @@ def test_case():
     return "2241081"
 
 
+@pytest.fixture()
+def about_prefs_category():
+    return "passwordsAutofill"
+
+
 def test_about_logins_navigation_from_about_preferences(
     driver: Firefox, about_prefs: AboutPrefs
 ):

--- a/tests/password_manager/test_add_primary_password.py
+++ b/tests/password_manager/test_add_primary_password.py
@@ -23,7 +23,7 @@ def test_add_primary_password(driver: Firefox):
     C2245178: Verify that a primary password can be added in about:preferences#privacy
     """
     # Instantiate objects
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
 
     # Select the "Use a primary password" check box to trigger the "Change Primary Password" window

--- a/tests/password_manager/test_can_view_password_when_PP_enabled.py
+++ b/tests/password_manager/test_can_view_password_when_PP_enabled.py
@@ -24,7 +24,7 @@ def test_password_can_be_shown(driver: Firefox):
     """
     # Instantiate object
     about_logins = AboutLogins(driver)
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
 
     # Open about:login and click on the "Add password" button

--- a/tests/password_manager/test_delete_primary_password.py
+++ b/tests/password_manager/test_delete_primary_password.py
@@ -20,7 +20,7 @@ def test_delete_primary_password(driver: Firefox):
     """
 
     # Instantiate objects
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
 
     # Have a Primary Password set
@@ -28,7 +28,7 @@ def test_delete_primary_password(driver: Firefox):
 
     # Uncheck the "Use a Primary Password" checkbox
     about_prefs.open()
-    about_prefs.click_on("use-primary-password")
+    about_prefs.click_on("turn-off-primary-password")
 
     # A "Remove Primary Password" prompt appears, containing a single input field for the current Primary Password
     primary_pw_popup = about_prefs.get_element("browser-popup")

--- a/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
+++ b/tests/password_manager/test_edit_autofill_after_pp_dismissed.py
@@ -33,7 +33,7 @@ def test_edit_autofill_after_pp_dismissed(driver: Firefox):
     """
 
     # Instantiate objects
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
     tabs = TabBar(driver)
     about_logins = AboutLogins(driver)

--- a/tests/password_manager/test_edit_primary_password.py
+++ b/tests/password_manager/test_edit_primary_password.py
@@ -25,7 +25,7 @@ def test_edit_primary_password(driver: Firefox):
     """
 
     # Instantiate objects
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
 
     # Have a Primary Password set

--- a/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
+++ b/tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
@@ -23,7 +23,7 @@ def test_no_generated_password_options_with_pp_and_no_credentials(driver: Firefo
     """
 
     # Instantiate objects
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
     tabs = TabBar(driver)
     about_logins = AboutLogins(driver)

--- a/tests/password_manager/test_primary_password_triggered_on_about_logins_access.py
+++ b/tests/password_manager/test_primary_password_triggered_on_about_logins_access.py
@@ -33,7 +33,7 @@ def test_primary_password_triggered_on_about_logins_access_via_hamburger_menu(
     """
 
     # Instantiate objects
-    about_prefs = AboutPrefs(driver, category="privacy")
+    about_prefs = AboutPrefs(driver, category="passwordsAutofill")
     ba = BrowserActions(driver)
     panel_ui = PanelUi(driver)
     tabs = TabBar(driver)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2043373](https://bugzilla.mozilla.org/show_bug.cgi?id=2043373)
TestRail: N/A

### Description of Code / Doc Changes

* Fix:
    tests/password_manager/test_about_logins_navigation_from_about_preferences.py
    tests/password_manager/test_about_logins_edit_prompts_primary_password.py
    tests/password_manager/test_about_logins_copy_prompts_primary_password.py
    tests/password_manager/test_add_primary_password.py
    tests/password_manager/test_can_view_password_when_PP_enabled.py
    tests/password_manager/test_primary_password_triggered_on_about_logins_access.py
    tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
    tests/password_manager/test_delete_primary_password.py
    tests/password_manager/test_edit_primary_password.py
    tests/password_manager/test_edit_autofill_after_pp_dismissed.py

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
