### PR TITLE
Anca/ Add heuristics disabled when trr mode is set on 2

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -684,6 +684,10 @@ networking:
     result: pass
     splits:
     - smoke
+  test_heuristics_disabled_when_trr_mode_2:
+    result: pass
+    splits:
+    - functional1
   test_http_site:
     result: pass
     splits:
@@ -1296,6 +1300,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional2
+  test_etp_toggle_on_off_behavior_private_window:
+    result: pass
+    splits:
+    - functional2
   test_extended_certificate_messaging_displayed_in_panel:
     result: pass
     splits:
@@ -1372,10 +1380,6 @@ security_and_privacy:
     splits:
     - functional2
   test_private_session_history_exclusion:
-    result: pass
-    splits:
-    - functional2
-  test_etp_toggle_on_off_behavior_private_window:
     result: pass
     splits:
     - functional2

--- a/tests/networking/test_heuristics_disabled_when_trr_mode_2.py
+++ b/tests/networking/test_heuristics_disabled_when_trr_mode_2.py
@@ -1,0 +1,41 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutConfig
+
+TRR_MODE_PREF = "network.trr.mode"
+TRR_MODE_DOH_ENABLED = 2
+DISABLE_HEURISTICS_PREF = "doh-rollout.disable-heuristics"
+HEURISTICS_DISABLED_VALUE = "true"
+
+
+@pytest.fixture()
+def test_case():
+    return "922818"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("browser.search.region", "US"),
+        ("doh-rollout.home-region", "US"),
+        ("doh-rollout.mode", 2),
+        ("browser.aboutConfig.showWarning", False),
+    ]
+
+
+def test_heuristics_disabled_when_trr_mode_2(driver: Firefox):
+    """
+    C922818 - Verify that DoH heuristics are disabled when setting network.trr.mode to 2.
+    """
+    # Instantiate objects
+    about_config = AboutConfig(driver)
+
+    # Set network.trr.mode to 2 in about:config
+    about_config.edit_config_value(TRR_MODE_PREF, TRR_MODE_DOH_ENABLED)
+
+    # Firefox disables the DoH heuristics in response to the manual trr.mode change
+    assert (
+        about_config.get_pref_value(DISABLE_HEURISTICS_PREF)
+        == HEURISTICS_DISABLED_VALUE
+    )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2011143](https://bugzilla.mozilla.org/show_bug.cgi?id=2011143)
TestRail: [922818](https://mozilla.testrail.io/index.php?/cases/view/922818)

### Description of Code / Doc Changes

- Add heuristics disabled when trr mode is set on 2

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

-  addtests.py run reordered additional test 

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
