### PR TITLE
Anca/ Fix paste and go opens correct url test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -99,8 +99,7 @@ address_bar_and_search:
     splits:
     - functional1
   test_paste_and_go_opens_correct_url:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043954
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_refresh_firefox_dialog:

--- a/tests/address_bar_and_search/test_paste_and_go_opens_correct_url.py
+++ b/tests/address_bar_and_search/test_paste_and_go_opens_correct_url.py
@@ -30,7 +30,7 @@ def test_paste_and_go_opens_correct_url(driver: Firefox):
 
     # Open a new tab and right click in the Address bar and choose Paste and Go
     nav.open_and_switch_to_new_window("tab")
-    nav.get_awesome_bar()
+    nav.context_click_in_awesome_bar()
     nav.click_and_hide_menu("context-menu-paste-and-go")
 
     # Check that the page is displayed


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2043954](https://bugzilla.mozilla.org/show_bug.cgi?id=2043954)
TestRail: N/A

### Description of Code / Doc Changes

- Fix paste and go opens correct url test
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
