### PR TITLE
Anca/ Attempt to fix image context menu actions

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -639,7 +639,11 @@ menus:
     splits:
     - smoke
   test_image_context_menu_actions:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049603
+    result:
+      linux: unstable
+      mac: pass
+      win: unstable
     splits:
     - functional1
   test_new_tab_label:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -639,11 +639,7 @@ menus:
     splits:
     - smoke
   test_image_context_menu_actions:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049603
-    result:
-      linux: unstable
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional1
   test_new_tab_label:

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -7,7 +7,6 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import ContextMenu, Navigation, TabBar
 from modules.page_object import GenericPage
-from modules.util import Utilities
 
 
 @pytest.fixture()
@@ -17,8 +16,8 @@ def test_case():
 
 @pytest.fixture()
 def delete_files_regex_string():
-    # Clear every saved variant (any extension/suffix); a leftover triggers a
-    # "replace?" prompt that cancels the save.
+    # Clear every saved variant (any extension/suffix) so no leftover interferes
+    # with the save.
     return rf"{re.escape(SAVED_IMAGE_STEM)}.*"
 
 
@@ -31,7 +30,9 @@ LOADED_IMAGE_URL = (
 )
 # Match the saved file by stem; the served format varies (.webp/.png).
 SAVED_IMAGE_STEM = "Firefox_logo,_2019.svg"
-# Poll for the saved file, re-confirming the save dialog each tick.
+# Deterministic target path used with the mock file picker on Linux.
+SAVED_IMAGE_FILENAME = f"{SAVED_IMAGE_STEM}.png"
+# Poll for the saved file, re-confirming the native save dialog each tick.
 SAVE_TIMEOUT_SECONDS = 15
 SAVE_POLL_INTERVAL_SECONDS = 1
 
@@ -63,14 +64,13 @@ def test_open_image_in_new_tab(driver: Firefox):
 
 
 @pytest.mark.headed
-def test_save_image_as(driver: Firefox, sys_platform, delete_files):
+def test_save_image_as(driver: Firefox, sys_platform, downloads_folder, delete_files):
     """
     C2637622.2: save image as
     """
     wiki_image_page = GenericPage(driver, url=LINK_IMAGE_URL)
     wiki_image_page.open()
     image_context_menu = ContextMenu(driver)
-    util = Utilities()
 
     # Wait for page to load
     wiki_image_page.wait_for_page_to_load()
@@ -79,32 +79,55 @@ def test_save_image_as(driver: Firefox, sys_platform, delete_files):
     image_logo = wiki_image_page.get_element("mediawiki-image")
     wiki_image_page.context_click(image_logo)
 
-    # Save the image
-    image_context_menu.click_and_hide_menu("context-menu-save-image-as")
+    # Linux CI can't drive the native "Save As" dialog, so use the mock file
+    # picker (repo convention for downloads); win/mac confirm the native dialog.
+    use_mock_picker = sys_platform == "Linux"
+    mock_saved_image_location = os.path.join(downloads_folder, SAVED_IMAGE_FILENAME)
+    if use_mock_picker:
+        wiki_image_page.install_mock_file_picker(mock_saved_image_location)
 
-    # The save dialog opens after a variable delay, so re-confirm on a poll loop
-    # until a non-empty file matching the stem appears.
-    downloads_dir = os.path.dirname(util.get_saved_file_path(SAVED_IMAGE_STEM))
-    saved_image_location = None
-    end_time = monotonic() + SAVE_TIMEOUT_SECONDS
-    while monotonic() < end_time:
-        wiki_image_page.handle_os_download_confirmation()
-        saved_image_location = next(
-            (
-                os.path.join(downloads_dir, name)
-                for name in os.listdir(downloads_dir)
-                if name.startswith(SAVED_IMAGE_STEM)
-                and os.path.getsize(os.path.join(downloads_dir, name)) > 0
-            ),
-            None,
-        )
-        if saved_image_location:
-            break
-        sleep(SAVE_POLL_INTERVAL_SECONDS)
+    try:
+        # Save the image
+        image_context_menu.click_and_hide_menu("context-menu-save-image-as")
 
