### PR TITLE
Hani/ Remove unstable from test_telemetry_download_and_open.py

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -469,8 +469,7 @@ downloads:
     splits:
     - functional1
   test_telemetry_download_and_open:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043391
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_telemetry_pdf_download_open:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2043391](https://bugzilla.mozilla.org/show_bug.cgi?id=2043391)

### Description of Code / Doc Changes

* Remove unstable from tests/downloads/test_telemetry_download_and_open.py
* Test passed locally

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
