### PR TITLE
Fix security_and_privacy ETP tests for Settings redesign (bug 2043366)

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -902,66 +902,115 @@ Location: about:preferences#home
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: custom-radio
-Selector Data: "customRadio"
-Description: In Enhanced Tracking Protection, the Custom radio button
+Selector Name: etp-advanced-button
+Selector Data: "etpStatusAdvancedButton"
+Description: ETP "Advanced" button on the privacy pane; opens the ETP settings subpage (Settings redesign)
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: custom-tracker-options-parent
-Selector Data: "contentBlockingOptionCustom"
-Description: Parent Element in custom tracker blocking checkboxes
-Location: about:preferences#privacy
+Selector Name: etp-level-standard
+Selector Data: "etpLevelStandard"
+Description: Enhanced Tracking Protection "Standard" level moz-radio
+Location: about:preferences#etp
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: cookies-checkbox
-Selector Data: "contentBlockingBlockCookiesCheckbox"
-Description: In Enhanced Tracking Protection, the check-box for Cookies
-Location: about:preferences#privacy
+Selector Name: etp-level-strict
+Selector Data: "etpLevelStrict"
+Description: Enhanced Tracking Protection "Strict" level moz-radio
+Location: about:preferences#etp
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: cookies-isolate-social-media-option
-Selector Data: "isolateCookiesSocialMedia"
-Description: In Enhanced Tracking Protection, the option for Cookies…, and isolate other…
-Location: about:preferences#privacy
+Selector Name: etp-level-custom
+Selector Data: "etpLevelCustom"
+Description: Enhanced Tracking Protection "Custom" level moz-radio
+Location: about:preferences#etp
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: tracking-in-all-windows
-Selector Data: "menuitem[data-l10n-id='content-blocking-tracking-protection-option-all-windows']"
-Description: In Enhanced Tracking Protection, the option for Tracking content, In all windows
-Location: about:preferences#privacy
+Selector Name: etp-customize-button
+Selector Data: "etpCustomizeButton"
+Description: "Customize" button shown under the Custom ETP level; opens the ETP Customize subpage
+Location: about:preferences#etp
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: tracking-checkbox
-Selector Data: "contentBlockingTrackingProtectionCheckbox"
-Description: In Enhanced Tracking Protection, the check-box for Tracking content
-Location: about:preferences#privacy
+Selector Name: etp-custom-tracking-toggle
+Selector Data: "etpCustomTrackingProtectionEnabled"
+Description: Custom ETP "Tracking content" moz-toggle
+Location: about:preferences#etpCustomize
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: cryptominers-checkbox
-Selector Data: "contentBlockingCryptominersCheckbox"
-Description: In Enhanced Tracking Protection, the check-box for Cryptominers
-Location: about:preferences#privacy
+Selector Name: etp-custom-tracking-context
+Selector Data: "etpCustomTrackingProtectionEnabledContext"
+Description: Custom ETP "Tracking content" context moz-select (all windows / private windows)
+Location: about:preferences#etpCustomize
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: known-fingerprints-checkbox
-Selector Data: "contentBlockingFingerprintingCheckbox"
-Description: In Enhanced Tracking Protection, the check-box for Known fingerprinters
-Location: about:preferences#privacy
+Selector Name: etp-custom-tracking-context-select
+Selector Data: "select"
+Description: Inner native <select> of the Tracking content context moz-select (shadowParent: etp-custom-tracking-context); values: all, pbmOnly
+Location: about:preferences#etpCustomize
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
-Selector Name: suspected-fingerprints-checkbox
-Selector Data: "contentBlockingFingerprintingProtectionCheckbox"
-Description: In Enhanced Tracking Protection, the check-box for Suspected fingerprinters
-Location: about:preferences#privacy
+Selector Name: etp-custom-cookies-toggle
+Selector Data: "etpCustomCookiesEnabled"
+Description: Custom ETP "Cookies" moz-toggle
+Location: about:preferences#etpCustomize
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: etp-custom-cookie-behavior
+Selector Data: "cookieBehavior"
+Description: Custom ETP cookie-behavior moz-select (which cookies to block)
+Location: about:preferences#etpCustomize
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: etp-custom-cookie-behavior-select
+Selector Data: "select"
+Description: Inner native <select> of the cookie-behavior moz-select (shadowParent: etp-custom-cookie-behavior); values 0/4/5/3/1/2. Disabled until the cookies toggle is on.
+Location: about:preferences#etpCustomize
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: etp-custom-cryptomining-toggle
+Selector Data: "etpCustomCryptominingProtectionEnabled"
+Description: Custom ETP "Cryptominers" moz-toggle
+Location: about:preferences#etpCustomize
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: etp-custom-known-fingerprinting-toggle
+Selector Data: "etpCustomKnownFingerprintingProtectionEnabled"
+Description: Custom ETP "Known fingerprinters" moz-toggle
+Location: about:preferences#etpCustomize
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: etp-custom-suspect-fingerprinting-toggle
+Selector Data: "etpCustomSuspectFingerprintingProtectionEnabled"
+Description: Custom ETP "Suspected fingerprinters" moz-toggle
+Location: about:preferences#etpCustomize
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: etp-custom-suspect-fingerprinting-context
+Selector Data: "etpCustomSuspectFingerprintingProtectionEnabledContext"
+Description: Custom ETP "Suspected fingerprinters" context moz-select (all windows / private windows)
+Location: about:preferences#etpCustomize
+Path to .json: modules/data/about_prefs.components.json
+```
+```
+Selector Name: etp-custom-suspect-fingerprinting-context-select
+Selector Data: "select"
+Description: Inner native <select> of the Suspected fingerprinters context moz-select (shadowParent: etp-custom-suspect-fingerprinting-context); values: all, pbmOnly
+Location: about:preferences#etpCustomize
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
@@ -1515,20 +1564,6 @@ Selector Name: remove-password
 Selector Data: "button[label^='Remove']"
 Description: Remove button to remove the primary password
 Location: about:preferences#privacy Primary Password popup
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: standard-radio
-Selector Data: "standardRadio"
-Description: In Enhanced Tracking Protection, the standard radio button
-Location: about:preferences#privacy
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: standard-section
-Selector Data: "contentBlockingOptionStandard"
-Description: In Enhanced Tracking Protection, the standard radio section
-Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
@@ -5346,20 +5381,6 @@ Selector Data: "trust-icon-container"
 Description: Address bar shield icon
 Location: Address bar
 Path to .json: modules/data/trust_panel.components.json
