### PR TITLE
Hani/ Fix test installed theme enabled

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -622,8 +622,7 @@ glean:
       - glean
 language_packs:
   test_language_pack_install_addons:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047894
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_language_pack_install_preferences:
@@ -1752,7 +1751,6 @@ theme_and_toolbar:
     - smoke
     - ci
   test_installed_theme_enabled:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047901
-    result: unstable
+    result: pass
     splits:
     - functional2

--- a/modules/data/amo_themes.components.json
+++ b/modules/data/amo_themes.components.json
@@ -13,35 +13,5 @@
         "selectorData": "AMInstallButton-button",
         "strategy": "class",
         "groups": []
-    },
-    "addon-install-add-button-parent": {
-        "selectorData": "addon-install-confirmation-notification",
-        "strategy": "id",
-        "groups": [
-            "doNotCache"
-        ]
-    },
-    "addon-install-add-button-field": {
-        "selectorData": "main-button",
-        "strategy": "id",
-        "shadowParent": "addon-install-add-button-parent",
-        "groups": [
-            "doNotCache"
-        ]
-    },
-    "addon-install-ok-button-parent": {
-        "selectorData": "moz-button.popup-notification-primary-button[label='OK']",
-        "strategy": "css",
-        "groups": [
-            "doNotCache"
-        ]
-    },
-    "addon-install-ok-button-field": {
-        "selectorData": "main-button",
-        "strategy": "id",
-        "shadowParent": "addon-install-ok-button-parent",
-        "groups": [
-            "doNotCache"
-        ]
     }
 }

--- a/modules/data/amo_themes.components.json
+++ b/modules/data/amo_themes.components.json
@@ -13,5 +13,35 @@
         "selectorData": "AMInstallButton-button",
         "strategy": "class",
         "groups": []
+    },
+    "addon-install-add-button-parent": {
+        "selectorData": "addon-install-confirmation-notification",
+        "strategy": "id",
+        "groups": [
+            "doNotCache"
+        ]
+    },
+    "addon-install-add-button-field": {
+        "selectorData": "main-button",
+        "strategy": "id",
+        "shadowParent": "addon-install-add-button-parent",
+        "groups": [
+            "doNotCache"
+        ]
+    },
+    "addon-install-ok-button-parent": {
+        "selectorData": "moz-button.popup-notification-primary-button[label='OK']",
+        "strategy": "css",
+        "groups": [
+            "doNotCache"
+        ]
+    },
+    "addon-install-ok-button-field": {
+        "selectorData": "main-button",
+        "strategy": "id",
+        "shadowParent": "addon-install-ok-button-parent",
+        "groups": [
+            "doNotCache"
+        ]
     }
 }

--- a/modules/page_object_addons_mozilla_org.py
+++ b/modules/page_object_addons_mozilla_org.py
@@ -20,11 +20,30 @@ class AmoThemes(BasePage):
         self.theme_title = self.get_element("theme-title").get_attribute("innerText")
         self.get_element("install-button").click()
         # TODO: Add toolbar browser object
-        with self.driver.context(self.driver.CONTEXT_CHROME):
-            self.driver.find_element(By.CSS_SELECTOR, "button[label='Add']").click()
-            self.driver.find_element(By.CSS_SELECTOR, "button[label='OK']").click()
-        return self
+        # with self.driver.context(self.driver.CONTEXT_CHROME):
+        #     self.driver.find_element(By.CSS_SELECTOR, "button[label='Add']").click()
+        #     self.driver.find_element(By.CSS_SELECTOR, "button[label='OK']").click()
+        # return self
 
