### PR TITLE
Hani/ Fix primary password tests

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1224,20 +1224,6 @@ Location: about:preferences#privacy Primary Password popup
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: enter-new-password
-Selector Data: "pw1"
-Description: Input for new primary password
-Location: about:preferences#privacy Primary Password popup
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: reenter-new-password
-Selector Data: "pw2"
-Description: Input for new primary password again
-Location: about:preferences#privacy Primary Password popup
-Path to .json: modules/data/about_prefs.components.json
-```
-```
 Selector Name: submit-password
 Selector Data: "button[label^='OK']
 Description: Ok button to submit the new primary password
@@ -1571,6 +1557,34 @@ Selector Name: turn-off-primary-password
 Selector Data: "turnOffPrimaryPassword"
 Description: "Turn off Primary Password" / remove button in the Remove Primary Password dialog, used to confirm clearing the primary password
 Location: about:preferences#privacy (Remove Primary Password dialog)
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: primary-password-new-input
+Selector Data: "pw1"
+Description: The outer moz-input-password custom element for the "Enter new password" field in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: primary-password-new-input-field
+Selector Data: "input#input"
+Description: The inner input field inside the shadow DOM of the "Enter new password" moz-input-password element in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: primary-password-reenter-input
+Selector Data: "pw2"
+Description: The outer moz-input-password custom element for the "Re-enter password" field in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: primary-password-reenter-input-field
+Selector Data: "input#input"
+Description: The inner input field inside the shadow DOM of the "Re-enter password" moz-input-password element in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
 Path to .json: modules/data/about_prefs.components.json
 ```
 #### about_profiles

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -773,8 +773,7 @@ notifications:
     - functional1
 password_manager:
   test_about_logins_copy_prompts_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047891
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_about_logins_direct_navigation:
@@ -782,8 +781,7 @@ password_manager:
     splits:
     - functional1
   test_about_logins_edit_prompts_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047891
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_about_logins_navigation_from_about_preferences:
@@ -835,8 +833,7 @@ password_manager:
     splits:
     - smoke
   test_add_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047891
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_add_username_via_doorhanger:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -552,12 +552,18 @@
     "strategy": "id",
     "groups": []
   },
-  "enter-new-password": {
+  "primary-password-new-input": {
     "selectorData": "pw1",
     "strategy": "id",
     "groups": [
       "doNotCache"
     ]
+  },
+  "primary-password-new-input-field": {
+    "selectorData": "input#input",
+    "strategy": "css",
+    "shadowParent": "primary-password-new-input",
+    "groups": []
   },
   "form-container": {
     "selectorData": "form",
@@ -571,12 +577,16 @@
     "strategy": "id",
     "groups": []
   },
-  "reenter-new-password": {
+  "primary-password-reenter-input": {
     "selectorData": "pw2",
     "strategy": "id",
-    "groups": [
-      "doNotCache"
-    ]
+    "groups": []
+  },
+  "primary-password-reenter-input-field": {
+      "selectorData": "input#input",
+      "strategy": "css",
+      "shadowParent": "primary-password-reenter-input",
+      "groups": []
   },
   "submit-password": {
     "selectorData": "button[label^='OK']",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1100,8 +1100,8 @@ class AboutPrefs(BasePage):
         """
         Sets a new primary password.
         """
-        self.get_element("enter-new-password").send_keys(password)
-        self.get_element("reenter-new-password").send_keys(password)
+        self.get_element("primary-password-new-input-field").send_keys(password)
+        self.get_element("primary-password-reenter-input-field").send_keys(password)
         self.click_on("submit-password")
         return self
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047891](https://bugzilla.mozilla.org/show_bug.cgi?id=2047891)

### Description of Code / Doc Changes

* Fix tests/password_manager/test_add_primary_password.py
* Fix tests/password_manager/test_about_logins_edit_prompts_primary_password.py
* Fix tests/password_manager/test_about_logins_copy_prompts_primary_password.py

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
