### PR TITLE
Anca/ Mark beta 6 failed test unstable

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -639,7 +639,11 @@ menus:
     splits:
     - smoke
   test_image_context_menu_actions:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049603
+    result:
+      linux: unstable
+      mac: pass
+      win: unstable
     splits:
     - functional1
   test_new_tab_label:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2049603](https://bugzilla.mozilla.org/show_bug.cgi?id=2049603)
TestRail: N/A

### Description of Code / Doc Changes

- test_save_image_as  from tests/menus/test_image_context_menu_actions regressed on beta 153.0b6  and now fails on Linux as well.
- The #1462 fix did not address the root cause entirely.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
