### PR TITLE
Hani/ Fix password doorhanger dismiss and type username

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -824,8 +824,7 @@ password_manager:
     splits:
     - functional1
   test_add_username_via_doorhanger:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_auto_saved_generated_password_context_menu:
@@ -878,8 +877,7 @@ password_manager:
     splits:
     - functional1
   test_multiple_saved_logins:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_navigation_to_about_logins_from_autocomplete:
@@ -911,13 +909,11 @@ password_manager:
     splits:
     - functional2
   test_password_field_only_triggers_dismissed_doorhanger:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_password_manager_key_icon_after_doorhanger_dismiss:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_password_manager_on_google_US:
@@ -969,8 +965,7 @@ password_manager:
     splits:
     - functional2
   test_username_edit_captured_in_dismissed_doorhanger:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047910
-    result: unstable
+    result: pass
     splits:
     - functional2
 pdf_viewer:

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -192,7 +192,9 @@ class AutofillPopup(BasePage):
         input_el = self.driver.execute_script(
             "return arguments[0].shadowRoot.querySelector('input')", parent
         )
-        assert input_el is not None, "Could not find input inside password-notification-username-field shadow root"
+        assert input_el is not None, (
+            "Could not find input inside password-notification-username-field shadow root"
+        )
         return input_el
 
     @BasePage.context_chrome

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -186,15 +186,19 @@ class AutofillPopup(BasePage):
         )
         return self
 
+    @BasePage.context_chrome
     def _get_doorhanger_username_input(self):
-        """Helper to get the input element inside the password doorhanger username shadow DOM"""
+        """Helper to get the input element inside the password doorhanger username shadow DOM.
+        Must be called from chrome context.
+        """
         parent = self.get_element("password-notification-username-field")
         input_el = self.driver.execute_script(
             "return arguments[0].shadowRoot.querySelector('input')", parent
         )
-        assert input_el is not None, (
-            "Could not find input inside password-notification-username-field shadow root"
-        )
+        if input_el is None:
+            raise RuntimeError(
+                "Could not find input inside password-notification-username-field shadow root"
+            )
         return input_el
 
     @BasePage.context_chrome

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -173,7 +173,11 @@ class AutofillPopup(BasePage):
     @BasePage.context_chrome
     def dismiss_password_doorhanger(self) -> BasePage:
         """Dismiss the Password Manager doorhanger using ESC."""
-        self.get_element("password-notification-username-field").send_keys(Keys.ESCAPE)
+        parent = self.get_element("password-notification-username-field")
+        input_el = self.driver.execute_script(
+            "return arguments[0].shadowRoot.querySelector('input')", parent
+        )
+        input_el.send_keys(Keys.ESCAPE)
         return self
 
     @BasePage.context_chrome
@@ -195,5 +199,9 @@ class AutofillPopup(BasePage):
     @BasePage.context_chrome
     def type_username_in_password_doorhanger(self, username: str) -> BasePage:
         """Type a username into the Password Manager doorhanger."""
-        self.get_element("password-notification-username-field").send_keys(username)
+        parent = self.get_element("password-notification-username-field")
+        input_el = self.driver.execute_script(
+            "return arguments[0].shadowRoot.querySelector('input')", parent
+        )
+        input_el.send_keys(username)
         return self

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -171,16 +171,6 @@ class AutofillPopup(BasePage):
         return element
 
     @BasePage.context_chrome
-    def dismiss_password_doorhanger(self) -> BasePage:
-        """Dismiss the Password Manager doorhanger using ESC."""
-        parent = self.get_element("password-notification-username-field")
-        input_el = self.driver.execute_script(
-            "return arguments[0].shadowRoot.querySelector('input')", parent
-        )
-        input_el.send_keys(Keys.ESCAPE)
-        return self
-
-    @BasePage.context_chrome
     def click_securely_generated_password(self) -> BasePage:
         """Click the 'Use a Securely Generated Password' option from the autofill popup."""
         self.click_on("generated-securely-password")
@@ -196,12 +186,23 @@ class AutofillPopup(BasePage):
         )
         return self
 
-    @BasePage.context_chrome
-    def type_username_in_password_doorhanger(self, username: str) -> BasePage:
-        """Type a username into the Password Manager doorhanger."""
+    def _get_doorhanger_username_input(self):
+        """Helper to get the input element inside the password doorhanger username shadow DOM"""
         parent = self.get_element("password-notification-username-field")
         input_el = self.driver.execute_script(
             "return arguments[0].shadowRoot.querySelector('input')", parent
         )
-        input_el.send_keys(username)
+        assert input_el is not None, "Could not find input inside password-notification-username-field shadow root"
+        return input_el
+
+    @BasePage.context_chrome
+    def type_username_in_password_doorhanger(self, username: str) -> BasePage:
+        """Type a username into the Password Manager doorhanger."""
+        self._get_doorhanger_username_input().send_keys(username)
+        return self
+
+    @BasePage.context_chrome
+    def dismiss_password_doorhanger(self) -> BasePage:
+        """Dismiss the Password Manager doorhanger using ESC."""
+        self._get_doorhanger_username_input().send_keys(Keys.ESCAPE)
         return self

--- a/modules/browser_object_autofill_popup.py
+++ b/modules/browser_object_autofill_popup.py
@@ -186,7 +186,6 @@ class AutofillPopup(BasePage):
         )
         return self
 
-    @BasePage.context_chrome
     def _get_doorhanger_username_input(self):
         """Helper to get the input element inside the password doorhanger username shadow DOM.
         Must be called from chrome context.


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047910](https://bugzilla.mozilla.org/show_bug.cgi?id=2047910)

### Description of Code / Doc Changes

* Fixed:
  * tests/password_manager/test_multiple_saved_logins.py
  * tests/password_manager/test_password_manager_key_icon_after_doorhanger_dismiss.py
  * tests/password_manager/test_password_field_only_triggers_dismissed_doorhanger.py
  * tests/password_manager/test_add_username_via_doorhanger.py
  * tests/password_manager/test_username_edit_captured_in_dismissed_doorhanger.py

* Couldn't find a locator since the input element is two levels deep inside the shadow root, so the locator system cannot reach it.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