-```
-```
-Selector Name: suspected-fingerprints-in-all-windows
-Selector Data: "#fingerprintingProtectionMenu menuitem[value='always']"
-Description: "In all windows" option in the Suspected Fingerprinters dropdown under ETP Custom mode
-Location: about:preferences#privacy > Custom > Suspected fingerprinters dropdown
-Path to .json: modules/data/about_prefs.components.json
-```
-```
-Selector Name: suspected-fingerprints-only-in-private-windows
-Selector Data: "#fingerprintingProtectionMenu menuitem[value='private']"
-Description: "Only in private windows" option in the Suspected Fingerprinters dropdown under ETP Custom mode
-Location: about:preferences#privacy > Custom > Suspected fingerprinters dropdown
-Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: see-all-trackers-parent

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1200,8 +1200,7 @@ security_and_privacy:
     splits:
     - smoke
   test_blocking_fingerprinters:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_blocking_social_media_trackers:
@@ -1249,8 +1248,7 @@ security_and_privacy:
     splits:
     - functional2
   test_cross_site_tracking_cookies_displayed_subpanel:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_cryptominers_blocked_and_shown_in_info_panel:
@@ -1262,23 +1260,19 @@ security_and_privacy:
     splits:
     - functional2
   test_cryptominers_displayed_subpanel:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_cryptominers_subpanel_display_when_not_blocked:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_custom_block_suspected_fingerprinters_in_all_windows:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_custom_block_suspected_fingerprinters_only_in_private_windows:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_data_clearance_from_private_window_can_be_canceled:
@@ -1310,18 +1304,15 @@ security_and_privacy:
     splits:
     - functional2
   test_etp_panel_displayed_when_all_protections_disabled_custom:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_etp_panel_displayed_when_no_trackers_detected:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_etp_panel_displayed_when_protection_off:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_etp_toggle_on_off_behavior:
@@ -1337,18 +1328,15 @@ security_and_privacy:
     splits:
     - functional2
   test_fingerprinters_blocked_and_shown_in_panel_and_preferences:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_fingerprinters_displayed_subpanel:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_fingerprinters_subpanel_display_when_not_blocked:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_http_lock_icon_connection_state:
