### PR TITLE
Bug 2009705: Verify that a PDF with filled data is successfully downloaded in Private window

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -967,7 +967,7 @@ pdf_viewer:
     splits:
     - functional2
   test_download_pdf_data:
-    result: pass
+    result: unstable
     splits:
     - functional2
   test_download_pdf_with_form_fields:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -966,7 +966,7 @@ pdf_viewer:
     result: unstable
     splits:
     - functional2
-  test_download_pdf_data
+  test_download_pdf_data:
     result: pass
     splits:
     - functional2

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -966,6 +966,10 @@ pdf_viewer:
     result: unstable
     splits:
     - functional2
+  test_download_pdf_data
+    result: pass
+    splits:
+    - functional2
   test_download_pdf_with_form_fields:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2018768
     result: unstable

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -967,7 +967,7 @@ pdf_viewer:
     splits:
     - functional2
   test_download_pdf_data:
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_download_pdf_with_form_fields:

--- a/tests/pdf_viewer/conftest.py
+++ b/tests/pdf_viewer/conftest.py
@@ -1,8 +1,13 @@
+import os
+import time
 from shutil import copyfile
 
 import pytest
 
 from modules.page_object import GenericPdf
+
+DOWNLOAD_TIMEOUT_SEC = 5.0
+POLL_INTERVAL_SEC = 1.0
 
 
 @pytest.fixture()
@@ -38,3 +43,26 @@ def pdf_file_path(tmp_path, file_name: str):
 @pytest.fixture()
 def pdf_viewer(driver, pdf_file_path):
     return GenericPdf(driver, pdf_url=f"file://{pdf_file_path}")
