### PR TITLE
Anca/ Fix notification and alert tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -714,29 +714,24 @@ networking:
     - functional1
 notifications:
   test_audio_video_permissions_notification:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047888; also Issue with
-      Mac GHA? trying pass to see what happens.
-    result: unstable
+    comment: Issue with Mac GHA? trying pass to see what happens.
+    result: pass
     splits:
     - functional1
   test_camera_permissions_notification:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047888
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_cancel_webextension:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047888
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_deny_geolocation:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047888
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_deny_screen_capture:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047888
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_downloads_button_is_displayed:
@@ -748,8 +743,7 @@ notifications:
     splits:
     - functional1
   test_geolocation_allow_browserleaks:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047888
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_geolocation_prompt_presence:
@@ -757,8 +751,7 @@ notifications:
     splits:
     - functional1
   test_microphone_permissions_notification:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047888
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_notifications_displayed:
@@ -771,8 +764,7 @@ notifications:
     splits:
     - smoke
   test_webextension_completed_installation_successfully_displayed:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047888
-    result: unstable
+    result: pass
     splits:
     - functional1
 password_manager:

--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -664,7 +664,7 @@ class Navigation(BasePage):
         self.element_clickable(button_selector)
         if remember_this_decision:
             self.click_on("checkbox-remember-this-decision")
-        self.click_on(button_selector)
+        self.js_click_on(button_selector)
 
     def open_searchmode_switcher_settings(self):
         """Open search settings from searchmode switcher in awesome bar"""

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -1352,11 +1352,12 @@ class BasePage(Page):
         # Default return if neither zoom nor transform is set
         return 1.0
 
-    @context_chrome
+    @context_of_model
     def js_click_on(self, reference, labels=None):
         """
         Perform a 'hard click' using a JS command. Use this when regular click_on()
-        doesn't work well
+        doesn't work well. Runs in the model's declared context, so it works for both
+        chrome BOMs and content POMs.
         """
         self.driver.execute_script(
             "arguments[0].click();", self.fetch(reference, labels=labels)

--- a/tests/notifications/test_audio_video_permissions_notification.py
+++ b/tests/notifications/test_audio_video_permissions_notification.py
@@ -50,4 +50,4 @@ def test_camera_and_microphone_permissions_notification(driver: Firefox, web_pag
     )
 
     nav.element_visible("popup-notification-secondary-button")
-    nav.click_on("popup-notification-secondary-button")
+    nav.js_click_on("popup-notification-secondary-button")

--- a/tests/notifications/test_camera_permissions_notification.py
+++ b/tests/notifications/test_camera_permissions_notification.py
@@ -49,4 +49,4 @@ def test_camera_permissions_notification(driver: Firefox, web_page):
     )
 
     nav.element_visible("popup-notification-secondary-button")
-    nav.click_on("popup-notification-secondary-button")
+    nav.js_click_on("popup-notification-secondary-button")

--- a/tests/notifications/test_cancel_webextension.py
+++ b/tests/notifications/test_cancel_webextension.py
@@ -38,7 +38,7 @@ def test_cancel_webextension(driver: Firefox, web_page):
 
     # Click Cancel in permission panel (chrome)
     nav.element_clickable("popup-notification-cancel")
-    nav.click_on("popup-notification-cancel")
+    nav.js_click_on("popup-notification-cancel")
 
     # Button should become visible again
     page.expect(lambda _: page.get_element("add-to-firefox").is_displayed())

--- a/tests/notifications/test_deny_geolocation.py
+++ b/tests/notifications/test_deny_geolocation.py
@@ -27,7 +27,7 @@ def test_deny_geolocation(driver: Firefox, web_page):
 
     # Block geolocation sharing for this website
     nav.element_clickable("popup-notification-secondary-button")
-    nav.click_on("popup-notification-secondary-button")
+    nav.js_click_on("popup-notification-secondary-button")
 
     # Check that the website cannot access the geolocation
     page.element_visible("not-allowed")

--- a/tests/notifications/test_deny_screen_capture.py
+++ b/tests/notifications/test_deny_screen_capture.py
@@ -36,7 +36,7 @@ def test_deny_screen_capture(driver: Firefox, web_page):
 
     # Block screen sharing for this website
     nav.element_clickable("popup-notification-secondary-button")
