### PR TITLE
Tracy/never remember history radio group

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1154,13 +1154,6 @@ Location: about:preferences#search
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: history_menulist
-Selector Data: "historyMode"
-Description: moz-radio-group for the "Firefox will" history option (Remember/Customize/Never remember history)
-Location: about:preferences#privacy History subsection
-Path to .json: modules/data/about_prefs.components.json
-```
-```
 Selector Name: history-option-radio
 Selector Data: "moz-radio[data-l10n-id='{option}']"
 Description: History option moz-radio by data-l10n-id label; valid {option} values: history-remember-option-all2 (Remember), history-remember-option-never2 (Never remember), history-remember-option-custom2 (Customize)

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1156,7 +1156,14 @@ Path to .json: modules/data/about_prefs.components.json
 ```
 Selector Name: history_menulist
 Selector Data: "historyMode"
-Description: Menu for "Firefox will" option
+Description: moz-radio-group for the "Firefox will" history option (Remember/Customize/Never remember history)
+Location: about:preferences#privacy History subsection
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: history-option-radio
+Selector Data: "moz-radio[data-l10n-id='{option}']"
+Description: History option moz-radio by data-l10n-id label; valid {option} values: history-remember-option-all2 (Remember), history-remember-option-never2 (Never remember), history-remember-option-custom2 (Customize)
 Location: about:preferences#privacy History subsection
 Path to .json: modules/data/about_prefs.components.json
 ```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -614,14 +614,16 @@ geolocation:
     splits:
     - functional1
 glean:
-  test_serp_abandonment:
-    result: pass
-    splits:
-    - glean
-  test_serp_impression:
-    result: pass
-    splits:
-    - glean
+  serp_abandonment:
+    test_serp_abandonment:
+      result: pass
+      splits:
+      - glean
+  serp_impression:
+    test_serp_impression:
+      result: pass
+      splits:
+      - glean
 language_packs:
   test_language_pack_install_addons:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047894

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1117,8 +1117,7 @@ preferences:
     splits:
     - smoke
   test_never_remember_history:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2042647
-    result: unstable
+    result: pass
     splits:
     - smoke
   test_notifications_change_set:

--- a/manifests/testkey.py
+++ b/manifests/testkey.py
@@ -459,6 +459,13 @@ class TestKey:
 
                 resplit = False
                 if testfile not in newkey[suite]:
+                    found_subsuite_test = False
+                    for subsuite in newkey[suite]:
+                        if testfile in newkey[suite][subsuite]:
+                            found_subsuite_test = True
+                            break
+                    if found_subsuite_test:
+                        continue
                     if not interactive:
                         sys.exit(
                             "Please run `python addtests.py` from your command prompt."

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -733,11 +733,12 @@
     "strategy": "id",
     "groups": []
   },
