### PR TITLE
Hani/ Fix primary password tests

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1573,6 +1573,34 @@ Description: "Turn off Primary Password" / remove button in the Remove Primary P
 Location: about:preferences#privacy (Remove Primary Password dialog)
 Path to .json: modules/data/about_prefs.components.json
 ```
+```
+Selector Name: primary-password-new-input
+Selector Data: "pw1"
+Description: The outer moz-input-password custom element for the "Enter new password" field in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: primary-password-new-input-field
+Selector Data: "input#input"
+Description: The inner input field inside the shadow DOM of the "Enter new password" moz-input-password element in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: primary-password-reenter-input
+Selector Data: "pw2"
+Description: The outer moz-input-password custom element for the "Re-enter password" field in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: primary-password-reenter-input-field
+Selector Data: "input#input"
+Description: The inner input field inside the shadow DOM of the "Re-enter password" moz-input-password element in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
 #### about_profiles
 ```
 Selector Name: profile-container

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -779,8 +779,7 @@ notifications:
     - functional1
 password_manager:
   test_about_logins_copy_prompts_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047891
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_about_logins_direct_navigation:
@@ -788,8 +787,7 @@ password_manager:
     splits:
     - functional1
   test_about_logins_edit_prompts_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047891
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_about_logins_navigation_from_about_preferences:
@@ -841,8 +839,7 @@ password_manager:
     splits:
     - smoke
   test_add_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047891
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_add_username_via_doorhanger:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -856,8 +856,7 @@ password_manager:
     splits:
     - functional2
   test_can_view_password_when_PP_enabled:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_changes_made_in_edit_mode_are_saved:
@@ -915,8 +914,7 @@ password_manager:
     splits:
     - smoke
   test_no_generated_password_options_with_pp_and_no_credentials:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_password_csv_correctness:
@@ -962,8 +960,7 @@ password_manager:
     splits:
     - functional2
   test_primary_password_triggered_on_about_logins_access:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_private_browsing_dismiss_doorhanger_credentials:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -880,5 +880,31 @@
     "selectorData": "turnOffPrimaryPassword",
     "strategy": "id",
     "groups": []
+  },
+  "primary-password-input": {
+    "selectorData": "pw1",
+    "strategy": "id",
+    "groups": [
+      "doNotCache"
+    ]
+  },
+  "primary-password-input-field": {
+    "selectorData": "input#input",
+    "strategy": "css",
+    "shadowParent": "primary-password-input",
+    "groups": []
+  },
+  "primary-password-reenter-input": {
+    "selectorData": "pw2",
+    "strategy": "id",
+    "groups": [
+      "doNotCache"
+    ]
+  },
+  "primary-password-reenter-input-field": {
+    "selectorData": "input#input",
+    "strategy": "css",
+    "shadowParent": "primary-password-reenter-input",
+    "groups": []
   }
 }

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1100,8 +1100,8 @@ class AboutPrefs(BasePage):
         """
         Sets a new primary password.
         """
-        self.get_element("enter-new-password").send_keys(password)
-        self.get_element("reenter-new-password").send_keys(password)
+        self.get_element("primary-password-input-field").send_keys(password)
+        self.get_element("primary-password-reenter-input-field").send_keys(password)
         self.click_on("submit-password")
         return self
 

--- a/tests/password_manager/conftest.py
+++ b/tests/password_manager/conftest.py
@@ -7,6 +7,8 @@ from selenium.webdriver import Firefox
 
 from modules.page_object import AboutLogins, AboutPrefs, AboutProtections
 
+# bump
+
 
 @pytest.fixture()
 def suite_id():

--- a/tests/password_manager/conftest.py
+++ b/tests/password_manager/conftest.py
@@ -7,8 +7,6 @@ from selenium.webdriver import Firefox
 
 from modules.page_object import AboutLogins, AboutPrefs, AboutProtections
 
-# bump
-
 
 @pytest.fixture()
 def suite_id():


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047891](https://bugzilla.mozilla.org/show_bug.cgi?id=2047891)

### Description of Code / Doc Changes

* Fix tests/password_manager/test_add_primary_password.py
* Fix tests/password_manager/test_about_logins_edit_prompts_primary_password.py
* Fix tests/password_manager/test_about_logins_copy_prompts_primary_password.py
* Fix tests/password_manager/test_primary_password_triggered_on_about_logins_access.py
* Fix tests/password_manager/test_no_generated_password_options_with_pp_and_no_credentials.py
* Fix tests/password_manager/test_can_view_password_when_PP_enabled.py

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