-    assert saved_image_location, (
-        f"No saved image matching '{SAVED_IMAGE_STEM}*' found in {downloads_dir}"
-    )
+        if use_mock_picker:
+            wiki_image_page.wait_for_mock_file_picker()
+            wiki_image_page.expect(
+                lambda _: (
+                    os.path.exists(mock_saved_image_location)
+                    and os.path.getsize(mock_saved_image_location) > 0
+                )
+            )
+            assert (
+                os.path.exists(mock_saved_image_location)
+                and os.path.getsize(mock_saved_image_location) > 0
+            ), f"No non-empty saved image at {mock_saved_image_location}"
+        else:
+            # Native dialog path: the save dialog opens after a variable delay, so
+            # re-confirm on a poll loop until a non-empty file matching the stem appears.
+            saved_image_location = None
+            end_time = monotonic() + SAVE_TIMEOUT_SECONDS
+            while monotonic() < end_time:
+                wiki_image_page.handle_os_download_confirmation()
+                saved_image_location = next(
+                    (
+                        os.path.join(downloads_folder, name)
+                        for name in os.listdir(downloads_folder)
+                        if name.startswith(SAVED_IMAGE_STEM)
+                        and os.path.getsize(os.path.join(downloads_folder, name)) > 0
+                    ),
+                    None,
+                )
+                if saved_image_location:
+                    break
+                sleep(SAVE_POLL_INTERVAL_SECONDS)
+
+            assert saved_image_location, (
+                f"No saved image matching '{SAVED_IMAGE_STEM}*' found in {downloads_folder}"
+            )
+    finally:
+        if use_mock_picker:
+            wiki_image_page.cleanup_mock_file_picker()
 
 
 def test_copy_image_link(driver: Firefox):

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -30,7 +30,8 @@ LOADED_IMAGE_URL = (
 )
 # Match the saved file by stem; the served format varies (.webp/.png).
 SAVED_IMAGE_STEM = "Firefox_logo,_2019.svg"
-# Deterministic target path used with the mock file picker on Linux.
+# Mock picker needs a deterministic target path; the extension is the test's
+# choice (we only verify a non-empty file was saved). Native saves are auto-named.
 SAVED_IMAGE_FILENAME = f"{SAVED_IMAGE_STEM}.png"
 # Poll for the saved file, re-confirming the native save dialog each tick.
 SAVE_TIMEOUT_SECONDS = 15
@@ -79,8 +80,9 @@ def test_save_image_as(driver: Firefox, sys_platform, downloads_folder, delete_f
     image_logo = wiki_image_page.get_element("mediawiki-image")
     wiki_image_page.context_click(image_logo)
 
-    # Linux CI can't drive the native "Save As" dialog, so use the mock file
-    # picker (repo convention for downloads); win/mac confirm the native dialog.
+    # Linux CI can't reliably drive the native "Save As" dialog, so use the mock
+    # file picker, which is the repo convention for downloads. Other platforms
+    # confirm the native dialog.
     use_mock_picker = sys_platform == "Linux"
     mock_saved_image_location = os.path.join(downloads_folder, SAVED_IMAGE_FILENAME)
     if use_mock_picker:
@@ -92,16 +94,13 @@ def test_save_image_as(driver: Firefox, sys_platform, downloads_folder, delete_f
 
         if use_mock_picker:
             wiki_image_page.wait_for_mock_file_picker()
-            wiki_image_page.expect(
+            wiki_image_page.custom_wait(timeout=SAVE_TIMEOUT_SECONDS).until(
                 lambda _: (
                     os.path.exists(mock_saved_image_location)
                     and os.path.getsize(mock_saved_image_location) > 0
-                )
+                ),
+                message=f"No non-empty saved image at {mock_saved_image_location}",
             )
-            assert (
-                os.path.exists(mock_saved_image_location)
-                and os.path.getsize(mock_saved_image_location) > 0
-            ), f"No non-empty saved image at {mock_saved_image_location}"
         else:
             # Native dialog path: the save dialog opens after a variable delay, so
             # re-confirm on a poll loop until a non-empty file matching the stem appears.


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2049603](https://bugzilla.mozilla.org/show_bug.cgi?id=2049603)
TestRail: N/A

### Description of Code / Doc Changes

- Attempt to fix image context menu actions
- Change Linux  to use the mock file picker, it skips the popup and saves straight to a known path. Reliable, and it's what our pdf download tests already do. 
- Keep Windows & Mac as it is, it confirms the real popup natively (like a user would)
- Windows showed one  sign of flakiness, I've decided to not change it for now, keep an eye on it, and If it becomes a problem, I'll just add "Windows" to the use_mock_picker check

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
