### PR TITLE
stabilize open_websites_from_history

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1629,9 +1629,9 @@ tabs:
   test_close_pinned_tab_via_mouse:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047903
     result:
+      linux: unstable
       mac: pass
       win: pass
-      linux: unstable
     splits:
     - smoke
     - ci

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -356,11 +356,7 @@ bookmarks_and_history:
     splits:
     - smoke
   test_open_websites_from_history:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043402
-    result:
-      linux: pass
-      mac: unstable
-      win: pass
+    result: pass
     splits:
     - smoke
   test_opened_website_in_new_tab_present_in_hamburger_history_menu:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1627,7 +1627,11 @@ tabs:
     splits:
     - functional2
   test_close_pinned_tab_via_mouse:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047903
+    result:
+      mac: pass
+      win: pass
+      linux: unstable
     splits:
     - smoke
     - ci

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -8,7 +8,8 @@ address_bar_and_search:
     splits:
     - functional1
   test_add_engine_address_bar:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049511
+    result: unstable
     splits:
     - smoke
   test_added_open_search_engine_default:
@@ -401,6 +402,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - ci
   test_close_browser_with_download_in_progress_shows_prompt:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2026665
     result: unstable

--- a/modules/browser_object_panel_ui.py
+++ b/modules/browser_object_panel_ui.py
@@ -1,3 +1,4 @@
+import logging
 import random
 from time import sleep
 from typing import List, Optional, Tuple
@@ -231,7 +232,7 @@ class PanelUi(BasePage):
         return self
 
     @BasePage.context_chrome
-    def get_random_history_entry(self) -> Optional[Tuple[str, str]]:
+    def get_history_entry_by_label(self, label) -> Optional[Tuple[str, str]]:
         """
         Retrieve a random browser history entry from the Panel UI.
 
@@ -244,7 +245,9 @@ class PanelUi(BasePage):
         if not items:
             return None
 
-        item = random.choice(items)
+        for item in items:
+            if label in item.get_attribute("label"):
+                break
         raw_url = item.get_attribute("image")
         label = item.get_attribute("label")
 

--- a/scripts/choose_test_split.py
+++ b/scripts/choose_test_split.py
@@ -14,7 +14,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SLASH = "/" if "/" in SCRIPT_DIR else "\\"
 ROOT_DIR = os.path.dirname(SCRIPT_DIR)
 IGNORE_FILE_REGEXES = [rf"\{SLASH}glean", rf"l10n_CM\{SLASH}.*\.py"]
-BIG_MODELS = ["Navigation", "GenericPage", "AboutPrefs"]
+BIG_MODELS = ["Navigation", "GenericPage", "AboutPrefs", "PanelUi"]
 
 
 def snakify(pascal: str) -> str:

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -45,15 +45,14 @@ tasks:
         . ./scripts/keyring-unlock.sh
         if [[ ! $(python3 ./scripts/choose_test_type.py) =~ "starfox" ]]; then exit 0; fi;
         pipenv run python -m scripts.choose_test_split;
-        pipenv run pytest --fx-executable ./firefox/firefox tests/form_autofill;
-        # pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
+        pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
         export FAILURE=${?};
         git fetch origin main --depth 2
         export ORIGIN=$(git merge-base origin/main HEAD)
         export GIT_DIFF=$(git --no-pager diff --name-only $ORIGIN)
         if [[ $GIT_DIFF =~ "/glean/" ]]; then pipenv run pytest --fx-executable ./firefox/firefox tests/glean; export FAILURE=$((FAILURE | ${?})); fi;
         mv ./config/ci_pyproject_headed.toml ./pyproject.toml;
-        # pipenv run python -m scripts.choose_test_split;
+        pipenv run python -m scripts.choose_test_split;
         pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
         exit $((${?} | ${FAILURE}))
     notify:

--- a/taskcluster/kinds/run-smoke-tests/kind.yml
+++ b/taskcluster/kinds/run-smoke-tests/kind.yml
@@ -45,7 +45,8 @@ tasks:
         . ./scripts/keyring-unlock.sh
         if [[ ! $(python3 ./scripts/choose_test_type.py) =~ "starfox" ]]; then exit 0; fi;
         pipenv run python -m scripts.choose_test_split;
-        pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
+        pipenv run pytest --fx-executable ./firefox/firefox tests/form_autofill;
+        # pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
         export FAILURE=${?};
         git fetch origin main --depth 2
         export ORIGIN=$(git merge-base origin/main HEAD)
@@ -53,7 +54,7 @@ tasks:
         if [[ $GIT_DIFF =~ "/glean/" ]]; then pipenv run pytest --fx-executable ./firefox/firefox tests/glean; export FAILURE=$((FAILURE | ${?})); fi;
         mv ./config/ci_pyproject_headed.toml ./pyproject.toml;
         # pipenv run python -m scripts.choose_test_split;
-        pipenv run pytest --fx-executable ./firefox/firefox tests/password_manager/test_password_csv_export.py tests/pdf_viewer/test_pdf_download.py
+        pipenv run pytest --fx-executable ./firefox/firefox $(cat selected_tests);
         exit $((${?} | ${FAILURE}))
     notify:
       recipients:

--- a/tests/bookmarks_and_history/test_open_websites_from_history.py
+++ b/tests/bookmarks_and_history/test_open_websites_from_history.py
@@ -6,6 +6,8 @@ from selenium.webdriver import Firefox
 from modules.browser_object import PanelUi
 from modules.page_object import GenericPage
 
+LABEL_TEXT = "Mozilla"
+
 
 @pytest.fixture()
 def test_case():
@@ -26,7 +28,7 @@ def test_open_websites_from_history(driver: Firefox):
 
     # Open History section from Hamburger Menu and get a random entry from browser history
     panel.open_history_menu()
-    result = panel.get_random_history_entry()
+    result = panel.get_history_entry_by_label("Mozilla")
 
     # Skip test if no history entries are available
     if result is None:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [link](https://bugzilla.mozilla.org/show_bug.cgi?id=2043402)

### Description of Code / Doc Changes

* Resolve test - fix object model method
* Test marking + add PanelUI to "too big to run" model list
* Rider: fix taskcluster CI kind

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes or creates a BOM/POM (name the object model): PanelUI
- [x] Changes CI flow

### Screenshots or Explanations

We need to revamp the test chooser but for now the huge object models get added to a list where we don't select all tests from them when they change.

### Comments or Future Work

Improve the test chooser, stabilize broken tests.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.

Thank you!
