### PR TITLE
Hani/ Fix edit delete primary password tests

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1476,17 +1476,31 @@ Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: current-primary-password
+Selector Name: primary-password-current-parent
 Selector Data: "oldpw"
-Description: Input for current password in the Change Primary Password dialog
-Location: about:preferences#privacy Primary Password popup
+Description: The outer moz-input-password element for the "Current password" field in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: current-primary-password
+Selector Data: "input"
+Description: The inner input element inside the shadow DOM of the "Current password" field in the Primary Password dialog
+Location: About Preferences - Passwords - Primary Password dialog
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: remove-current-password-parent
+Selector Data: "password"
+Description: The outer moz-input-password element for the "Current password" field in the Remove Primary Password dialog
+Location: About Preferences - Passwords - Remove Primary Password dialog
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: remove-current-password
-Selector Data: "password"
-Description: Input for current password in the Remove Primary Password dialog
-Location: about:preferences#privacy Primary Password popup
+Selector Data: "input"
+Description: The inner input element inside the shadow DOM of the "Current password" field in the Remove Primary Password dialog
+Location: About Preferences - Passwords - Remove Primary Password dialog
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
@@ -1574,21 +1588,21 @@ Location: about:preferences#privacy (Remove Primary Password dialog)
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: primary-password-new-input
+Selector Name: primary-password-input-parent
 Selector Data: "pw1"
 Description: The outer moz-input-password custom element for the "Enter new password" field in the Primary Password dialog
 Location: About Preferences - Passwords - Primary Password dialog
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: primary-password-new-input-field
+Selector Name: primary-password-input-field
 Selector Data: "input#input"
 Description: The inner input field inside the shadow DOM of the "Enter new password" moz-input-password element in the Primary Password dialog
 Location: About Preferences - Passwords - Primary Password dialog
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: primary-password-reenter-input
+Selector Name: primary-password-reenter-input-parent
 Selector Data: "pw2"
 Description: The outer moz-input-password custom element for the "Re-enter password" field in the Primary Password dialog
 Location: About Preferences - Passwords - Primary Password dialog

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1476,7 +1476,7 @@ Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: primary-password-current-parent
+Selector Name: current-primary-password-parent
 Selector Data: "oldpw"
 Description: The outer moz-input-password element for the "Current password" field in the Primary Password dialog
 Location: About Preferences - Passwords - Primary Password dialog

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -853,13 +853,11 @@ password_manager:
     splits:
     - smoke
   test_delete_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_edit_autofill_after_pp_dismissed:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_edit_generated_password_triggers_autosave:
@@ -867,8 +865,7 @@ password_manager:
     splits:
     - functional2
   test_edit_primary_password:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_facebook_login_autofill_dropdown:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -907,7 +907,7 @@
     "strategy": "id",
     "shadowParent": "primary-password-input-parent",
     "groups": [
-        "doNotCache"
+      "doNotCache"
     ]
   },
   "primary-password-reenter-input-parent": {
@@ -922,7 +922,7 @@
     "strategy": "id",
     "shadowParent": "primary-password-reenter-input-parent",
     "groups": [
-        "doNotCache"
+      "doNotCache"
     ]
   }
 }

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -767,7 +767,7 @@
       "doNotCache"
     ]
   },
