### PR TITLE
Hani/ Test etp toggle private window

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1366,6 +1366,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_etp_toggle_on_off_behavior_private_window:
+    result: pass
+    splits:
+    - functional2
   test_private_window_from_panelui:
     result: pass
     splits:

--- a/tests/security_and_privacy/test_etp_toggle_on_off_behavior_private_window.py
+++ b/tests/security_and_privacy/test_etp_toggle_on_off_behavior_private_window.py
@@ -1,8 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import TrustPanel
-from modules.browser_object_panel_ui import PanelUi
+from modules.browser_object import TrustPanel, PanelUi
 from modules.page_object import GenericPage
 
 TEST_URL = "https://youtube.com/"

--- a/tests/security_and_privacy/test_etp_toggle_on_off_behavior_private_window.py
+++ b/tests/security_and_privacy/test_etp_toggle_on_off_behavior_private_window.py
@@ -13,18 +13,17 @@ def test_case():
 
 
 def test_etp_toggle_on_off_behavior_private_window(
-    driver: Firefox, trust_panel: TrustPanel
+    driver: Firefox, trust_panel: TrustPanel, panel_ui: PanelUi
 ):
     """
     C2230197 - Font Visibility Protection - verify that Fingerprinting can be disabled/enabled trough the ETP toggle
     """
 
     # Instantiate objects
-    panel = PanelUi(driver)
     test_page = GenericPage(driver, url=TEST_URL)
 
     # Open a private window and switch to it
-    panel.open_and_switch_to_new_window("private")
+    panel_ui.open_and_switch_to_new_window("private")
 
     # Open test page and click on the shield icon
     test_page.open()

--- a/tests/security_and_privacy/test_etp_toggle_on_off_behavior_private_window.py
+++ b/tests/security_and_privacy/test_etp_toggle_on_off_behavior_private_window.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import TrustPanel, PanelUi
+from modules.browser_object import PanelUi, TrustPanel
 from modules.page_object import GenericPage
 
 TEST_URL = "https://youtube.com/"

--- a/tests/security_and_privacy/test_etp_toggle_on_off_behavior_private_window.py
+++ b/tests/security_and_privacy/test_etp_toggle_on_off_behavior_private_window.py
@@ -1,0 +1,57 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TrustPanel
+from modules.browser_object_panel_ui import PanelUi
+from modules.page_object import GenericPage
+
+TEST_URL = "https://youtube.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "2230197"
+
+
+def test_etp_toggle_on_off_behavior_private_window(
+    driver: Firefox, trust_panel: TrustPanel
+):
+    """
+    C2230197 - Font Visibility Protection - verify that Fingerprinting can be disabled/enabled trough the ETP toggle
+    """
+
+    # Instantiate objects
+    panel = PanelUi(driver)
+    test_page = GenericPage(driver, url=TEST_URL)
+
+    # Open a private window and switch to it
+    panel.open_and_switch_to_new_window("private")
+
+    # Open test page and click on the shield icon
+    test_page.open()
+    trust_panel.open_panel()
+
+    # Click the blue switch to OFF
+    trust_panel.trustpanel_toggle_on_off()
+
+    # Site reloads; shield icon shows disabled state
+    trust_panel.element_visible("shield-icon-disabled")
+    trust_panel.open_panel()
+
+    # Toggle turns gray
+    trust_panel.element_visible("trustpanel-tracking-protection-disabled")
+
+    # Panel strings update to “You turned off protections”
+    trust_panel.trustpanel_status("off")
+
+    # Click the gray switch to turn ON the panel
+    trust_panel.trustpanel_toggle_on_off()
+
+    # The panel reverts to default
+    trust_panel.open_panel()
+
+    # Tracker blocking is active
+    trust_panel.trustpanel_status("on")
+
+    # Icon and UI updates to reflect the blocking trackers; "Firefox is on guard" text is displayed inside the card
+    trust_panel.element_visible("trustpanel-header-enabled")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2015773](https://bugzilla.mozilla.org/show_bug.cgi?id=2015773)
TestRail: [2230197](https://mozilla.testrail.io/index.php?/cases/view/2230197)

### Description of Code / Doc Changes

* Add test to verify that etp can be toggled on off in private window, since the first step was referring to private window
* I didn't follow the exact steps because they require installing the JetBrains Mono font and verifying that it is being used

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [ ] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [x] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
