### PR TITLE
Anca/nextdns as doh provider

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1539,6 +1539,20 @@ Location: about:preferences#privacy (shadow DOM of dohRadioCustom)
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
+Selector Name: doh-provider-select
+Selector Data: "dohProviderSelect"
+Description: "Choose provider" moz-select host element in the Custom-mode DoH provider menu; options are hydrated asynchronously from remote settings
+Location: about:preferences#privacy - DNS over HTTPS advanced section (Custom mode)
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: doh-provider-select-inner
+Selector Data: "select"
+Description: Inner native <select> inside the dohProviderSelect shadow root; used with Selenium's Select class to pick a DoH provider by value
+Location: about:preferences#privacy (shadow DOM of dohProviderSelect)
+Path to .json: modules/data/about_prefs.components.json
+```
+```
 Selector Name: turn-off-primary-password
 Selector Data: "turnOffPrimaryPassword"
 Description: "Turn off Primary Password" / remove button in the Remove Primary Password dialog, used to confirm clearing the primary password

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -684,6 +684,10 @@ networking:
     result: pass
     splits:
     - functional1
+  test_nextdns_as_doh_provider:
+    result: pass
+    splits:
+    - functional1
 notifications:
   test_audio_video_permissions_notification:
     comment: Issue with Mac GHA? trying pass to see what happens.

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -854,6 +854,17 @@
     "groups": [],
     "shadowParent": "doh-radio-custom"
   },
+  "doh-provider-select": {
+    "selectorData": "dohProviderSelect",
+    "strategy": "id",
+    "groups": []
+  },
+  "doh-provider-select-inner": {
+    "selectorData": "select",
+    "strategy": "css",
+    "groups": [],
+    "shadowParent": "doh-provider-select"
+  },
   "turn-off-primary-password": {
     "selectorData": "turnOffPrimaryPassword",
     "strategy": "id",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -224,6 +224,27 @@ class AboutPrefs(BasePage):
         self.element_attribute_contains(option_id, "checked", "")
         return self
 
+    def select_doh_provider(self, provider_value: str) -> BasePage:
+        """Select a DoH provider from the Custom-mode provider menu.
+
+        Requires `select_doh_protection_level("custom")` first. The provider
+        list is hydrated asynchronously from remote settings, so wait until
+        the target option is present before selecting.
+        """
+        self.wait.until(
+            lambda _: any(
+                opt.get_attribute("value") == provider_value
+                for opt in self.get_element("doh-provider-select-inner").find_elements(
+                    By.TAG_NAME, "option"
+                )
+            )
+        )
+        Select(self.get_element("doh-provider-select-inner")).select_by_value(
+            provider_value
+        )
+        self.element_attribute_is("doh-provider-select", "value", provider_value)
+        return self
+
     def verify_doh_provider(self, provider_name: str) -> BasePage:
         """Wait until the DoH status box reports the given provider name."""
         self.element_attribute_contains(

--- a/tests/networking/test_nextdns_as_doh_provider.py
+++ b/tests/networking/test_nextdns_as_doh_provider.py
@@ -1,0 +1,41 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutConfig, AboutPrefs
+
+NEXTDNS_URL = "https://firefox.dns.nextdns.io/"
+TRR_PREF = "network.trr.uri"
+
+
+@pytest.fixture()
+def test_case():
+    return "545742"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("browser.search.region", "US"),
+        ("browser.aboutConfig.showWarning", False),
+    ]
+
+
+def test_nextdns_as_doh_provider(driver: Firefox):
+    """
+    C545742 - Verify that NextDNS can be set as the DoH provider in Custom mode
+    """
+    # Instantiate objects
+    prefs = AboutPrefs(driver, category="privacy")
+    about_config = AboutConfig(driver)
+
+    # Open DoH Advanced sub-pane and switch to Custom mode (provider menu only shows here)
+    prefs.open()
+    prefs.open_doh_advanced()
+    prefs.select_doh_protection_level("custom")
+
+    # Select NextDNS from the provider dropdown and verify status box reflects it
+    prefs.select_doh_provider(NEXTDNS_URL)
+    prefs.verify_doh_provider("NextDNS")
+
+    # Verify network.trr.uri in about:config
+    assert about_config.get_pref_value(TRR_PREF) == NEXTDNS_URL


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2011141](https://bugzilla.mozilla.org/show_bug.cgi?id=2011141)
TestRail: [545742](https://mozilla.testrail.io/index.php?/cases/view/545742)

### Description of Code / Doc Changes

 - Add nextdns as doh provider test
 - Add selectors based on the new UI and a new doh selection method in POM

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