+
+
+@pytest.fixture()
+def wait_for_file_download():
+    """Return a helper that blocks until a file finishes downloading."""
+
+    def _wait_for_file_download(
+        saved_pdf_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
+    ) -> bool:
+        """Wait until file exists on disk or raise a pytest failure."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if os.path.exists(saved_pdf_path):
+                initial_size = os.path.getsize(saved_pdf_path)
+                time.sleep(interval)
+                final_size = os.path.getsize(saved_pdf_path)
+                if initial_size == final_size and final_size > 0:
+                    return True
+            time.sleep(interval)
+        pytest.fail(f"The file was not downloaded within {timeout:.1f} seconds.")
+        return None
+
+    return _wait_for_file_download

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -6,30 +6,58 @@ from selenium.webdriver import Firefox
 from modules.page_object import GenericPdf
 from modules.browser_object import PanelUi
 
+
 @pytest.fixture()
 def test_case():
     return "1020327"
 
+
 PDF_FILE_NAME = "i-9.pdf"
 DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
+DOWNLOAD_TIMEOUT_SEC = 5.0
+POLL_INTERVAL_SEC = 1.0
+
 
 @pytest.fixture()
 def file_name():
     return PDF_FILE_NAME
 
+
 @pytest.fixture()
 def delete_files_regex_string():
     return DOWNLOADED_PDF_REGEX
 
-def wait_for_file_download(file_path, timeout=10, interval=0.5):
-    start = time.time()
-    while time.time() - start < timeout:
-        if os.path.exists(file_path):
-            return True
-        time.sleep(interval)
-    return False
 
-def test_download_pdf_data(driver: Firefox, fillable_pdf_url: str, downloads_folder: str, file_name, delete_files):
+def _wait_for_file_download(
+    saved_pdf_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
+) -> None:
+    """Wait until file exists on disk or raise a pytest failure."""
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        if os.path.exists(saved_pdf_path):
+            initial_size = os.path.getsize(saved_pdf_path)
+            time.sleep(interval)
+            final_size = os.path.getsize(saved_pdf_path)
+
+            if initial_size == final_size and final_size > 0:
+                return True
+
+        time.sleep(interval)
+
+    pytest.fail(f"The file was not downloaded within {timeout:.1f} seconds.")
+    return None
+
+
+@pytest.mark.headed
+def test_download_pdf_data(
+    driver: Firefox,
+    fillable_pdf_url: str,
+    downloads_folder: str,
+    file_name,
+    delete_files,
+    delete_files_regex_string,
+):
     """
     C1020327: Sangie/Verify that a PDF with filled data is successfully downloaded in Private window
     """
@@ -49,7 +77,7 @@ def test_download_pdf_data(driver: Firefox, fillable_pdf_url: str, downloads_fol
 
     # Set the expected download path and the expected PDF name
     saved_pdf_location = os.path.join(downloads_folder, file_name)
-    wait_for_file_download(saved_pdf_location)
+    _wait_for_file_download(saved_pdf_location)
 
     # Verify if the file exists
     assert os.path.exists(saved_pdf_location), (

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -29,6 +29,19 @@ def delete_files_regex_string():
     return DOWNLOADED_PDF_REGEX
 
 
+@pytest.fixture()
+def add_to_prefs_list():
+    # Suppress the Firefox 150+ private-browsing download notification dialog.
+    return [("browser.download.enableDeletePrivate", False)]
+
+
+@pytest.fixture()
+def hard_quit():
+    # Skip the graceful driver.quit(); gracefully closing the private window
+    # with the edited PDF still open re-raises a native save/cancel prompt.
+    return True
+
+
 def _wait_for_file_download(
     saved_pdf_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
 ) -> None:
@@ -53,7 +66,7 @@ def _wait_for_file_download(
 @pytest.mark.headed
 def test_download_pdf_data(
     driver: Firefox,
-    fillable_pdf_url: str,
+    pdf_file_path,
     downloads_folder: str,
     file_name,
     delete_files,
@@ -67,8 +80,7 @@ def test_download_pdf_data(
     panel = PanelUi(driver)
     panel.open_and_switch_to_new_window("private")
 
-    pdf_viewer = GenericPdf(driver, pdf_url=fillable_pdf_url)
-    pdf_viewer.open()
+    pdf_viewer = GenericPdf(driver, pdf_url=f"file://{pdf_file_path}")
     pdf_viewer.fill_element("first-name-field", "John")
 
     # Finally download the edited pdf
@@ -79,7 +91,6 @@ def test_download_pdf_data(
     # Set the expected download path and the expected PDF name
     saved_pdf_location = os.path.join(downloads_folder, file_name)
     _wait_for_file_download(saved_pdf_location)
-
     # Verify if the file exists
     assert os.path.exists(saved_pdf_location), (
         f"The file was not downloaded to {saved_pdf_location}."

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -7,22 +7,27 @@ from selenium.webdriver import Firefox
 from modules.browser_object import PanelUi
 from modules.page_object import GenericPdf
 
+
 @pytest.fixture()
 def test_case():
     return "1020327"
+
 
 PDF_FILE_NAME = "i-9.pdf"
 DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
 DOWNLOAD_TIMEOUT_SEC = 5.0
 POLL_INTERVAL_SEC = 1.0
 
+
 @pytest.fixture()
 def file_name():
     return PDF_FILE_NAME
 
+
 @pytest.fixture()
 def delete_files_regex_string():
     return DOWNLOADED_PDF_REGEX
+
 
 def _wait_for_file_download(
     saved_pdf_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
@@ -43,6 +48,7 @@ def _wait_for_file_download(
 
     pytest.fail(f"The file was not downloaded within {timeout:.1f} seconds.")
     return None
+
 
 @pytest.mark.headed
 def test_download_pdf_data(

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -6,6 +6,7 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import PanelUi
 from modules.page_object import GenericPdf
+from modules.browser_object import TabBar
 
 
 @pytest.fixture()
@@ -15,8 +16,6 @@ def test_case():
 
 PDF_FILE_NAME = "i-9.pdf"
 DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
-DOWNLOAD_TIMEOUT_SEC = 5.0
-POLL_INTERVAL_SEC = 1.0
 
 
 @pytest.fixture()
@@ -42,55 +41,59 @@ def hard_quit():
     return True
 
 
-def _wait_for_file_download(
-    saved_pdf_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
-) -> None:
-    """Wait until file exists on disk or raise a pytest failure."""
-
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        if os.path.exists(saved_pdf_path):
-            initial_size = os.path.getsize(saved_pdf_path)
-            time.sleep(interval)
-            final_size = os.path.getsize(saved_pdf_path)
-
-            if initial_size == final_size and final_size > 0:
-                return True
-
-        time.sleep(interval)
-
-    pytest.fail(f"The file was not downloaded within {timeout:.1f} seconds.")
-    return None
-
-
 @pytest.mark.headed
 def test_download_pdf_data(
     driver: Firefox,
     pdf_file_path,
     downloads_folder: str,
+    sys_platform,
     file_name,
     delete_files,
     delete_files_regex_string,
+    wait_for_file_download,
 ):
     """
