### PR TITLE
Fix new addy bar and search failures

### DIFF
--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -1141,8 +1141,8 @@ Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: cookies-privacy-label
-Selector Data: "[data-l10n-id='sitedata-delete-on-close-private-browsing3']"
-Description: Message in Cookies and Site data when History is not remembered
+Selector Data: "deleteOnCloseInfo"
+Description: moz-message-bar shown in Cookies and Site Data when history is not remembered (Settings redesign: l10n id is now sitedata-delete-on-close-private-browsing4; read its `message` attribute)
 Location: about:preferences#privacy
 Path to .json: modules/data/about_prefs.components.json
 ```
@@ -1156,21 +1156,21 @@ Path to .json: modules/data/about_prefs.components.json
 ```
 Selector Name: logins-ask-to-save-password
 Selector Data: "savePasswords"
-Description: Check box for Ask to save passwords
-Location: about:preferences#privacy Passwords subsection
+Description: Check box for Ask to save passwords (Settings redesign: moved from #privacy to the #passwordsAutofill pane; same id)
+Location: about:preferences#passwordsAutofill Passwords subsection
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: logins-exceptions
 Selector Data: "managePasswordExceptions"
-Description: Manage Exceptions… button
-Location: about:preferences#privacy Passwords subsection
+Description: Manage Exceptions… button (Settings redesign: moved from #privacy to the #passwordsAutofill pane; same id)
+Location: about:preferences#passwordsAutofill Passwords subsection
 Path to .json: modules/data/about_prefs.components.json
 ```
 ```
 Selector Name: history-privacy-label
-Selector Data: "description[data-l10n-id='history-dontremember-description']"
-Description: Message History is not remembered
+Selector Data: "moz-radio[data-l10n-id='history-remember-option-never2']"
+Description: The "Never Remember History" moz-radio option; checked (checked='true') and its `description` reflects permanent private browsing when history is not remembered (Settings redesign: History section is now a moz-radio-group)
 Location: about:preferences#privacy History subsection
 Path to .json: modules/data/about_prefs.components.json
 ```

--- a/SELECTOR_INFO.md
+++ b/SELECTOR_INFO.md
@@ -4105,16 +4105,37 @@ Path to .json: modules/data/navigation.components.json
 ```
 ```
 Selector Name: searchmode-switcher-settings
-Selector Data: menuitem[data-l10n-id='urlbar-searchmode-popup-search-settings-menuitem']
-Description: Search settings button in the searchmode switcher dropdown
+Selector Data: panel-item[data-l10n-id='urlbar-searchmode-popup-search-settings-panelitem']
+Description: Search settings button in the searchmode switcher dropdown (Fx redesign: dropdown is now a panel-list of panel-items)
 Location: Address bar
 Path to .json: modules/data/navigation.components.json
 ```
 ```
 Selector Name: search-mode-switcher-option
-Selector Data: menuitem[label*='{title}']
-Description: Option by label in search mode list
-Location: Search mode of awesomebar
+Selector Data: panel-item.searchmode-switcher-installed[label*='{title}']
+Description: Installed search engine option by label in the search mode switcher list (Fx redesign: was a menuitem in a menupopup, now a panel-item in a panel-list)
+Location: Search mode switcher dropdown of awesomebar
+Path to .json: modules/data/navigation.components.json
+```
+```
+Selector Name: search-mode-local-option
+Selector Data: panel-item.searchmode-switcher-local.search-button-{function}
+Description: Local search mode option (bookmarks/tabs/history/actions) in the search mode switcher list, by {function}
+Location: Search mode switcher dropdown of awesomebar
+Path to .json: modules/data/navigation.components.json
+```
+```
+Selector Name: search-mode-add-option
+Selector Data: panel-item.searchmode-switcher-addEngine[data-engine-name*='{title}']
+Description: "Add <engine>" open-search option in the search mode switcher list; matched on data-engine-name since the add-engine item has no label attribute
+Location: Search mode switcher dropdown of awesomebar
+Path to .json: modules/data/navigation.components.json
+```
+```
+Selector Name: search-mode-switcher-prefs
+Selector Data: panel-item.searchmode-switcher-panel-search-settings-button
+Description: Search Settings button at the bottom of the search mode switcher dropdown
+Location: Search mode switcher dropdown of awesomebar
 Path to .json: modules/data/navigation.components.json
 ```
 ```
@@ -4203,8 +4224,8 @@ Path to .json: modules/data/navigation.components.json
 ```
 ```
 Selector Name: search-mode-chicklet
-Selector Data: label.searchmode-switcher-title
-Description: Search mode chicklet
+Selector Data: span.searchmode-switcher-title
+Description: Search mode chicklet (Fx redesign: title is now a span inside the moz-button switcher, was a label)
 Location: Address bar search mode
 Path to .json: modules/data/navigation.components.json
 ```
@@ -4217,8 +4238,8 @@ Path to .json: modules/data/navigation.components.json
 ```
 ```
 Selector Name: exit-button-searchmode
-Selector Data: toolbarbutton[data-l10n-id='urlbar-searchmode-exit-button']
-Description: Exit button searchmode
+Selector Data: button.searchmode-switcher-close
+Description: Exit button searchmode (Fx redesign: close button now lives inside the moz-button switcher, was a toolbarbutton[data-action='exitsearchmode'])
 Location: Address bar searchmode
 Path to .json: modules/data/navigation.components.json
 ```

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -8,13 +8,11 @@ address_bar_and_search:
     splits:
     - functional1
   test_add_engine_address_bar:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049511
-    result: unstable
+    result: pass
     splits:
     - smoke
   test_added_open_search_engine_default:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_addon_suggestion:
@@ -31,8 +29,7 @@ address_bar_and_search:
     splits:
     - functional1
   test_bing_search_codes:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_clipboard_pref_flip:
@@ -52,13 +49,11 @@ address_bar_and_search:
     splits:
     - functional1
   test_ddg_search_codes:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_default_search_provider_change_awesome_bar:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_default_search_provider_change_legacy_search_bar:
@@ -71,8 +66,7 @@ address_bar_and_search:
     splits:
     - functional1
   test_disable_websearch_from_awesome_bar:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_dont_show_search_suggestions_in_private_window:
@@ -88,8 +82,7 @@ address_bar_and_search:
     splits:
     - functional1
   test_insertion_point_no_search_terms_display:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_no_suggestions_for_empty_query:
@@ -139,18 +132,15 @@ address_bar_and_search:
     splits:
     - functional1
   test_search_engine_selector:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049601
-    result: unstable
+    result: pass
     splits:
     - smoke
   test_search_mode_appears_after_input:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_search_mode_change_tab:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_search_mode_cleared_on_engine_removal:
@@ -159,13 +149,11 @@ address_bar_and_search:
     splits:
     - functional1
   test_search_mode_exits_correctly:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_search_mode_persists_mixed_with_bing:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_search_mode_update_on_alias_prefix:
@@ -195,8 +183,7 @@ address_bar_and_search:
     splits:
     - functional1
   test_search_works_correctly_with_ddg_telemetry:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_server_not_found_error:
@@ -223,13 +210,11 @@ address_bar_and_search:
     splits:
     - functional1
   test_use_different_search_shortcut_while_already_in_search_mode:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_verify_url_after_tab_switch_with_search_mode:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605
-    result: unstable
+    result: pass
     splits:
     - functional1
 ai_controls:

--- a/modules/browser_object_tabbar.py
+++ b/modules/browser_object_tabbar.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
 
-from modules.browser_object import ContextMenu
+from modules.browser_object_context_menu import ContextMenu
 from modules.page_base import BasePage
 
 

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -480,13 +480,13 @@
     "groups": []
   },
   "cookies-privacy-label": {
-    "selectorData": "moz-message-bar[data-l10n-id='sitedata-delete-on-close-private-browsing3']",
-    "strategy": "css",
+    "selectorData": "deleteOnCloseInfo",
+    "strategy": "id",
     "groups": []
   },
   "history-privacy-label": {
-    "selectorData": "historyMode",
-    "strategy": "id",
+    "selectorData": "moz-radio[data-l10n-id='history-remember-option-never2']",
+    "strategy": "css",
     "groups": []
   },
   "cookies-delete-on-close": {

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -138,29 +138,29 @@
         ]
     },
     "search-mode-switcher-option": {
-        "selectorData": ".searchmode-switcher-popup menuitem.searchmode-switcher-installed[label*='{title}']",
+        "selectorData": "panel-item.searchmode-switcher-installed[label*='{title}']",
         "strategy": "css",
         "groups": [
             "doNotCache"
         ]
     },
     "search-mode-local-option": {
-        "selectorData": ".searchmode-switcher-popup menuitem[id='search-button-{function}']",
+        "selectorData": "panel-item.searchmode-switcher-local.search-button-{function}",
         "strategy": "css",
         "groups": [
             "doNotCache"
         ]
     },
     "search-mode-add-option": {
-        "selectorData": ".searchmode-switcher-popup menuitem.searchmode-switcher-addEngine[label*='{title}']",
+        "selectorData": "panel-item.searchmode-switcher-addEngine[data-engine-name*='{title}']",
         "strategy": "css",
         "groups": [
             "doNotCache"
         ]
     },
     "search-mode-switcher-prefs": {
-        "selectorData": "searchmode-switcher-popup-search-settings-button",
-        "strategy": "class",
+        "selectorData": "panel-item.searchmode-switcher-panel-search-settings-button",
+        "strategy": "css",
         "groups": [
             "doNotCache"
         ]
@@ -579,7 +579,7 @@
         "groups": []
     },
     "searchmode-switcher-settings": {
-        "selectorData": "menuitem[data-l10n-id='urlbar-searchmode-popup-search-settings-menuitem']",
+        "selectorData": "panel-item[data-l10n-id='urlbar-searchmode-popup-search-settings-panelitem']",
         "strategy": "css",
         "groups": []
     },
@@ -648,7 +648,7 @@
         ]
     },
     "search-mode-chicklet": {
-        "selectorData": "label.searchmode-switcher-title",
+        "selectorData": "span.searchmode-switcher-title",
         "strategy": "css",
         "groups": []
     },
@@ -658,7 +658,7 @@
         "groups": []
     },
     "exit-button-searchmode": {
-        "selectorData": "toolbarbutton[data-action='exitsearchmode']",
+        "selectorData": "button.searchmode-switcher-close",
         "strategy": "css",
         "groups": []
     },

--- a/tests/address_bar_and_search/test_disable_websearch_from_awesome_bar.py
+++ b/tests/address_bar_and_search/test_disable_websearch_from_awesome_bar.py
@@ -1,5 +1,4 @@
 import pytest
-from selenium.webdriver.support.wait import WebDriverWait
 
 from modules.browser_object import Navigation
 from modules.browser_object_tabbar import TabBar

--- a/tests/address_bar_and_search/test_no_suggestions_for_empty_query.py
+++ b/tests/address_bar_and_search/test_no_suggestions_for_empty_query.py
@@ -2,7 +2,6 @@ import sys
 
 import pytest
 from selenium.webdriver import Firefox
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
 from modules.browser_object import Navigation

--- a/tests/address_bar_and_search/test_use_different_search_shortcut_while_already_in_search_mode.py
+++ b/tests/address_bar_and_search/test_use_different_search_shortcut_while_already_in_search_mode.py
@@ -45,5 +45,8 @@ def test_use_search_shortcut_for_a_different_search_engine_while_already_in_sear
     # Verify the domain is explicitly wikipedia.org
     nav.verify_domain(URL_DOMAIN)
 
-    # Verify search term is also present in the URL
-    nav.url_contains(SEARCH_TERM.lstrip("@"))
+    # Verify search term is also present in the URL. Wikipedia's "go" feature may land on
+    # the matching article (e.g. /wiki/Amazon_(company)) where the term is capitalized, so
+    # compare case-insensitively.
+    term = SEARCH_TERM.lstrip("@").lower()
+    nav.expect_in_content(lambda d: term in d.current_url.lower())

--- a/tests/security_and_privacy/test_never_remember_browsing_history.py
+++ b/tests/security_and_privacy/test_never_remember_browsing_history.py
@@ -21,12 +21,10 @@ links = [
 ]
 
 COOKIE_LABEL_TEXT = (
-    "Firefox clears cookies and site data from your session "
-    "when you close the browser."
+    "Firefox clears cookies and site data from your session when you close the browser."
 )
 HISTORY_LABEL_TEXT = (
-    "Every window acts like a private window. "
-    "When on, extensions need to be allowed."
+    "Every window acts like a private window. When on, extensions need to be allowed."
 )
 
 

--- a/tests/security_and_privacy/test_never_remember_browsing_history.py
+++ b/tests/security_and_privacy/test_never_remember_browsing_history.py
@@ -21,12 +21,12 @@ links = [
 ]
 
 COOKIE_LABEL_TEXT = (
-    "Based on your history settings, Firefox deletes cookies "
-    "and site data from your session when you close the browser."
+    "Firefox clears cookies and site data from your session "
+    "when you close the browser."
 )
 HISTORY_LABEL_TEXT = (
-    "Firefox will use the same settings as private browsing, "
-    "and will not remember any history as you browse the Web."
+    "Every window acts like a private window. "
+    "When on, extensions need to be allowed."
 )
 
 
@@ -53,14 +53,18 @@ def test_never_remember_browsing_history_settings(
     delete_cookies_checkbox = about_prefs_privacy.get_element("cookies-delete-on-close")
     assert delete_cookies_checkbox.get_attribute("checked") == "true"
 
-    save_password = about_prefs_privacy.get_element("logins-ask-to-save-password")
+    # History is now a moz-radio-group; "Never Remember History" should be the
+    # selected option, and its description matches the private-browsing text.
+    history_never_remember = about_prefs_privacy.get_element("history-privacy-label")
+    assert history_never_remember.get_attribute("checked") == "true"
+    assert history_never_remember.get_attribute("description") == HISTORY_LABEL_TEXT
+
+    # The Settings redesign moved the "Ask to save passwords" control out of the
+    # privacy pane into the Passwords and autofill pane. It should be unchecked.
+    about_prefs_passwords = AboutPrefs(driver, category="passwordsAutofill")
+    about_prefs_passwords.open()
+    save_password = about_prefs_passwords.get_element("logins-ask-to-save-password")
     assert save_password.get_attribute("checked") is None
-
-    login_exceptions = about_prefs_privacy.get_element("logins-exceptions")
-    assert login_exceptions.get_attribute("disabled") == "true"
-
-    history_mode_description = about_prefs_privacy.get_element("history-privacy-label")
-    assert history_mode_description.get_attribute("description") == HISTORY_LABEL_TEXT
 
 
 def test_never_remember_browsing_history_from_panel(


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2049605

#### Description of Code / Doc Changes
  Root cause: Firefox 153+ rebuilt the address-bar search-mode switcher from XUL <menupopup>/<menuitem> into a               
  <panel-list>/<panel-item> structure, breaking the search-mode selectors. A separate circular import broke collection of the two *_search_codes tests.
                                                                                                                  
  - modules/data/navigation.components.json — 7 selectors updated to the new panel-item DOM (option, local-option,           
  add-option, switcher-prefs, switcher-settings, exit button, chicklet).                                                     
  - modules/browser_object_tabbar.py — fixed circular import (ContextMenu now from its own submodule).                       
  - test_use_different_search_shortcut_while_already_in_search_mode.py — case-insensitive final URL check (Wikipedia "go"  routing).                                                                                                                  
  - SELECTOR_INFO.md — documented all selector changes + added 3 previously-undocumented entries.                            
  - manifests/key.yaml — flipped all 15 fixed tests to pass and removed their Bugzilla comments.

additional failing test fix:
  tests/security_and_privacy/test_never_remember_browsing_history.py:                                                        
  - COOKIE_LABEL_TEXT → "Firefox clears cookies and site data from your session when you close the browser."                 
  - HISTORY_LABEL_TEXT → "Every window acts like a private window. When on, extensions need to be allowed."                  
  - History assertion now verifies the "Never Remember" radio is checked and its description matches                         
  - Per your call: navigate to the #passwordsAutofill pane to assert savePasswords is unchecked; dropped the                 
  managePasswordExceptions disabled assertion (no longer disabled under permanent private browsing in the new UI)            
                                                                                                                             
  SELECTOR_INFO.md: updated the 4 affected entries (cookies label, history label, and the two password controls' new pane    
  location).

#### Process Changes Required
- [X] Changes or creates a BOM/POM (name the object model): _

#### Workflow Checklist
- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.

Thank you!
