### PR TITLE
Hani/ Fix test_close_pinned_tab_via_mouse

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1568,8 +1568,7 @@ tabs:
     splits:
     - functional2
   test_close_pinned_tab_via_mouse:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2042645
-    result: unstable
+    result: pass
     splits:
     - smoke
     - ci


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2042645](https://bugzilla.mozilla.org/show_bug.cgi?id=2042645)
TestRail: N/A

### Description of Code / Doc Changes

* test_close_pinned_tab_via_mouse passed every time while run locally

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
