### PR TITLE
Edwyn/ Test copy clean link

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -2438,7 +2438,7 @@ Path to .json: modules/data/context_menu.components.json
 Selector Name: context-menu-copy-clean-link
 Selector Data: strip-on-share
 Description: "Copy Clean Link" context menu option
-Location: Tab context menu
+Location: Address bar context menu
 Path to .json: modules/data/context_menu.components.json
 ```
 #### credit_card_fill

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -2434,6 +2434,13 @@ Description: "Ask ChatGPT" context menu option
 Location: Tab context menu
 Path to .json: modules/data/context_menu.components.json
 ```
+```
+Selector Name: context-menu-copy-clean-link
+Selector Data: strip-on-share
+Description: "Copy Clean Link" context menu option
+Location: Tab context menu
+Path to .json: modules/data/context_menu.components.json
+```
 #### credit_card_fill
 ```
 Selector Name: form-field

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1212,6 +1212,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_copy_clean_link:
+    result: pass
+    splits:
+    - functional2
   test_cross_site_tracking_cookies_blocked:
     result: deprecated
     splits:
@@ -1296,6 +1300,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_etp_toggle_on_off_behavior_private_window:
+    result: pass
+    splits:
+    - functional2
   test_extended_certificate_messaging_displayed_in_panel:
     result: pass
     splits:
@@ -1372,10 +1380,6 @@ security_and_privacy:
     splits:
     - functional2
   test_private_session_history_exclusion:
-    result: pass
-    splits:
-    - functional2
-  test_etp_toggle_on_off_behavior_private_window:
     result: pass
     splits:
     - functional2

--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -332,5 +332,10 @@
         "selectorData": "context_askChat",
         "strategy": "id",
         "groups": []
+    },
+    "context-menu-copy-clean-link": {
+        "selectorData": "strip-on-share",
+        "strategy": "id",
+        "groups": []
     }
 }

--- a/tests/security_and_privacy/test_copy_clean_link.py
+++ b/tests/security_and_privacy/test_copy_clean_link.py
@@ -37,5 +37,5 @@ def test_copy_clean_link(driver: Firefox):
     nav.context_click_in_awesome_bar()
     nav.perform_key_combo_chrome(Keys.CONTROL, "v")
     with driver.context(driver.CONTEXT_CHROME):
-            pasted_url = driver.find_element(By.ID, "urlbar-input").get_attribute("value")
+        pasted_url = driver.find_element(By.ID, "urlbar-input").get_attribute("value")
     assert pasted_url == EXPECTED_URL

--- a/tests/security_and_privacy/test_copy_clean_link.py
+++ b/tests/security_and_privacy/test_copy_clean_link.py
@@ -1,6 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.keys import Keys
+
 from modules.browser_object import Navigation
 
 SOURCE_URL = "https://example.com/?fbclid=1234"

--- a/tests/security_and_privacy/test_copy_clean_link.py
+++ b/tests/security_and_privacy/test_copy_clean_link.py
@@ -3,7 +3,6 @@ from selenium.webdriver import Firefox
 from selenium.webdriver.common.keys import Keys
 
 from modules.browser_object import Navigation
-import time
 from selenium.webdriver.common.by import By
 
 SOURCE_URL = "https://example.com/?fbclid=1234"

--- a/tests/security_and_privacy/test_copy_clean_link.py
+++ b/tests/security_and_privacy/test_copy_clean_link.py
@@ -19,26 +19,22 @@ def test_case():
 def add_to_prefs_list():
     return [
         ("privacy.query_stripping.strip_on_share.enabled", True),
-        ("privacy.query_stripping.enabled", True),
+        ("privacy.query_stripping.enabled", False),
     ]
 
 
 def test_copy_clean_link(driver: Firefox):
     # Open a new tab and load source URL
     nav = Navigation(driver)
-
     nav.type_in_awesome_bar(SOURCE_URL)
 
     # Select URL and copy clean link from address bar
-    time.sleep(1)
     nav.perform_key_combo_chrome(Keys.CONTROL, "l")
-    time.sleep(1)
     nav.context_click_in_awesome_bar()
     nav.context_menu.click_and_hide_menu("context-menu-copy-clean-link")
 
-    # Paste-and-go in a new tab and verify query params are stripped
+    # Paste in a new tab and verify query params are stripped
     nav.open_and_switch_to_new_window("tab")
-    time.sleep(1)
     nav.context_click_in_awesome_bar()
     nav.perform_key_combo_chrome(Keys.CONTROL, "v")
     with driver.context(driver.CONTEXT_CHROME):

--- a/tests/security_and_privacy/test_copy_clean_link.py
+++ b/tests/security_and_privacy/test_copy_clean_link.py
@@ -1,0 +1,46 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.keys import Keys
+
+from modules.browser_object import Navigation
+import time
+from selenium.webdriver.common.by import By
+
+SOURCE_URL = "https://example.com/?fbclid=1234"
+EXPECTED_URL = "https://example.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "2307354"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("privacy.query_stripping.strip_on_share.enabled", True),
+        ("privacy.query_stripping.enabled", True),
+    ]
+
+
+def test_copy_clean_link(driver: Firefox):
+    # Open a new tab and load source URL
+    nav = Navigation(driver)
+
+    nav.type_in_awesome_bar(SOURCE_URL)
+
+    # Select URL and copy clean link from address bar
+    time.sleep(1)
+    nav.perform_key_combo_chrome(Keys.CONTROL, "l")
+    time.sleep(1)
+    nav.context_click_in_awesome_bar()
+    nav.context_menu.click_and_hide_menu("context-menu-copy-clean-link")
+
+    # Paste-and-go in a new tab and verify query params are stripped
+    nav.open_and_switch_to_new_window("tab")
+    time.sleep(1)
+    nav.context_click_in_awesome_bar()
+    nav.perform_key_combo_chrome(Keys.CONTROL, "v")
+    with driver.context(driver.CONTEXT_CHROME):
+            pasted_url = driver.find_element(By.ID, "urlbar-input").get_attribute("value")
+    assert pasted_url == EXPECTED_URL

--- a/tests/security_and_privacy/test_copy_clean_link.py
+++ b/tests/security_and_privacy/test_copy_clean_link.py
@@ -1,9 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.keys import Keys
-
 from modules.browser_object import Navigation
-from selenium.webdriver.common.by import By
 
 SOURCE_URL = "https://example.com/?fbclid=1234"
 EXPECTED_URL = "https://example.com/"
@@ -23,7 +21,7 @@ def add_to_prefs_list():
 
 
 def test_copy_clean_link(driver: Firefox):
-    # Open a new tab and load source URL
+    # Load source URL into address bar
     nav = Navigation(driver)
     nav.type_in_awesome_bar(SOURCE_URL)
 
@@ -35,7 +33,5 @@ def test_copy_clean_link(driver: Firefox):
     # Paste in a new tab and verify query params are stripped
     nav.open_and_switch_to_new_window("tab")
     nav.context_click_in_awesome_bar()
-    nav.perform_key_combo_chrome(Keys.CONTROL, "v")
-    with driver.context(driver.CONTEXT_CHROME):
-        pasted_url = driver.find_element(By.ID, "urlbar-input").get_attribute("value")
-    assert pasted_url == EXPECTED_URL
+    nav.context_menu.click_and_hide_menu("context-menu-paste")
+    assert nav.get_awesome_bar_text() == EXPECTED_URL


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2015774](https://bugzilla.mozilla.org/show_bug.cgi?id=2015774)
TestRail: [2307354](https://mozilla.testrail.io/index.php?/cases/view/2307354)

### Description of Code / Doc Changes

- Add test to verify query parameters are stripped when using copy clean link.
- Add selector for copy clean link.

### Process Changes Required

N/A

### Screenshots or Explanations

- Skipped pre-commit due to failing git hook errors.
- Only used https://www.example.com/?fbclid=1234 for test, no https://output.jsbin.com/munovedasi as test felt redundant using both and description on what to do with the latter is unclear.

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
