### PR TITLE
Hani/ Fix credential doorhanger tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -945,13 +945,11 @@ password_manager:
     splits:
     - functional2
   test_private_browsing_dismiss_doorhanger_credentials:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_save_login_via_doorhanger:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_saved_hyperlink_redirects_to_corresponding_page:
@@ -963,8 +961,7 @@ password_manager:
     splits:
     - functional2
   test_update_login_via_doorhanger:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_use_saved_password_option_not_in_password_field_context_menu_without_saved_logins:

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -89,8 +89,10 @@ class GenericPage(BasePage):
             GenericPage: The current page object.
         """
         self.wait.until(
-            lambda _: self.driver.execute_script("return performance.timeOrigin")
-            != previous_time_origin
+            lambda _: (
+                self.driver.execute_script("return performance.timeOrigin")
+                != previous_time_origin
+            )
         )
         self.element_visible(field_name)
         self.element_attribute_is(field_name, "value", "")

--- a/tests/password_manager/test_private_browsing_dismiss_doorhanger_credentials.py
+++ b/tests/password_manager/test_private_browsing_dismiss_doorhanger_credentials.py
@@ -1,6 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
+from modules.browser_object import AutofillPopup
 from modules.browser_object_navigation import Navigation
 from modules.browser_object_panel_ui import PanelUi
 from modules.page_object_about_pages import AboutLogins
@@ -33,6 +34,7 @@ def test_private_browsing_dismiss_doorhanger_credentials(driver: Firefox):
     nav = Navigation(driver)
     panel = PanelUi(driver)
     about_logins = AboutLogins(driver)
+    autofill_popup_panel = AutofillPopup(driver)
 
     # Open a private window and switch to it
     panel.open_and_switch_to_new_window("private")
@@ -60,8 +62,7 @@ def test_private_browsing_dismiss_doorhanger_credentials(driver: Firefox):
     nav.wait_for_notification_popup_open()
 
     # Choose to save the credentials
-    nav.element_clickable("password-notification-save-button")
-    nav.click_on("password-notification-save-button")
+    autofill_popup_panel.click_doorhanger_button("save")
 
     # Re-load the form
     login_autofill.open()
@@ -80,7 +81,7 @@ def test_private_browsing_dismiss_doorhanger_credentials(driver: Firefox):
     nav.element_visible("password-notification-popup")
 
     # Confirm the changes in the doorhanger
-    nav.click_on("password-notification-save-button")
+    autofill_popup_panel.click_doorhanger_button("update")
 
     # The credentials have the password updated correctly, check this in about:logins
     about_logins.open()

--- a/tests/password_manager/test_private_browsing_dismiss_doorhanger_credentials.py
+++ b/tests/password_manager/test_private_browsing_dismiss_doorhanger_credentials.py
@@ -1,8 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import AutofillPopup
-from modules.browser_object_navigation import Navigation
+from modules.browser_object import AutofillPopup, Navigation
 from modules.browser_object_panel_ui import PanelUi
 from modules.page_object_about_pages import AboutLogins
 from modules.page_object_autofill import LoginAutofill

--- a/tests/password_manager/test_private_browsing_dismiss_doorhanger_credentials.py
+++ b/tests/password_manager/test_private_browsing_dismiss_doorhanger_credentials.py
@@ -1,8 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import AutofillPopup, Navigation
-from modules.browser_object_panel_ui import PanelUi
+from modules.browser_object import AutofillPopup, Navigation, PanelUi
 from modules.page_object_about_pages import AboutLogins
 from modules.page_object_autofill import LoginAutofill
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047910](https://bugzilla.mozilla.org/show_bug.cgi?id=2047910)

### Description of Code / Doc Changes

* Fix test_private_browsing_dismiss_doorhanger_credentials

Mark 2 tests as pass since they were fixed in previous commits:
* Fix test_save_login_via_doorhanger
* Fix test_update_login_via_doorhanger

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
