### PR TITLE
Tracy/ Fix for false positive reporting due  (bug 2044175)

### DIFF
--- a/modules/testrail.py
+++ b/modules/testrail.py
@@ -27,6 +27,14 @@ from time import sleep
 
 import requests
 
+TESTRAIL_STATUS = {
+    "passed": 1,
+    "blocked": 2,
+    "skipped": 3,
+    "xfailed": 4,
+    "failed": 5,
+}
+
 
 class APIClient:
     """
@@ -433,13 +441,7 @@ class TestRail:
     ):
         """Given a project id, a run id, and a suite id, for each case given a status,
         update the test objects with the correct status code"""
-        status_key = {
-            "passed": 1,
-            "skipped": 3,
-            "blocked": 2,
-            "xfailed": 4,
-            "failed": 5,
-        }
+        status_key = TESTRAIL_STATUS
         if not test_case_ids:
             test_case_ids = [
                 test_case.get("id")

--- a/modules/testrail.py
+++ b/modules/testrail.py
@@ -27,6 +27,9 @@ from time import sleep
 
 import requests
 
+# Values double as severity scores: passed < blocked < skipped < xfailed < failed.
+# mark_results() relies on this ordering to avoid downgrading a result, so keep
+# these in ascending order of severity if statuses are ever added/changed.
 TESTRAIL_STATUS = {
     "passed": 1,
     "blocked": 2,

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -587,7 +587,7 @@ def mark_results(testrail_session: TestRail, test_results):
             test_cases_ids = []
             durations = []
             for i, test_case in enumerate(all_test_cases):
-                current_severity = current_results.get(test_case) or 0
+                current_severity = current_results.get(test_case, 0)
                 if TESTRAIL_STATUS[category] < current_severity:
                     continue
                 test_cases_ids.append(test_case)

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -24,6 +24,8 @@ TESTRAIL_RUN_FMT = (
 PLAN_NAME_RE = re.compile(r"\[(\w+) (\d+)\]")
 TEST_KEY_LOCATION = os.path.join("manifests", "key.yaml")
 CONFIG_GROUP_ID = 95
+_CATEGORY_SEVERITY = {"failed": 4, "xfailed": 3, "blocked": 2, "passed": 1}
+_STATUS_ID_SEVERITY = {1: 1, 2: 2, 5: 4}  # TestRail: passed=1, blocked=2, failed=5
 TESTRAIL_FX_DESK_PRJ = 17
 TC_EXECUTION_TEMPLATE = (
     "https://firefox-ci-tc.services.mozilla.com/tasks/"
@@ -583,13 +585,17 @@ def mark_results(testrail_session: TestRail, test_results):
                 all_test_cases.append(result.get("test_case"))
                 all_durations.append(result.get("duration"))
 
-            # Don't set passed tests to another status.
+            # Never downgrade a result — skip if the new category is less severe.
             test_cases_ids = []
             durations = []
             for i, test_case in enumerate(all_test_cases):
-                if current_results.get(test_case) != 1:
-                    test_cases_ids.append(test_case)
-                    durations.append(all_durations[i])
+                current_severity = _STATUS_ID_SEVERITY.get(
+                    current_results.get(test_case), 0
+                )
+                if _CATEGORY_SEVERITY[category] < current_severity:
+                    continue
+                test_cases_ids.append(test_case)
+                durations.append(all_durations[i])
             logging.warning(
                 f"Setting the following test cases in run {run_id} to {category}: {test_cases_ids}"
             )

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -25,7 +25,6 @@ PLAN_NAME_RE = re.compile(r"\[(\w+) (\d+)\]")
 TEST_KEY_LOCATION = os.path.join("manifests", "key.yaml")
 CONFIG_GROUP_ID = 95
 _CATEGORY_SEVERITY = {name: sid for name, sid in TESTRAIL_STATUS.items() if name != "skipped"}
-_STATUS_ID_SEVERITY = {sid: sid for name, sid in TESTRAIL_STATUS.items() if name != "skipped"}
 TESTRAIL_FX_DESK_PRJ = 17
 TC_EXECUTION_TEMPLATE = (
     "https://firefox-ci-tc.services.mozilla.com/tasks/"
@@ -589,9 +588,7 @@ def mark_results(testrail_session: TestRail, test_results):
             test_cases_ids = []
             durations = []
             for i, test_case in enumerate(all_test_cases):
-                current_severity = _STATUS_ID_SEVERITY.get(
-                    current_results.get(test_case), 0
-                )
+                current_severity = current_results.get(test_case) or 0
                 if _CATEGORY_SEVERITY[category] < current_severity:
                     continue
                 test_cases_ids.append(test_case)

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -24,7 +24,9 @@ TESTRAIL_RUN_FMT = (
 PLAN_NAME_RE = re.compile(r"\[(\w+) (\d+)\]")
 TEST_KEY_LOCATION = os.path.join("manifests", "key.yaml")
 CONFIG_GROUP_ID = 95
-_CATEGORY_SEVERITY = {name: sid for name, sid in TESTRAIL_STATUS.items() if name != "skipped"}
+_CATEGORY_SEVERITY = {
+    name: sid for name, sid in TESTRAIL_STATUS.items() if name != "skipped"
+}
 TESTRAIL_FX_DESK_PRJ = 17
 TC_EXECUTION_TEMPLATE = (
     "https://firefox-ci-tc.services.mozilla.com/tasks/"

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -9,7 +9,7 @@ import sys
 from manifests.testkey import TestKey
 from modules import taskcluster as tc
 from modules import testrail as tr
-from modules.testrail import TestRail
+from modules.testrail import TESTRAIL_STATUS, TestRail
 from modules.util import env_true
 from scripts.choose_l10n_ci_set import select_l10n_mappings
 from scripts.collect_executables import get_fx_version
@@ -24,8 +24,8 @@ TESTRAIL_RUN_FMT = (
 PLAN_NAME_RE = re.compile(r"\[(\w+) (\d+)\]")
 TEST_KEY_LOCATION = os.path.join("manifests", "key.yaml")
 CONFIG_GROUP_ID = 95
-_CATEGORY_SEVERITY = {"failed": 4, "xfailed": 3, "blocked": 2, "passed": 1}
-_STATUS_ID_SEVERITY = {1: 1, 2: 2, 5: 4}  # TestRail: passed=1, blocked=2, failed=5
+_CATEGORY_SEVERITY = {name: sid for name, sid in TESTRAIL_STATUS.items() if name != "skipped"}
+_STATUS_ID_SEVERITY = {sid: sid for name, sid in TESTRAIL_STATUS.items() if name != "skipped"}
 TESTRAIL_FX_DESK_PRJ = 17
 TC_EXECUTION_TEMPLATE = (
     "https://firefox-ci-tc.services.mozilla.com/tasks/"

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -24,9 +24,6 @@ TESTRAIL_RUN_FMT = (
 PLAN_NAME_RE = re.compile(r"\[(\w+) (\d+)\]")
 TEST_KEY_LOCATION = os.path.join("manifests", "key.yaml")
 CONFIG_GROUP_ID = 95
-_CATEGORY_SEVERITY = {
-    name: sid for name, sid in TESTRAIL_STATUS.items() if name != "skipped"
-}
 TESTRAIL_FX_DESK_PRJ = 17
 TC_EXECUTION_TEMPLATE = (
     "https://firefox-ci-tc.services.mozilla.com/tasks/"
@@ -591,7 +588,7 @@ def mark_results(testrail_session: TestRail, test_results):
             durations = []
             for i, test_case in enumerate(all_test_cases):
                 current_severity = current_results.get(test_case) or 0
-                if _CATEGORY_SEVERITY[category] < current_severity:
+                if TESTRAIL_STATUS[category] < current_severity:
                     continue
                 test_cases_ids.append(test_case)
                 durations.append(all_durations[i])


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2044175

#### Description of Code / Doc Changes
Changes in testrail_integration.py

Gave bot a couple tries at this.  It's second attempt appeared to be more closely in line with what Ben had mentioned in 1:1.

  - Module level: added _CATEGORY_SEVERITY and _STATUS_ID_SEVERITY dicts mapping category names and TestRail status IDs to a
   common severity scale.                                                                                                   
  - mark_results guard: replaced the != 1 check with a severity comparison — a result is only skipped if the incoming       
    category is strictly less severe than what TestRail already has. This means passed can no longer overwrite failed,        but failed can always overwrite anything.                                                                                     
                                           

#### Workflow Checklist
- [X] Reviewers have been requested.

Thank you!
