### PR TITLE
Hani/ Test ensure panel renders of first run

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -5354,3 +5354,38 @@ Description: Banner header label shown in the Trustpanel when the connection is 
 Location: Trustpanel - Connection protections tab (insecure banner)
 Path to .json: modules/data/trust_panel.components.json
 ```
+```
+Selector Name: site-icon
+Selector Data: "trustpanel-popup-icon"
+Description: Site favicon displayed at the top of the Trustpanel (e.g. the YouTube icon)
+Location: Trustpanel - header row
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: site-domain
+Selector Data: "trustpanel-popup-host"
+Description: Domain/host label shown next to the site favicon (value attribute holds the host, e.g. "youtube.com")
+Location: Trustpanel - header row
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: connection-icon
+Selector Data: "trustpanel-connection-icon"
+Description: Lock-state icon shown in the "Connection secure" row of the Trustpanel
+Location: Trustpanel - connection row
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: purple-card
+Selector Data: "trustpanel-graphic-section"
+Description: Purple graphic/banner card in the Trustpanel ("Firefox is on guard!")
+Location: Trustpanel - graphic section
+Path to .json: modules/data/trust_panel.components.json
+```
+```
+Selector Name: clear-cookies-button
+Selector Data: "trustpanel-clear-cookies-button"
+Description: "Clear cookies and site data" action button in the Trustpanel footer
+Location: Trustpanel - footer actions
+Path to .json: modules/data/trust_panel.components.json
+```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1256,6 +1256,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_ensure_panel_renders_on_first_run:
+    result: pass
+    splits:
+    - functional2
   test_etp_panel_displayed_when_all_protections_disabled_custom:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
     result: unstable

--- a/modules/data/trust_panel.components.json
+++ b/modules/data/trust_panel.components.json
@@ -180,5 +180,30 @@
         "selectorData": "[data-l10n-id='trustpanel-insecure-section-header']",
         "strategy": "css",
         "groups": []
+    },
+    "site-icon": {
+        "selectorData": "trustpanel-popup-icon",
+        "strategy": "id",
+        "groups": []
+    },
+    "site-domain": {
+        "selectorData": "trustpanel-popup-host",
+        "strategy": "id",
+        "groups": []
+    },
+    "connection-icon": {
+        "selectorData": "trustpanel-connection-icon",
+        "strategy": "id",
+        "groups": []
+    },
+    "purple-card": {
+        "selectorData": "trustpanel-graphic-section",
+        "strategy": "id",
+        "groups": []
+    },
+    "clear-cookies-button": {
+        "selectorData": "trustpanel-clear-cookies-button",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/security_and_privacy/test_ensure_panel_renders_on_first_run.py
+++ b/tests/security_and_privacy/test_ensure_panel_renders_on_first_run.py
@@ -12,7 +12,14 @@ def test_case():
     return "3054026"
 
 
-def test_ensure_panel_renders_on_first_run(driver: Firefox, trust_panel: TrustPanel):
+@pytest.fixture()
+def temp_selectors() -> dict:
+    return {"yt-icon": {"selectorData": "yt-icon", "strategy": "class", "groups": []}}
+
+
+def test_ensure_panel_renders_on_first_run(
+    driver: Firefox, trust_panel: TrustPanel, temp_selectors: dict
+):
     """
     C3054026 - The panel opens & renders correctly on the first run
     """
@@ -22,6 +29,8 @@ def test_ensure_panel_renders_on_first_run(driver: Firefox, trust_panel: TrustPa
 
     # Open test page and click on the shield icon
     test_page.open()
+    test_page.elements |= temp_selectors
+    test_page.element_visible("yt-icon")
     trust_panel.open_panel()
 
     # Site icon and its domain are displayed

--- a/tests/security_and_privacy/test_ensure_panel_renders_on_first_run.py
+++ b/tests/security_and_privacy/test_ensure_panel_renders_on_first_run.py
@@ -1,0 +1,46 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TrustPanel
+from modules.page_object import GenericPage
+
+TEST_URL = "https://youtube.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054026"
+
+
+def test_ensure_panel_renders_on_first_run(driver: Firefox):
+    """
+    C3054026 - The panel opens & renders correctly on the first run
+    """
+
+    # Instantiate objects
+    test_page = GenericPage(driver, url=TEST_URL)
+    trust_panel = TrustPanel(driver)
+
+    # Open test page and click on the shield icon
+    test_page.open()
+    trust_panel.open_panel()
+
+    # Site icon and its domain are displayed
+    trust_panel.element_visible("site-icon")
+    trust_panel.element_visible("site-domain")
+
+    # Lock state icon with the text: "Connection secure" are displayed
+    trust_panel.element_visible("trustpanel-connect-button")
+    trust_panel.element_visible("connection-icon")
+
+    # Purple card
+    trust_panel.element_visible("purple-card")
+
+    # “Enhanced Tracking Protection is on” toggle
+    trust_panel.element_visible("trustpanel-toggle-button")
+
+    # “Clear cookies and site data”
+    trust_panel.element_visible("clear-cookies-button")
+
+    # “Privacy settings”
+    trust_panel.element_visible("trustpanel-privacy-link")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025814](https://bugzilla.mozilla.org/show_bug.cgi?id=2025814)
TestRail: [3054026](https://mozilla.testrail.io/index.php?/cases/view/3054026)

### Description of Code / Doc Changes

* Add test to verify that the panel opens & renders correctly on the first run

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