-    nav.click_on("popup-notification-secondary-button")
+    nav.js_click_on("popup-notification-secondary-button")
 
     # Check that the website cannot access the screen
     page.element_has_text(

--- a/tests/notifications/test_geolocation_prompt_presence.py
+++ b/tests/notifications/test_geolocation_prompt_presence.py
@@ -54,8 +54,8 @@ def test_geolocation_prompt_is_triggered_on_request_location_on_a_website(
 
     _dismiss_cookie_banner_if_present(driver, page)
     # The cookie-consent CMP (<iframe id="fast-cmp-iframe">) can overlay the button and intercept a
-    # native click; ActionChains would hit the overlay too. Dispatch the click directly so
-    # getLocation() still fires and triggers the geolocation prompt regardless of the overlay.
-    driver.execute_script("arguments[0].click();", page.find_element(*TRY_IT_BUTTON))
+    # native click; js_click_on dispatches the click directly so getLocation() still fires and
+    # triggers the geolocation prompt regardless of the overlay.
+    page.js_click_on(TRY_IT_BUTTON)
 
     nav.wait.until(lambda _: nav.element_visible("geolocation-notification-container"))

--- a/tests/notifications/test_geolocation_prompt_presence.py
+++ b/tests/notifications/test_geolocation_prompt_presence.py
@@ -53,6 +53,9 @@ def test_geolocation_prompt_is_triggered_on_request_location_on_a_website(
     page = GenericPage(driver, url=TEST_URL).open()
 
     _dismiss_cookie_banner_if_present(driver, page)
-    page.find_element(*TRY_IT_BUTTON).click()
+    # The cookie-consent CMP (<iframe id="fast-cmp-iframe">) can overlay the button and intercept a
+    # native click; ActionChains would hit the overlay too. Dispatch the click directly so
+    # getLocation() still fires and triggers the geolocation prompt regardless of the overlay.
+    driver.execute_script("arguments[0].click();", page.find_element(*TRY_IT_BUTTON))
 
     nav.wait.until(lambda _: nav.element_visible("geolocation-notification-container"))

--- a/tests/notifications/test_microphone_permissions_notification.py
+++ b/tests/notifications/test_microphone_permissions_notification.py
@@ -56,4 +56,4 @@ def test_microphone_permissions_notification(driver: Firefox, web_page):
     # Verify that the notification is displayed
     _verify_microphone_permission_prompt(driver, nav)
 
-    nav.click_on("popup-notification-secondary-button")
+    nav.js_click_on("popup-notification-secondary-button")

--- a/tests/notifications/test_notifications_displayed.py
+++ b/tests/notifications/test_notifications_displayed.py
@@ -70,6 +70,6 @@ def test_notifications_displayed(driver: Firefox, temp_page, web_page):
 
     # Grant permission if we need to
     if _permission_was_requested(page):
-        nav.click_on("popup-notification-primary-button")
+        nav.js_click_on("popup-notification-primary-button")
 
     page.element_has_text("notification-log", TEST_PHRASE)

--- a/tests/notifications/test_webextension_completed_installation_successfully_displayed.py
+++ b/tests/notifications/test_webextension_completed_installation_successfully_displayed.py
@@ -38,7 +38,7 @@ def test_webextension_completed_installation_successfully_displayed(
 
     # Click the Add button
     nav.element_clickable("popup-notification-add")
-    nav.click_on("popup-notification-add")
+    nav.js_click_on("popup-notification-add")
 
     # The WebExtension completed installation panel is successfully displayed
     nav.element_visible("popup-notification-panel")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047888](https://bugzilla.mozilla.org/show_bug.cgi?id=2047888)
TestRail: See bellow

### Description of Code / Doc Changes

- Firefox swapped the popup-notification buttons from old XUL <button>s to the new <moz-button> web components. The class selectors still match, so the visibility checks pass, but a normal click just stopped working — Marionette throws could not be scrolled into view because it can't deal with an HTML element sitting inside a XUL panel popup. Fix the following tests: 

1. tests/notifications/test_microphone_permissions_notification.py
2. tests/notifications/test_webextension_completed_installation_successfully_displayed.py
3. tests/notifications/test_geolocation_allow_browserleaks.py
4. tests/notifications/test_deny_screen_capture.py
5. tests/notifications/test_deny_geolocation.py
6. tests/notifications/test_cancel_webextension.py
7. tests/notifications/test_camera_permissions_notification.py
8. tests/notifications/test_audio_video_permissions_notification.py

- Made js_click_on context-aware (@context_chrome → @context_of_model) so it works on content pages too, not just chrome.
- Used page.js_click_on to click through the w3schools cookie banner that was covering the button.
   
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