-    C1020327: Sangie/Verify that a PDF with filled data is successfully downloaded in Private window
+    C1020327: Verify that a PDF with filled data is successfully downloaded in Private window
     """
 
     # Open Private Window
     panel = PanelUi(driver)
+    saved_pdf_location = os.path.join(downloads_folder, file_name)
+    tabs = TabBar(driver)
+
     panel.open_and_switch_to_new_window("private")
 
     pdf_viewer = GenericPdf(driver, pdf_url=f"file://{pdf_file_path}")
-    pdf_viewer.fill_element("first-name-field", "John")
+    pdf_viewer.fill_element("first-name-field", "Mark")
 
-    # Finally download the edited pdf
-    pdf_viewer.click_download_button()
-    time.sleep(2)
-    pdf_viewer.handle_os_download_confirmation()
+    use_mock_picker = sys_platform == "Linux"
+    if use_mock_picker:
+        pdf_viewer.install_mock_file_picker(saved_pdf_location)
 
-    # Set the expected download path and the expected PDF name
-    saved_pdf_location = os.path.join(downloads_folder, file_name)
-    _wait_for_file_download(saved_pdf_location)
+    # Click the download button
+    try:
+        pdf_viewer.click_download_button()
+
+        if use_mock_picker:
+            pdf_viewer.wait_for_mock_file_picker()
+        else:
+            # Allow time for the download dialog to appear and pressing enter to download
+            time.sleep(2)
+
+            # Handle OS download prompt
+            pdf_viewer.handle_os_download_confirmation()
+    finally:
+        if use_mock_picker:
+            pdf_viewer.cleanup_mock_file_picker()
+
+    # # Set the expected download path and the expected PDF name
+    wait_for_file_download(saved_pdf_location)
+
+    # Open the saved pdf and check if the edited field is displayed
+    tabs.open_and_switch_to_new_tab()
+    driver.get("file://" + os.path.realpath(saved_pdf_location))
+    pdf_viewer.element_visible("edited-name-field")
+
     # Verify if the file exists
     assert os.path.exists(saved_pdf_location), (
         f"The file was not downloaded to {saved_pdf_location}."

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -4,8 +4,9 @@ import time
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.page_object import GenericPdf
 from modules.browser_object import PanelUi
+from modules.page_object import GenericPdf
+
 
 
 @pytest.fixture()

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -1,0 +1,62 @@
+import os
+import logging
+import time
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.keys import Keys
+
+from modules.page_object import GenericPdf
+from modules.browser_object import PanelUi
+
+@pytest.fixture()
+def test_case():
+    return "1020327"
+
+PDF_FILE_NAME = "i-9.pdf"
+DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
+
+@pytest.fixture()
+def file_name():
+    return PDF_FILE_NAME
+
+@pytest.fixture()
+def delete_files_regex_string():
+    return DOWNLOADED_PDF_REGEX
+
+def wait_for_file_download(file_path, timeout=10, interval=0.5):
+    start = time.time()
+    while time.time() - start < timeout:
+        if os.path.exists(file_path):
+            return True
+        time.sleep(interval)
+    return False
+
+def test_download_pdf_data(driver: Firefox, fillable_pdf_url: str, downloads_folder: str, file_name, delete_files):
+    """
+    C1020327: Sangie/Verify that a PDF with filled data is successfully downloaded in Private window
+    """
+
+    # Open Private Window
+    panel = PanelUi(driver)
+    panel.open_and_switch_to_new_window("private")
+
+    pdf_viewer = GenericPdf(driver, pdf_url=fillable_pdf_url)
+    pdf_viewer.open()
+    pdf_viewer.fill_element("first-name-field", "John")
+
+    # Finally download the edited pdf
+    pdf_viewer.click_download_button()
+    time.sleep(2)
+    pdf_viewer.handle_os_download_confirmation()
+
+    # Set the expected download path and the expected PDF name
+    saved_pdf_location = os.path.join(downloads_folder, file_name)
+    wait_for_file_download(saved_pdf_location)
+
+    # Verify if the file exists
+    assert os.path.exists(saved_pdf_location), (
+        f"The file was not downloaded to {saved_pdf_location}."
+    )
+
+
+

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -1,6 +1,7 @@
 import os
-import pytest
 import time
+
+import pytest
 from selenium.webdriver import Firefox
 
 from modules.page_object import GenericPdf

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -7,28 +7,22 @@ from selenium.webdriver import Firefox
 from modules.browser_object import PanelUi
 from modules.page_object import GenericPdf
 
-
-
 @pytest.fixture()
 def test_case():
     return "1020327"
-
 
 PDF_FILE_NAME = "i-9.pdf"
 DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
 DOWNLOAD_TIMEOUT_SEC = 5.0
 POLL_INTERVAL_SEC = 1.0
 
-
 @pytest.fixture()
 def file_name():
     return PDF_FILE_NAME
 
-
 @pytest.fixture()
 def delete_files_regex_string():
     return DOWNLOADED_PDF_REGEX
-
 
 def _wait_for_file_download(
     saved_pdf_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
@@ -49,7 +43,6 @@ def _wait_for_file_download(
 
     pytest.fail(f"The file was not downloaded within {timeout:.1f} seconds.")
     return None
-
 
 @pytest.mark.headed
 def test_download_pdf_data(

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -4,8 +4,7 @@ import time
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import PanelUi
-from modules.browser_object import TabBar
+from modules.browser_object import PanelUi, TabBar
 from modules.page_object import GenericPdf
 
 

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -1,6 +1,6 @@
 import os
-import time
 import pytest
+import time
 from selenium.webdriver import Firefox
 
 from modules.page_object import GenericPdf

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -1,9 +1,7 @@
 import os
-import logging
 import time
 import pytest
 from selenium.webdriver import Firefox
-from selenium.webdriver.common.keys import Keys
 
 from modules.page_object import GenericPdf
 from modules.browser_object import PanelUi
@@ -57,6 +55,3 @@ def test_download_pdf_data(driver: Firefox, fillable_pdf_url: str, downloads_fol
     assert os.path.exists(saved_pdf_location), (
         f"The file was not downloaded to {saved_pdf_location}."
     )
-
-
-

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -5,8 +5,8 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import PanelUi
-from modules.page_object import GenericPdf
 from modules.browser_object import TabBar
+from modules.page_object import GenericPdf
 
 
 @pytest.fixture()

--- a/tests/pdf_viewer/test_download_pdf_with_form_fields.py
+++ b/tests/pdf_viewer/test_download_pdf_with_form_fields.py
@@ -8,29 +8,6 @@ from modules.page_object_generics import GenericPdf
 
 PDF_FILE_NAME = "i-9.pdf"
 DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
-DOWNLOAD_TIMEOUT_SEC = 5.0
-POLL_INTERVAL_SEC = 1.0
-
-
-def _wait_for_file_download(
-    saved_pdf_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
-) -> None:
-    """Wait until file exists on disk or raise a pytest failure."""
-
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        if os.path.exists(saved_pdf_path):
-            initial_size = os.path.getsize(saved_pdf_path)
-            time.sleep(interval)
-            final_size = os.path.getsize(saved_pdf_path)
-
-            if initial_size == final_size and final_size > 0:
-                return True
-
-        time.sleep(interval)
-
-    pytest.fail(f"The file was not downloaded within {timeout:.1f} seconds.")
-    return None
 
 
 @pytest.fixture()
@@ -57,6 +34,7 @@ def test_download_pdf_with_form_fields(
     delete_files,
     downloads_folder: str,
     delete_files_regex_string,
+    wait_for_file_download,
 ):
     """
     C1020326 Download pdf with form fields
@@ -81,7 +59,7 @@ def test_download_pdf_with_form_fields(
     saved_pdf_path = os.path.join(downloads_folder, PDF_FILE_NAME)
 
     # Verify if the file exists
-    _wait_for_file_download(saved_pdf_path)
+    wait_for_file_download(saved_pdf_path)
 
     # Open the saved pdf and check if the edited field is displayed
     driver.get("file://" + os.path.realpath(saved_pdf_path))


### PR DESCRIPTION
### Relevant Links

Bugzilla: Bug 2009705 (https://bugzilla.mozilla.org/show_bug.cgi?id=2009705)
TestRail: 1020327 (https://mozilla.testrail.io/index.php?/cases/view/1020327)

### Description of Code / Doc Changes

Create test for PDF Viewer manual test case: Verify that a PDF with filled data is successfully downloaded in Private window

### Process Changes Required

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