-  "primary-password-current-parent": {
+  "current-primary-password-parent": {
     "selectorData": "oldpw",
     "strategy": "id",
     "groups": []
@@ -775,7 +775,7 @@
   "current-primary-password": {
     "selectorData": "input",
     "strategy": "id",
-    "shadowParent": "primary-password-current-parent",
+    "shadowParent": "current-primary-password-parent",
     "groups": []
   },
   "remove-current-password-parent": {

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -767,16 +767,26 @@
       "doNotCache"
     ]
   },
-  "current-primary-password": {
+  "primary-password-current-parent": {
     "selectorData": "oldpw",
     "strategy": "id",
-    "groups": [
-      "doNotCache"
-    ]
+    "groups": []
   },
-  "remove-current-password": {
+  "current-primary-password": {
+    "selectorData": "input",
+    "strategy": "id",
+    "shadowParent": "primary-password-current-parent",
+    "groups": []
+  },
+  "remove-current-password-parent": {
     "selectorData": "password",
     "strategy": "id",
+    "groups": []
+  },
+  "remove-current-password": {
+    "selectorData": "input",
+    "strategy": "id",
+    "shadowParent": "remove-current-password-parent",
     "groups": []
   },
   "remove-primary-password-box": {
@@ -881,7 +891,7 @@
     "strategy": "id",
     "groups": []
   },
-  "primary-password-input": {
+  "primary-password-input-parent": {
     "selectorData": "pw1",
     "strategy": "id",
     "groups": [
@@ -889,12 +899,14 @@
     ]
   },
   "primary-password-input-field": {
-    "selectorData": "input#input",
-    "strategy": "css",
-    "shadowParent": "primary-password-input",
-    "groups": []
+    "selectorData": "input",
+    "strategy": "id",
+    "shadowParent": "primary-password-input-parent",
+    "groups": [
+        "doNotCache"
+    ]
   },
-  "primary-password-reenter-input": {
+  "primary-password-reenter-input-parent": {
     "selectorData": "pw2",
     "strategy": "id",
     "groups": [
@@ -902,9 +914,11 @@
     ]
   },
   "primary-password-reenter-input-field": {
-    "selectorData": "input#input",
-    "strategy": "css",
-    "shadowParent": "primary-password-reenter-input",
-    "groups": []
+    "selectorData": "input",
+    "strategy": "id",
+    "shadowParent": "primary-password-reenter-input-parent",
+    "groups": [
+        "doNotCache"
+    ]
   }
 }

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -770,13 +770,17 @@
   "current-primary-password-parent": {
     "selectorData": "oldpw",
     "strategy": "id",
-    "groups": []
+    "groups": [
+      "doNotCache"
+    ]
   },
   "current-primary-password": {
     "selectorData": "input",
     "strategy": "id",
     "shadowParent": "current-primary-password-parent",
-    "groups": []
+    "groups": [
+      "doNotCache"
+    ]
   },
   "remove-current-password-parent": {
     "selectorData": "password",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1127,6 +1127,24 @@ class AboutPrefs(BasePage):
         self.accept_alert_and_verify_text(alert_text)
         return self
 
+    def change_primary_password(
+        self, current_password: str, new_password: str, alert_text: str, ba
+    ):
+        """Changes an existing Primary Password and confirms alert"""
+        self.open()
+        self.open_change_primary_password_popup(ba)
+        self.get_element("current-primary-password").send_keys(current_password)
+        self.set_primary_password(new_password)
+        self.accept_alert_and_verify_text(alert_text)
+        return self
+
+    def open_change_primary_password_popup(self, browser_actions):
+        """Opens the Change Primary Password popup and switches to the iframe context"""
+        self.click_on("change-primary-password")
+        popup = self.get_element("browser-popup")
+        browser_actions.switch_to_iframe_context(popup)
+        return self
+
     # ── AI Controls ──────────────────────────────────────────────────────
 
     def toggle_ai_killswitch_click(self) -> BasePage:

--- a/tests/password_manager/test_edit_primary_password.py
+++ b/tests/password_manager/test_edit_primary_password.py
@@ -31,17 +31,7 @@ def test_edit_primary_password(driver: Firefox):
     # Have a Primary Password set
     about_prefs.create_primary_password(PRIMARY_PASSWORD, ALERT_MESSAGE, ba)
 
-    # Click on the Change Primary Password button
-    about_prefs.open()
-    about_prefs.click_on("change-primary-password")
-
-    # Input your current Primary Password followed by a new Primary Password(confirming it in the second field)
-    primary_pw_popup = about_prefs.get_element("browser-popup")
-    ba.switch_to_iframe_context(primary_pw_popup)
-    about_prefs.get_element("current-primary-password").send_keys(PRIMARY_PASSWORD)
-    about_prefs.get_element("enter-new-password").send_keys(NEW_PRIMARY_PASSWORD)
-    about_prefs.get_element("reenter-new-password").send_keys(NEW_PRIMARY_PASSWORD)
-    about_prefs.click_on("submit-password")
-
-    # Check that the pop-up appears
-    about_prefs.accept_alert_and_verify_text(ALERT_MESSAGE)
+    # Change the Primary Password
+    about_prefs.change_primary_password(
+        PRIMARY_PASSWORD, NEW_PRIMARY_PASSWORD, ALERT_MESSAGE, ba
+    )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047910](https://bugzilla.mozilla.org/show_bug.cgi?id=2047910)

### Description of Code / Doc Changes

* Fix tests/password_manager/test_edit_autofill_after_pp_dismissed.py
* Fix tests/password_manager/test_delete_primary_password.py
* Fix tests/password_manager/test_edit_primary_password.py

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
