### PR TITLE
PR to set Deprecated to all tests that could only run on <152 version…

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1085,10 +1085,7 @@ preferences:
     splits:
     - functional2
   test_clear_cookie_data:
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: deprecated
     splits:
     - smoke
   test_firefox_home_new_tabs:
@@ -1105,7 +1102,7 @@ preferences:
     splits:
     - functional2
   test_manage_cookie_data:
-    result: pass
+    result: deprecated
     splits:
     - smoke
   test_never_remember_history:
@@ -1114,7 +1111,7 @@ preferences:
     - smoke
   test_notifications_change_set:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047906
-    result: unstable
+    result: deprecated
     splits:
     - functional2
 printing_ui:

--- a/tests/preferences/test_notifications_change_set.py
+++ b/tests/preferences/test_notifications_change_set.py
@@ -28,7 +28,7 @@ def test_url(driver):
 
 
 @pytest.mark.parametrize("button_data, button_text, permission", associated_labels)
-def test_notifications_allow(
+def test_notifications_change_set(
     driver: Firefox,
     button_data: str,
     button_text: str,


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047906](https://bugzilla.mozilla.org/show_bug.cgi?id=2047906)
TestRail: N/A

### Description of Code / Doc Changes

Marked tests as deprecated since they should only run in <152 versions according to new Firefox changes. 
Changed one test name to correspond with the file name.

Thank you!
