### PR TITLE
Hani/ Test see all trackers redirects to blocked trackers

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1370,6 +1370,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_see_all_link_redirects_to_blocked_trackers:
+    result: pass
+    splits:
+    - functional2
   test_sidebar_removed_on_end_private_session:
     result: pass
     splits:

--- a/tests/security_and_privacy/test_see_all_link_redirects_to_blocked_trackers.py
+++ b/tests/security_and_privacy/test_see_all_link_redirects_to_blocked_trackers.py
@@ -1,0 +1,32 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TrustPanel
+from modules.page_object import GenericPage
+
+TEST_URL = "https://edition.cnn.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "3054033"
+
+
+def test_see_all_link_redirects_to_blocked_trackers(driver: Firefox, trust_panel: TrustPanel):
+    """
+    C3054033 - “See all” link correctly redirects the user to the blocked trackers
+    """
+
+    # Instantiate objects
+    test_page = GenericPage(driver, url=TEST_URL)
+
+    # Open test page and click on the shield icon
+    test_page.open()
+    trust_panel.open_panel()
+
+    # Click on the "See All" button
+    trust_panel.click_see_all()
+
+    # The blocked and allowed trackers are displayed in the panel
+    trust_panel.element_visible("blocked-items")
+    trust_panel.element_visible("detected-items")

--- a/tests/security_and_privacy/test_see_all_link_redirects_to_blocked_trackers.py
+++ b/tests/security_and_privacy/test_see_all_link_redirects_to_blocked_trackers.py
@@ -12,7 +12,9 @@ def test_case():
     return "3054033"
 
 
-def test_see_all_link_redirects_to_blocked_trackers(driver: Firefox, trust_panel: TrustPanel):
+def test_see_all_link_redirects_to_blocked_trackers(
+    driver: Firefox, trust_panel: TrustPanel
+):
     """
     C3054033 - “See all” link correctly redirects the user to the blocked trackers
     """
@@ -25,6 +27,7 @@ def test_see_all_link_redirects_to_blocked_trackers(driver: Firefox, trust_panel
     trust_panel.open_panel()
 
     # Click on the "See All" button
+    trust_panel.wait_for_trackers()
     trust_panel.click_see_all()
 
     # The blocked and allowed trackers are displayed in the panel


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2025819](https://bugzilla.mozilla.org/show_bug.cgi?id=2025819)
TestRail: [3054033](https://mozilla.testrail.io/index.php?/cases/view/3054033)

### Description of Code / Doc Changes

* Add test to verify that “See all” link correctly redirects the user to the blocked trackers

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