+    @BasePage.context_chrome
+    def confirm_language_install_popup(self):
+        """Confirms the language install popup by clicking Add then OK"""
+        # Wait for the Add button to appear
+        self.custom_wait(timeout=10).until(
+            lambda _: self.get_element("addon-install-add-button-parent") is not None
+        )
+
+        # Click "Add" button
+        self.js_click_on("addon-install-add-button-field")
+
+        # Wait for the OK button to appear
+        self.custom_wait(timeout=10).until(
+            lambda _: self.get_element("addon-install-ok-button-parent") is not None
+        )
+
+        # Click "OK" button
+        self.js_click_on("addon-install-ok-button-field")
+        return self
 
 class AmoLanguages(BasePage):
     """

--- a/modules/page_object_addons_mozilla_org.py
+++ b/modules/page_object_addons_mozilla_org.py
@@ -1,11 +1,38 @@
-from selenium.webdriver.common.by import By
-
 from modules.page_base import BasePage
 
 # PLEASE add all AMO page models to this file
 
 
-class AmoThemes(BasePage):
+class AmoBase(BasePage):
+    """
+    Shared base class for AMO page models
+    """
+
+    @BasePage.context_chrome
+    def confirm_addon_install_popup(self):
+        """Confirms the addon install popup by clicking Add then OK"""
+        # Wait for the Add button and click it via JavaScript
+        self.custom_wait(timeout=10).until(
+            lambda d: d.execute_script(
+                "return document.querySelector(\"moz-button[label='Add'].popup-notification-primary-button\")"
+            )
+        )
+        self.driver.execute_script(
+            "document.querySelector(\"moz-button[label='Add'].popup-notification-primary-button\").shadowRoot.querySelector('button#main-button').click()"
+        )
+
+        # Wait for the OK button and click it via JavaScript
+        self.custom_wait(timeout=10).until(
+            lambda d: d.execute_script(
+                "return document.querySelector(\"moz-button[data-l10n-id='popup-notification-default-button2']\")"
+            )
+        )
+        self.driver.execute_script(
+            "document.querySelector(\"moz-button[data-l10n-id='popup-notification-default-button2']\").shadowRoot.querySelector('button#main-button').click()"
+        )
+        return self
+
+class AmoThemes(AmoBase):
     """
     POM for AMO Themes
     """
@@ -19,33 +46,8 @@ class AmoThemes(BasePage):
         self.get_element("recommended-addon").click()
         self.theme_title = self.get_element("theme-title").get_attribute("innerText")
         self.get_element("install-button").click()
-        # TODO: Add toolbar browser object
-        # with self.driver.context(self.driver.CONTEXT_CHROME):
-        #     self.driver.find_element(By.CSS_SELECTOR, "button[label='Add']").click()
-        #     self.driver.find_element(By.CSS_SELECTOR, "button[label='OK']").click()
-        # return self
 
-    @BasePage.context_chrome
-    def confirm_language_install_popup(self):
-        """Confirms the language install popup by clicking Add then OK"""
-        # Wait for the Add button to appear
-        self.custom_wait(timeout=10).until(
-            lambda _: self.get_element("addon-install-add-button-parent") is not None
-        )
-
-        # Click "Add" button
-        self.js_click_on("addon-install-add-button-field")
-
-        # Wait for the OK button to appear
-        self.custom_wait(timeout=10).until(
-            lambda _: self.get_element("addon-install-ok-button-parent") is not None
-        )
-
-        # Click "OK" button
-        self.js_click_on("addon-install-ok-button-field")
-        return self
-
-class AmoLanguages(BasePage):
+class AmoLanguages(AmoBase):
     """
     POM for AMO Languages
     """
@@ -74,19 +76,4 @@ class AmoLanguages(BasePage):
         self.custom_wait(timeout=20).until(
             lambda _: self.get_element("language-addons-subpage-header") is not None
         )
-        return self
-
-    @BasePage.context_chrome
-    def confirm_language_install_popup(self):
-        """Confirms the language install popup by clicking Add then OK"""
-        # Click "Add" button
-        self.js_click_on("addon-install-add-button-field")
-
-        # Wait for the OK button to appear
-        self.custom_wait(timeout=10).until(
-            lambda _: self.get_element("addon-install-ok-button-parent") is not None
-        )
-
-        # Click "OK" button
-        self.js_click_on("addon-install-ok-button-field")
         return self

--- a/modules/page_object_addons_mozilla_org.py
+++ b/modules/page_object_addons_mozilla_org.py
@@ -32,6 +32,7 @@ class AmoBase(BasePage):
         )
         return self
 
+
 class AmoThemes(AmoBase):
     """
     POM for AMO Themes
@@ -46,6 +47,7 @@ class AmoThemes(AmoBase):
         self.get_element("recommended-addon").click()
         self.theme_title = self.get_element("theme-title").get_attribute("innerText")
         self.get_element("install-button").click()
+
 
 class AmoLanguages(AmoBase):
     """

--- a/modules/page_object_addons_mozilla_org.py
+++ b/modules/page_object_addons_mozilla_org.py
@@ -47,6 +47,7 @@ class AmoThemes(AmoBase):
         self.get_element("recommended-addon").click()
         self.theme_title = self.get_element("theme-title").get_attribute("innerText")
         self.get_element("install-button").click()
+        return self
 
 
 class AmoLanguages(AmoBase):

--- a/tests/language_packs/test_language_pack_install_addons.py
+++ b/tests/language_packs/test_language_pack_install_addons.py
@@ -42,7 +42,7 @@ def test_language_pack_install_from_addons(
     amo_languages.find_language_row_and_navigate(language_label)
     amo_languages.click_on("language-addons-subpage-add-to-firefox")
 
-    amo_languages.confirm_language_install_popup()
+    amo_languages.confirm_addon_install_popup()
 
     # Ensure that the about:addons has the language listed
     about_addons.open()

--- a/tests/theme_and_toolbar/test_installed_theme_enabled.py
+++ b/tests/theme_and_toolbar/test_installed_theme_enabled.py
@@ -44,7 +44,9 @@ def test_installed_theme_enabled(driver: Firefox) -> None:
     )
 
     # Go to AMO and install a recommended theme (POM encapsulates waits and flows)
-    AmoThemes(driver).open().install_recommended_theme()
+    amo_themes = AmoThemes(driver).open()
+    amo_themes.install_recommended_theme()
+    amo_themes.confirm_language_install_popup()
 
     # Return to about:addons > Themes and verify the enabled theme changed
     about_addons = AboutAddons(driver).open()

--- a/tests/theme_and_toolbar/test_installed_theme_enabled.py
+++ b/tests/theme_and_toolbar/test_installed_theme_enabled.py
@@ -46,7 +46,7 @@ def test_installed_theme_enabled(driver: Firefox) -> None:
     # Go to AMO and install a recommended theme (POM encapsulates waits and flows)
     amo_themes = AmoThemes(driver).open()
     amo_themes.install_recommended_theme()
-    amo_themes.confirm_language_install_popup()
+    amo_themes.confirm_addon_install_popup()
 
     # Return to about:addons > Themes and verify the enabled theme changed
     about_addons = AboutAddons(driver).open()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047901](https://bugzilla.mozilla.org/show_bug.cgi?id=2047901)

### Description of Code / Doc Changes

* Fixed tests/theme_and_toolbar/test_installed_theme_enabled.py
* Fixed tests/language_packs/test_language_pack_install_addons.py
* Changes made in [PR 1424](https://github.com/mozilla/fx-desktop-qa-automation/pull/1424) for tests/language_packs/test_language_pack_install_addons.py are no longer working as expected. I have not removed the add/OK button locators yet, in case another solution is found that still relies on them.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `pipenv install`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
