### PR TITLE
Anca/ Improve test_search_term_persists test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -190,8 +190,7 @@ address_bar_and_search:
     splits:
     - functional1
   test_search_term_persists:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047893
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_search_works_correctly_with_ddg_telemetry:

--- a/tests/address_bar_and_search/test_search_term_persists.py
+++ b/tests/address_bar_and_search/test_search_term_persists.py
@@ -37,13 +37,13 @@ def test_search_term_persists(driver: Firefox):
 
     nav.search(FIRST_SEARCH)
     tab.expect_title_contains(SEARCH_ENGINE)
-    address_bar_text = nav.get_awesome_bar_text()
-    assert FIRST_SEARCH == address_bar_text
+    # The "show search terms" feature swaps the SERP URL in the urlbar for the
+    # search term asynchronously, so wait for that value rather than reading once.
+    nav.element_attribute_is("awesome-bar", "value", FIRST_SEARCH)
 
     nav.set_content_context()
     driver.get("about:robots")
 
     nav.search(SECOND_SEARCH)
     tab.expect_title_contains(SEARCH_ENGINE)
-    address_bar_text = nav.get_awesome_bar_text()
-    assert SECOND_SEARCH == address_bar_text
+    nav.element_attribute_is("awesome-bar", "value", SECOND_SEARCH)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047893](https://bugzilla.mozilla.org/show_bug.cgi?id=2047893)
TestRail: N/A

### Description of Code / Doc Changes
- test_search_term_persists passed locally on all 50 of 50 runs. Despite that, I went ahead and improved it, the urlbar assertion now waits for the search-term value instead of reading it once, removing a small remaining flakiness risk.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