@@ -1432,8 +1420,7 @@ security_and_privacy:
     splits:
     - functional2
   test_social_media_trackers_displayed_subpanel:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_third_party_content_blocked_private_browsing:
@@ -1449,23 +1436,19 @@ security_and_privacy:
     splits:
     - functional2
   test_trackers_cryptominers_fingerprinters_blocked:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - smoke
   test_tracking_content_custom_mode:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_tracking_content_subpanel_display_when_not_blocked:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_tracking_elements_not_blocked_with_etp_disabled:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_undo_close_tab_private_browsing:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -60,11 +60,6 @@
       "searchEngineDropdown"
     ]
   },
-  "custom-tracker-options-parent": {
-    "selectorData": "contentBlockingOptionCustom",
-    "strategy": "id",
-    "groups": []
-  },
   "search-engine-dropmarker": {
     "selectorData": "dropmarker",
     "strategy": "tag",
@@ -299,54 +294,87 @@
     "strategy": "css",
     "groups": []
   },
-  "custom-radio": {
-    "selectorData": "customRadio",
+  "etp-advanced-button": {
+    "selectorData": "etpStatusAdvancedButton",
     "strategy": "id",
     "groups": []
   },
-  "cookies-checkbox": {
-    "selectorData": "contentBlockingBlockCookiesCheckbox",
+  "etp-level-standard": {
+    "selectorData": "etpLevelStandard",
     "strategy": "id",
     "groups": []
   },
-  "cookies-isolate-social-media-option": {
-    "selectorData": "isolateCookiesSocialMedia",
+  "etp-level-strict": {
+    "selectorData": "etpLevelStrict",
     "strategy": "id",
     "groups": []
   },
-  "tracking-in-all-windows": {
-    "selectorData": "menuitem[data-l10n-id='content-blocking-tracking-protection-option-all-windows']",
+  "etp-level-custom": {
+    "selectorData": "etpLevelCustom",
+    "strategy": "id",
+    "groups": []
+  },
+  "etp-customize-button": {
+    "selectorData": "etpCustomizeButton",
+    "strategy": "id",
+    "groups": []
+  },
+  "etp-custom-tracking-toggle": {
+    "selectorData": "etpCustomTrackingProtectionEnabled",
+    "strategy": "id",
+    "groups": []
+  },
+  "etp-custom-tracking-context": {
+    "selectorData": "etpCustomTrackingProtectionEnabledContext",
+    "strategy": "id",
+    "groups": []
+  },
+  "etp-custom-tracking-context-select": {
+    "selectorData": "select",
     "strategy": "css",
+    "shadowParent": "etp-custom-tracking-context",
     "groups": []
   },
-  "tracking-checkbox": {
-    "selectorData": "contentBlockingTrackingProtectionCheckbox",
+  "etp-custom-cookies-toggle": {
+    "selectorData": "etpCustomCookiesEnabled",
     "strategy": "id",
     "groups": []
   },
-  "cryptominers-checkbox": {
-    "selectorData": "contentBlockingCryptominersCheckbox",
+  "etp-custom-cookie-behavior": {
+    "selectorData": "cookieBehavior",
     "strategy": "id",
     "groups": []
   },
-  "known-fingerprints-checkbox": {
-    "selectorData": "contentBlockingFingerprintersCheckbox",
-    "strategy": "id",
-    "groups": []
-  },
-  "suspected-fingerprints-checkbox": {
-    "selectorData": "contentBlockingFingerprintingProtectionCheckbox",
-    "strategy": "id",
-    "groups": []
-  },
-  "suspected-fingerprints-in-all-windows": {
-    "selectorData": "#fingerprintingProtectionMenu menuitem[value='always']",
+  "etp-custom-cookie-behavior-select": {
+    "selectorData": "select",
     "strategy": "css",
+    "shadowParent": "etp-custom-cookie-behavior",
     "groups": []
   },
-  "suspected-fingerprints-only-in-private-windows": {
-    "selectorData": "#fingerprintingProtectionMenu menuitem[value='private']",
+  "etp-custom-cryptomining-toggle": {
+    "selectorData": "etpCustomCryptominingProtectionEnabled",
+    "strategy": "id",
+    "groups": []
+  },
+  "etp-custom-known-fingerprinting-toggle": {
+    "selectorData": "etpCustomKnownFingerprintingProtectionEnabled",
+    "strategy": "id",
+    "groups": []
+  },
+  "etp-custom-suspect-fingerprinting-toggle": {
+    "selectorData": "etpCustomSuspectFingerprintingProtectionEnabled",
+    "strategy": "id",
+    "groups": []
+  },
+  "etp-custom-suspect-fingerprinting-context": {
+    "selectorData": "etpCustomSuspectFingerprintingProtectionEnabledContext",
+    "strategy": "id",
+    "groups": []
+  },
+  "etp-custom-suspect-fingerprinting-context-select": {
+    "selectorData": "select",
     "strategy": "css",
+    "shadowParent": "etp-custom-suspect-fingerprinting-context",
     "groups": []
   },
   "cookies-shadow-root": {
@@ -798,16 +826,6 @@
     "selectorData": "button[label^='Remove']",
     "strategy": "css",
     "shadowParent": "remove-primary-password-box",
-    "groups": []
-  },
-  "standard-section": {
-    "selectorData": "contentBlockingOptionStandard",
-    "strategy": "id",
-    "groups": []
-  },
-  "standard-radio": {
-    "selectorData": "standardRadio",
-    "strategy": "id",
     "groups": []
   },
   "ai-controls-toggle-tile": {

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -340,29 +340,132 @@ class AboutPrefs(BasePage):
         )  # verify selection
         return self
 
-    def select_trackers_to_block(self, *options):
-        """Select the trackers to block in the about:preferences page. Unchecks all first."""
-        self.elements |= {
-            "checkbox-by-label": {
-                "selectorData": "checkbox[label='{}']",
-                "strategy": "css",
-                "groups": ["doNotCache"],
-            }
-        }
-        self.click_on("custom-radio")
-        checkboxes = self.get_element("custom-tracker-options-parent").find_elements(
-            By.TAG_NAME, "checkbox"
+    # ---- Enhanced Tracking Protection (Settings redesign, about:preferences#etp) -----------------
+
+    # Per-category toggles on the ETP Customize page (moz-toggle elements)
+    ETP_TOGGLE_OPTIONS = {
+        "tracking-checkbox": "etp-custom-tracking-toggle",
+        "cookies-checkbox": "etp-custom-cookies-toggle",
+        "cryptominers-checkbox": "etp-custom-cryptomining-toggle",
+        "known-fingerprints-checkbox": "etp-custom-known-fingerprinting-toggle",
+        "suspected-fingerprints-checkbox": "etp-custom-suspect-fingerprinting-toggle",
+    }
+    # Context dropdowns: option keyword -> (inner <select> element name, value)
+    ETP_CONTEXT_OPTIONS = {
+        "tracking-in-all-windows": ("etp-custom-tracking-context-select", "all"),
+        "suspected-fingerprints-in-all-windows": (
+            "etp-custom-suspect-fingerprinting-context-select",
+            "all",
+        ),
+        "suspected-fingerprints-only-in-private-windows": (
+            "etp-custom-suspect-fingerprinting-context-select",
+            "pbmOnly",
+        ),
+    }
+    # Cookie behavior dropdown: option keyword -> (inner <select> element name, value)
+    ETP_COOKIE_OPTIONS = {
+        "cookies-isolate-social-media-option": (
+            "etp-custom-cookie-behavior-select",
+            "5",
+        ),
+    }
+
+    ETP_LEVEL_RADIOS = {
+        "standard": "etp-level-standard",
+        "strict": "etp-level-strict",
+        "custom": "etp-level-custom",
+    }
+
+    def open_etp_settings(self) -> BasePage:
+        """
+        From about:preferences#privacy, open the ETP settings subpage
+        (about:preferences#etp) via the "Advanced" button.
+        """
+        self.click_on("etp-advanced-button")
+        self.element_visible("etp-level-custom")
+        return self
+
+    def set_etp_level(self, level: str) -> BasePage:
+        """
+        Select an Enhanced Tracking Protection level on about:preferences#etp.
+
+        level: one of "standard", "strict", "custom".
+        """
+        if level not in self.ETP_LEVEL_RADIOS:
+            raise ValueError(f"Unknown ETP level: {level!r}")
+        self.click_on(self.ETP_LEVEL_RADIOS[level])
+        return self
+
+    def select_etp_level(self, level: str) -> BasePage:
+        """
+        From about:preferences#privacy, open the ETP settings subpage and select
+        an Enhanced Tracking Protection level. level: standard|strict|custom.
+        """
+        self.open_etp_settings()
+        self.set_etp_level(level)
+        return self
+
+    def open_etp_customize(self) -> BasePage:
+        """
+        From the Custom ETP level on about:preferences#etp, open the Customize
+        subpage (about:preferences#etpCustomize) where the per-category controls live.
+        """
+        self.click_on("etp-customize-button")
+        self.element_visible("etp-custom-tracking-toggle")
+        return self
+
+    def _set_etp_toggle(self, element_name: str, enabled: bool) -> None:
+        """Set a moz-toggle on the ETP Customize page to the desired on/off state."""
+        toggle = self.get_element(element_name)
+        is_on = bool(
+            self.driver.execute_script("return !!arguments[0].pressed;", toggle)
         )
-        for checkbox in checkboxes:
-            if checkbox.is_selected():
-                checkbox.click()
+        if is_on != enabled:
+            self.driver.execute_script(
+                "arguments[0].shadowRoot.querySelector('button, input').click();",
+                toggle,
+            )
+            self.wait.until(
+                lambda _: bool(
+                    self.driver.execute_script("return !!arguments[0].pressed;", toggle)
+                )
+                == enabled
+            )
+
+    def select_trackers_to_block(self, *options):
+        """
+        Configure Custom ETP blocking on about:preferences (Settings redesign).
+
+        Navigates Privacy -> Advanced -> Custom -> Customize, turns every category
+        toggle off, then enables only the requested options. The option keywords are
+        kept stable across the old/new UI:
+          toggles:  tracking-checkbox, cookies-checkbox, cryptominers-checkbox,
+                    known-fingerprints-checkbox, suspected-fingerprints-checkbox
+          contexts: tracking-in-all-windows, suspected-fingerprints-in-all-windows,
+                    suspected-fingerprints-only-in-private-windows
+          cookies:  cookies-isolate-social-media-option
+        """
+        self.select_etp_level("custom")
+        self.open_etp_customize()
+
+        # Reset: turn every category toggle off before enabling the requested ones.
+        for element_name in self.ETP_TOGGLE_OPTIONS.values():
+            self._set_etp_toggle(element_name, False)
+
         for option in options:
-            self.click_on(option)
-            tag = self.get_element(option).tag_name
-            if tag == "checkbox":
-                self.element_has_attribute(option, "checked")
-            elif tag == "menuitem":
-                self.element_attribute_is(option, "selected", "true")
+            if option in self.ETP_TOGGLE_OPTIONS:
+                self._set_etp_toggle(self.ETP_TOGGLE_OPTIONS[option], True)
+            elif option in self.ETP_CONTEXT_OPTIONS:
+                element_name, value = self.ETP_CONTEXT_OPTIONS[option]
+                Select(self.get_element(element_name)).select_by_value(value)
+            elif option in self.ETP_COOKIE_OPTIONS:
+                element_name, value = self.ETP_COOKIE_OPTIONS[option]
+                # The cookie-behavior dropdown is disabled until cookie blocking
+                # is enabled, so turn the toggle on before setting the value.
+                self._set_etp_toggle("etp-custom-cookies-toggle", True)
+                Select(self.get_element(element_name)).select_by_value(value)
+            else:
+                raise ValueError(f"Unknown tracker option: {option!r}")
 
         sleep(0.25)
         return self

--- a/tests/security_and_privacy/test_etp_panel_displayed_when_no_trackers_detected.py
+++ b/tests/security_and_privacy/test_etp_panel_displayed_when_no_trackers_detected.py
@@ -24,7 +24,7 @@ def test_etp_panel_displayed_when_no_trackers_detected(driver: Firefox):
 
     # Make sure that the "Standard" option is selected from the ETP section in about:preferences#privacy
     about_prefs.open()
-    about_prefs.click_on("standard-radio")
+    about_prefs.select_etp_level("standard")
 
     # Click on the shield icon
     test_page.open()

--- a/tests/security_and_privacy/test_etp_panel_displayed_when_protection_off.py
+++ b/tests/security_and_privacy/test_etp_panel_displayed_when_protection_off.py
@@ -24,7 +24,7 @@ def test_etp_panel_displayed_when_protection_off(driver: Firefox):
 
     # Make sure that the "Standard" option is selected from the ETP section in about:preferences#privacy
     about_prefs.open()
-    about_prefs.click_on("standard-radio")
+    about_prefs.select_etp_level("standard")
 
     # Click on the shield icon and turn off the Enhanced Tracking Protection
     test_page.open()

--- a/tests/security_and_privacy/test_fingerprinters_blocked_and_shown_in_panel_and_preferences.py
+++ b/tests/security_and_privacy/test_fingerprinters_blocked_and_shown_in_panel_and_preferences.py
@@ -35,9 +35,10 @@ def test_fingerprinters_blocked_and_shown_in_panel_and_preferences(driver: Firef
     # Navigate to about:preferences#privacy
     about_prefs.open()
 
-    # Check Standard section
-    about_prefs.click_on("standard-radio")
-
-    # Check Standard section contains "Fingerprinters"
-    standard_section = about_prefs.get_element("standard-section")
-    assert "Fingerprinters" in standard_section.text
+    # The ETP Customize settings expose a Fingerprinters protection control
+    about_prefs.select_etp_level("custom")
+    about_prefs.open_etp_customize()
+    fingerprinters_control = about_prefs.get_element(
+        "etp-custom-known-fingerprinting-toggle"
+    )
+    assert "fingerprinters" in fingerprinters_control.get_attribute("label").lower()

--- a/tests/security_and_privacy/test_social_media_trackers_displayed_subpanel.py
+++ b/tests/security_and_privacy/test_social_media_trackers_displayed_subpanel.py
@@ -19,6 +19,11 @@ def test_case():
     return "3054913"
 
 
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("privacy.trackingprotection.socialtracking.enabled", True)]
+
+
 def test_social_media_trackers_displayed_subpanel(driver: Firefox):
     """
     C3054913 - Social media trackers are correctly displayed in the sub panel

--- a/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
+++ b/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
@@ -25,7 +25,7 @@ def test_trackers_cryptominers_fingerprinters_blocked(
 
     # Make sure that the "Standard" option is selected from the ETP section in about:preferences#privacy
     about_prefs.open()
-    about_prefs.click_on("standard-radio")
+    about_prefs.select_etp_level("standard")
 
     # wait for the shield icon
     tracker_page.open()

--- a/tests/security_and_privacy/test_tracking_elements_not_blocked_with_etp_disabled.py
+++ b/tests/security_and_privacy/test_tracking_elements_not_blocked_with_etp_disabled.py
@@ -23,7 +23,7 @@ def test_tracking_elements_not_blocked_with_etp_disabled(
 
     # Make sure that the "Standard" option is selected from the ETP section in about:preferences#privacy
     about_prefs.open()
-    about_prefs.click_on("standard-radio")
+    about_prefs.select_etp_level("standard")
 
     # open the trackers page
     tracker_website = GenericPage(driver, url=TRACKER_URL)


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2043366

#### Description of Code / Doc Changes
Firefox 153's Settings redesign moved Enhanced Tracking Protection to a dedicated about:preferences#etp / #etpCustomize flow, replacing the old single-pane XUL radios/checkboxes (customRadio, standardRadio, contentBlocking*Checkbox) which no longer exist.

- Rewrite AboutPrefs.select_trackers_to_block and add ETP navigation helpers (open_etp_settings, set_etp_level, select_etp_level, open_etp_customize, _set_etp_toggle) to drive the new moz-radio-group / moz-toggle / moz-select controls on the #etp and #etpCustomize subpages.
- Add new etp-* manifest selectors; remove the 13 deprecated ETP selectors.
- Migrate test call sites: standard-radio -> select_etp_level("standard").
- Social-media-trackers tests set privacy.trackingprotection.socialtracking.enabled (the new Custom UI has no social-trackers control).
- Adapt the fingerprinters preferences-side assertion to the Customize page (the Standard option no longer enumerates categories).
- key.yaml: mark the 17 fixed tests result: pass and drop the bug comments.
- Document the new selectors in SELECTOR_INFO.md.

#### Process Changes Required
- [X] Changes or creates a BOM/POM (name the object model):

#### Workflow Checklist
- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.

Thank you!