-  "history-option-select": {
-    "selectorData": "select[id='input']",
+  "history-option-radio": {
+    "selectorData": "moz-radio[data-l10n-id='{option}']",
     "strategy": "css",
-    "shadowParent": "history_menulist",
-    "groups": []
+    "groups": [
+      "doNotCache"
+    ]
   },
   "tab-hover-preview-checkbox": {
     "selectorData": "tabPreviewShowThumbnails",

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -497,11 +497,6 @@
     "strategy": "id",
     "groups": []
   },
-  "history_menulist": {
-    "selectorData": "historyMode",
-    "strategy": "id",
-    "groups": []
-  },
   "mime-type-item": {
     "selectorData": "richlistitem[type='{item}']",
     "strategy": "css",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -378,7 +378,7 @@ class AboutPrefs(BasePage):
         Set the history option in about:preferences.
 
         Firefox now renders the history setting as a moz-radio-group rather than
-        a menulist, so the legacy option keys are mapped to the matching
+        a menulist. The legacy option keys are now mapped to the matching
         moz-radio data-l10n-id and selected by click.
         """
         history_option_l10n_ids = {

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -367,12 +367,6 @@ class AboutPrefs(BasePage):
         sleep(0.25)
         return self
 
-    def get_history_menulist(self) -> WebElement:
-        """
-        Gets the web element for the list of history items that appear in about:preferences
-        """
-        return self.get_element("history_menulist")
-
     def set_history_option(self, option: str):
         """
         Set the history option in about:preferences.
@@ -386,6 +380,8 @@ class AboutPrefs(BasePage):
             "dontremember": "history-remember-option-never2",
             "custom": "history-remember-option-custom2",
         }
+        if option not in history_option_l10n_ids:
+            raise ValueError(f"Unknown history option: {option!r}")
         history_radio = self.get_element(
             "history-option-radio", labels=[history_option_l10n_ids[option]]
         )

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -376,12 +376,20 @@ class AboutPrefs(BasePage):
     def set_history_option(self, option: str):
         """
         Set the history option in about:preferences.
+
+        Firefox now renders the history setting as a moz-radio-group rather than
+        a menulist, so the legacy option keys are mapped to the matching
+        moz-radio data-l10n-id and selected by click.
         """
-        history_menulist = self.get_history_menulist()
-        self.driver.execute_script("arguments[0].scrollIntoView();", history_menulist)
-        sleep(1)
-        menulist_popup = Select(self.get_element("history-option-select"))
-        menulist_popup.select_by_value(option)
+        history_option_l10n_ids = {
+            "remember": "history-remember-option-all2",
+            "dontremember": "history-remember-option-never2",
+            "custom": "history-remember-option-custom2",
+        }
+        history_radio = self.get_element(
+            "history-option-radio", labels=[history_option_l10n_ids[option]]
+        )
+        history_radio.click()
         return self
 
     # ---- Payment and Address Management ---------------------------------------------------------

--- a/scripts/choose_test_split.py
+++ b/scripts/choose_test_split.py
@@ -13,7 +13,7 @@ OUTPUT_FILE = "selected_tests"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SLASH = "/" if "/" in SCRIPT_DIR else "\\"
 ROOT_DIR = os.path.dirname(SCRIPT_DIR)
-IGNORE_FILE_REGEXES = [rf"{SLASH}glean", rf"l10n_CM{SLASH}.*\.py"]
+IGNORE_FILE_REGEXES = [rf"\{SLASH}glean", rf"l10n_CM\{SLASH}.*\.py"]
 BIG_MODELS = ["Navigation", "GenericPage"]
 
 

--- a/scripts/choose_test_split.py
+++ b/scripts/choose_test_split.py
@@ -14,7 +14,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SLASH = "/" if "/" in SCRIPT_DIR else "\\"
 ROOT_DIR = os.path.dirname(SCRIPT_DIR)
 IGNORE_FILE_REGEXES = [rf"\{SLASH}glean", rf"l10n_CM\{SLASH}.*\.py"]
-BIG_MODELS = ["Navigation", "GenericPage"]
+BIG_MODELS = ["Navigation", "GenericPage", "AboutPrefs"]
 
 
 def snakify(pascal: str) -> str:
@@ -256,6 +256,8 @@ if __name__ == "__main__":
             model_file_contents = "".join([line for line in open(model_file)])
             classes = re_obj.get("class_re").findall(model_file_contents)
             for model_name in classes:
+                if model_name in BIG_MODELS:
+                    continue  # model too big, don't run all tests
                 for test_name in get_tests_by_model(
                     model_name, test_paths_and_contents, run_list
                 ):

--- a/scripts/choose_test_split.py
+++ b/scripts/choose_test_split.py
@@ -13,7 +13,7 @@ OUTPUT_FILE = "selected_tests"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SLASH = "/" if "/" in SCRIPT_DIR else "\\"
 ROOT_DIR = os.path.dirname(SCRIPT_DIR)
-IGNORE_FILE_REGEXES = [rf"\{SLASH}glean", rf"l10n_CM\{SLASH}.*\.py"]
+IGNORE_FILE_REGEXES = [rf"{SLASH}glean", rf"l10n_CM{SLASH}.*\.py"]
 BIG_MODELS = ["Navigation", "GenericPage"]
 
 


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2042647

#### Description of Code / Doc Changes
  Firefox 153 replaced the History menulist/select in about:preferences#privacy                                             
  with a moz-radio-group. Update AboutPrefs.set_history_option to select the                                                
  matching moz-radio, swap the manifest selector, and document it in SELECTOR_INFO.

#### Workflow Checklist
- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.

Thank you!
