### PR TITLE
Hani/ remove unstable from test_new_tab_label

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -661,8 +661,7 @@ menus:
     splits:
     - functional1
   test_new_tab_label:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047899
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_tab_context_menu_actions:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047899](https://bugzilla.mozilla.org/show_bug.cgi?id=2047899)

### Description of Code / Doc Changes

* Remove unstable from tests/menus/test_new_tab_label.py since the test passed locally

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
