### PR TITLE
add test for creating, resizing, moving and deleting drawed areas

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1053,6 +1053,10 @@ pdf_viewer:
       win: pass
     splits:
     - functional2
+  test_pdf_drawing_area_actions:
+    result: pass
+    splits:
+    - functional1
   test_pdf_dropdown_functionality:
     result: pass
     splits:

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -314,7 +314,7 @@ class GenericPdf(BasePage):
         self.element_has_text("added-text", text)
         return self
 
-    def get_element_rect(self, element: str | WebElement) -> dict[str, float]:
+    def get_element_rect(self, element: WebElement) -> dict[str, float]:
         """Return the element bounding client rect."""
         return self.driver.execute_script(
             """
@@ -326,7 +326,7 @@ class GenericPdf(BasePage):
                 height: rect.height,
             };
             """,
-            self.fetch(element),
+            element,
         )
 
     def get_drawing_area(self) -> WebElement:
@@ -341,7 +341,7 @@ class GenericPdf(BasePage):
         return drawing_area
 
     def select_drawing_area(self) -> WebElement:
-        """Dismiss drawing mode and select the existing drawing area."""
+        """Dismiss drawing mode, select, and return the existing drawing area."""
         self.actions.send_keys(Keys.ESCAPE).perform()
 
         drawing_area = self.get_drawing_area()
@@ -349,20 +349,18 @@ class GenericPdf(BasePage):
 
         return drawing_area
 
-    def get_drawing_resize_handle(self) -> WebElement:
+    def get_drawing_resize_handle(self, drawing_area: WebElement) -> WebElement:
         """
         Return the resize handle for the selected drawing area.
 
-        The handle is nested inside the selected drawing editor, so Selenium cannot
-        reliably fetch it directly with a normal selector. The script starts from
-        the selected drawing element and returns the resize handle used for dragging.
+        The script searches inside the PDF viewer for visible resize handle candidates
+        and returns the one closest to the drawing area's bottom-right corner.
         """
