### PR TITLE
Anca/ Fix open link in private window test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1363,11 +1363,7 @@ security_and_privacy:
     splits:
     - functional2
   test_open_link_in_private_window:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049894
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - smoke
   test_open_private_browsing_via_keyboard:

--- a/tests/security_and_privacy/test_open_link_in_private_window.py
+++ b/tests/security_and_privacy/test_open_link_in_private_window.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 import pytest
 from selenium.webdriver import Firefox
 
@@ -18,13 +16,11 @@ def test_open_link_in_private_window(driver: Firefox, nav: Navigation):
     context_menu = ContextMenu(driver)
     example.open()
 
-    sleep(1)
     example.context_click("learn-more")
-    sleep(1)
     context_menu.click_and_hide_menu("context-menu-open-link-in-new-private-window")
 
+    nav.wait_for_num_windows(2)
     nav.switch_to_new_window()
-    sleep(1)
     nav.is_private()
     example.title_contains(example.MORE_INFO_TITLE)
     example.url_contains(example.MORE_INFO_URL)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2049894](https://bugzilla.mozilla.org/show_bug.cgi?id=2049894)
TestRail: N/A

### Description of Code / Doc Changes

- Fix open link in private window test, by improving the initial sleep approach 

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