-        drawing_area = self.get_drawing_area()
-
         resize_handle = self.driver.execute_script(
             """
             const drawingArea = arguments[0];
             const drawingRect = drawingArea.getBoundingClientRect();
+            const viewer = drawingArea.closest("#viewer") || document;
 
             const selectors = [
                 ".resizer.bottomRight",
@@ -375,13 +373,15 @@ class GenericPdf(BasePage):
             ];
 
             const candidates = selectors
-                .flatMap(selector => [...document.querySelectorAll(selector)])
+                .flatMap(selector => [...viewer.querySelectorAll(selector)])
                 .filter(element => {
                     const rect = element.getBoundingClientRect();
                     return rect.width > 0 && rect.height > 0;
                 });
 
-            if (!candidates.length) {
+            const unique = [...new Set(candidates)];
+
+            if (!unique.length) {
                 return null;
             }
 
@@ -390,7 +390,7 @@ class GenericPdf(BasePage):
                 y: drawingRect.bottom,
             };
 
-            return candidates.sort((first, second) => {
+            return unique.sort((first, second) => {
                 const firstRect = first.getBoundingClientRect();
                 const secondRect = second.getBoundingClientRect();
 
@@ -412,30 +412,32 @@ class GenericPdf(BasePage):
         assert resize_handle is not None, "Expected drawing resize handle to exist."
         return resize_handle
 
-    def move_drawing_area(self) -> BasePage:
+    def move_drawing_area(self, drawing_area: WebElement) -> BasePage:
         """Move the selected drawing area and verify its position changed."""
-        drawing_area = self.select_drawing_area()
         initial_rect = self.get_element_rect(drawing_area)
 
         self.actions.drag_and_drop_by_offset(drawing_area, 80, 50).perform()
 
         def drawing_moved(_):
-            rect = self.get_element_rect(self.get_drawing_area())
+            rect = self.get_element_rect(drawing_area)
             return rect["x"] != initial_rect["x"] or rect["y"] != initial_rect["y"]
 
         self.expect(drawing_moved)
         return self
 
-    def resize_drawing_area(self) -> BasePage:
+    def resize_drawing_area(self, drawing_area: WebElement) -> BasePage:
         """Resize the selected drawing area and verify its size changed."""
-        drawing_area = self.select_drawing_area()
         initial_rect = self.get_element_rect(drawing_area)
-        resize_handle = self.get_drawing_resize_handle()
+        resize_handle = self.get_drawing_resize_handle(drawing_area)
 
-        self.actions.drag_and_drop_by_offset(resize_handle, 40, 30).perform()
+        self.actions.move_to_element(resize_handle)
+        self.actions.click_and_hold()
+        self.actions.move_by_offset(40, 40)
+        self.actions.release()
+        self.actions.perform()
 
         def drawing_resized(_):
-            rect = self.get_element_rect(self.get_drawing_area())
+            rect = self.get_element_rect(drawing_area)
             return (
                 rect["width"] != initial_rect["width"]
                 or rect["height"] != initial_rect["height"]

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -313,3 +313,71 @@ class GenericPdf(BasePage):
         self.element_visible("added-text")
         self.element_has_text("added-text", text)
         return self
+
+    def get_element_rect(self, element: str | WebElement) -> dict[str, float]:
+        """Return the element bounding client rect."""
+        return self.driver.execute_script(
+            """
+            const rect = arguments[0].getBoundingClientRect();
+            return {
+                x: rect.x,
+                y: rect.y,
+                width: rect.width,
+                height: rect.height,
+            };
+            """,
+            self.fetch(element),
+        )
+
+    def get_drawing_area(self) -> WebElement:
+        """Return the SVG container for the added drawing."""
+        drawing = self.get_element("added-drawing")
+        drawing_area = self.driver.execute_script(
+            "return arguments[0].closest('svg.draw');",
+            drawing,
+        )
+
+        assert drawing_area is not None, "Expected drawing SVG area to exist."
+        return drawing_area
+
+    def select_drawing_area(self) -> WebElement:
+        """Dismiss drawing mode and select the existing drawing area."""
+        self.actions.send_keys(Keys.ESCAPE).perform()
+
+        drawing_area = self.get_drawing_area()
+        self.actions.move_to_element(drawing_area).click().perform()
+
+        return drawing_area
+
+    def move_drawing_area(self) -> BasePage:
+        """Move the selected drawing area and verify its position changed."""
+        drawing_area = self.select_drawing_area()
+        initial_rect = self.get_element_rect(drawing_area)
+
+        self.actions.drag_and_drop_by_offset(drawing_area, 80, 50).perform()
+
+        self.expect(
+            lambda _: self.get_element_rect(self.get_drawing_area())["x"]
+            != initial_rect["x"]
+            or self.get_element_rect(self.get_drawing_area())["y"] != initial_rect["y"]
+        )
+        return self
+
+    def resize_drawing_area(self) -> BasePage:
+        """Resize the selected drawing area and verify its size changed."""
+        drawing_area = self.select_drawing_area()
+        initial_rect = self.get_element_rect(drawing_area)
+
+        self.actions.move_to_element_with_offset(
+            drawing_area,
+            initial_rect["width"] / 2,
+            initial_rect["height"] / 2,
+        ).click_and_hold().move_by_offset(40, 30).release().perform()
+
+        self.expect(
+            lambda _: self.get_element_rect(self.get_drawing_area())["width"]
+            != initial_rect["width"]
+            or self.get_element_rect(self.get_drawing_area())["height"]
+            != initial_rect["height"]
+        )
+        return self

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -349,6 +349,63 @@ class GenericPdf(BasePage):
 
         return drawing_area
 
+    def get_drawing_resize_handle(self) -> WebElement:
+        """Return the bottom-right resize handle for the selected drawing area."""
+        drawing_area = self.get_drawing_area()
+
+        resize_handle = self.driver.execute_script(
+            """
+            const drawingArea = arguments[0];
+            const drawingRect = drawingArea.getBoundingClientRect();
+
+            const selectors = [
+                ".resizer.bottomRight",
+                ".resizer[data-resizer-name='bottomRight']",
+                "[data-resizer-name='bottomRight']",
+                "[class*='bottomRight']",
+                "[class*='resize']",
+                "[class*='resizer']",
+                "[class*='handle']"
+            ];
+
+            const candidates = selectors
+                .flatMap(selector => [...document.querySelectorAll(selector)])
+                .filter(element => {
+                    const rect = element.getBoundingClientRect();
+                    return rect.width > 0 && rect.height > 0;
+                });
+
+            if (!candidates.length) {
+                return null;
+            }
+
+            const drawingBottomRight = {
+                x: drawingRect.right,
+                y: drawingRect.bottom,
+            };
+
+            return candidates.sort((first, second) => {
+                const firstRect = first.getBoundingClientRect();
+                const secondRect = second.getBoundingClientRect();
+
+                const firstDistance = Math.hypot(
+                    firstRect.left - drawingBottomRight.x,
+                    firstRect.top - drawingBottomRight.y
+                );
+                const secondDistance = Math.hypot(
+                    secondRect.left - drawingBottomRight.x,
+                    secondRect.top - drawingBottomRight.y
+                );
+
+                return firstDistance - secondDistance;
+            })[0];
+            """,
+            drawing_area,
+        )
+
+        assert resize_handle is not None, "Expected drawing resize handle to exist."
+        return resize_handle
+
     def move_drawing_area(self) -> BasePage:
         """Move the selected drawing area and verify its position changed."""
         drawing_area = self.select_drawing_area()
@@ -356,28 +413,28 @@ class GenericPdf(BasePage):
 
         self.actions.drag_and_drop_by_offset(drawing_area, 80, 50).perform()
 
-        self.expect(
-            lambda _: self.get_element_rect(self.get_drawing_area())["x"]
-            != initial_rect["x"]
-            or self.get_element_rect(self.get_drawing_area())["y"] != initial_rect["y"]
-        )
+        def drawing_moved(_):
+            rect = self.get_element_rect(self.get_drawing_area())
+            return rect["x"] != initial_rect["x"] or rect["y"] != initial_rect["y"]
+
+        self.expect(drawing_moved)
         return self
 
     def resize_drawing_area(self) -> BasePage:
         """Resize the selected drawing area and verify its size changed."""
-        drawing_area = self.select_drawing_area()
+        self.select_drawing_area()
+        drawing_area = self.get_drawing_area()
         initial_rect = self.get_element_rect(drawing_area)
+        resize_handle = self.get_drawing_resize_handle()
 
-        self.actions.move_to_element_with_offset(
-            drawing_area,
-            initial_rect["width"] / 2,
-            initial_rect["height"] / 2,
-        ).click_and_hold().move_by_offset(40, 30).release().perform()
+        self.actions.drag_and_drop_by_offset(resize_handle, 40, 30).perform()
 
-        self.expect(
-            lambda _: self.get_element_rect(self.get_drawing_area())["width"]
-            != initial_rect["width"]
-            or self.get_element_rect(self.get_drawing_area())["height"]
-            != initial_rect["height"]
-        )
+        def drawing_resized(_):
+            rect = self.get_element_rect(self.get_drawing_area())
+            return (
+                rect["width"] != initial_rect["width"]
+                or rect["height"] != initial_rect["height"]
+            )
+
+        self.expect(drawing_resized)
         return self

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -350,7 +350,13 @@ class GenericPdf(BasePage):
         return drawing_area
 
     def get_drawing_resize_handle(self) -> WebElement:
-        """Return the bottom-right resize handle for the selected drawing area."""
+        """
+        Return the resize handle for the selected drawing area.
+
+        The handle is nested inside the selected drawing editor, so Selenium cannot
+        reliably fetch it directly with a normal selector. The script starts from
+        the selected drawing element and returns the resize handle used for dragging.
+        """
         drawing_area = self.get_drawing_area()
 
         resize_handle = self.driver.execute_script(
@@ -422,8 +428,7 @@ class GenericPdf(BasePage):
 
     def resize_drawing_area(self) -> BasePage:
         """Resize the selected drawing area and verify its size changed."""
-        self.select_drawing_area()
-        drawing_area = self.get_drawing_area()
+        drawing_area = self.select_drawing_area()
         initial_rect = self.get_element_rect(drawing_area)
         resize_handle = self.get_drawing_resize_handle()
 

--- a/tests/pdf_viewer/test_pdf_drawing_area_actions.py
+++ b/tests/pdf_viewer/test_pdf_drawing_area_actions.py
@@ -1,0 +1,53 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import ContextMenu
+from modules.page_object import GenericPdf
+
+PDF_FILE_NAME = "i-9.pdf"
+DELETE_MENU_OPTION = "pdfjs-delete"
+
+
+@pytest.fixture()
+def test_case():
+    return "1938259"
+
+
+@pytest.fixture()
+def hard_quit():
+    return True
+
+
+@pytest.fixture()
+def file_name():
+    return PDF_FILE_NAME
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("pdfjs.annotationEditorMode", 0)]
+
+
+def test_pdf_drawing_area_can_be_deleted_moved_or_resized(
+    driver: Firefox, pdf_viewer: GenericPdf
+):
+    """
+    C1938259: Verify that the drawing areas can be deleted, moved or resized.
+    """
+    context_menu = ContextMenu(driver)
+
+    # Step 1: PDF is opened and the Draw toolbar button is available.
+    pdf_viewer.element_visible("toolbar-draw")
+
+    # Step 2: Select Draw and draw on the PDF document.
+    pdf_viewer.select_editor_tool("toolbar-draw")
+    pdf_viewer.draw_on_pdf_page()
+
+    # Step 3: Verify the drawing area can be resized, moved, and deleted.
+    pdf_viewer.resize_drawing_area()
+    pdf_viewer.move_drawing_area()
+
+    drawing_area = pdf_viewer.select_drawing_area()
+    pdf_viewer.context_click(drawing_area)
+    context_menu.click_and_hide_menu(DELETE_MENU_OPTION)
+    pdf_viewer.element_does_not_exist("added-drawing")

--- a/tests/pdf_viewer/test_pdf_drawing_area_actions.py
+++ b/tests/pdf_viewer/test_pdf_drawing_area_actions.py
@@ -44,8 +44,9 @@ def test_pdf_drawing_area_can_be_deleted_moved_or_resized(
     pdf_viewer.draw_on_pdf_page()
 
     # Step 3: Verify the drawing area can be resized, moved, and deleted.
-    pdf_viewer.resize_drawing_area()
-    pdf_viewer.move_drawing_area()
+    drawing_area = pdf_viewer.select_drawing_area()
+    pdf_viewer.resize_drawing_area(drawing_area)
+    pdf_viewer.move_drawing_area(drawing_area)
 
     drawing_area = pdf_viewer.select_drawing_area()
     pdf_viewer.context_click(drawing_area)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009708](https://bugzilla.mozilla.org/show_bug.cgi?id=2009708)
TestRail: [1938259](https://mozilla.testrail.io/index.php?/cases/view/1938259)

### Description of Code / Doc Changes

Add coverage for PDF drawing areas by creating a drawing with the Draw toolbar button, selecting the created drawing, deleting it through the PDF.js context menu, and verifying it is removed from the document.
Add GenericPdf helpers for selecting PDF drawing areas and covers deleting a created drawing area through the context menu.


Thank you!
