### PR TITLE
Stabilize test always ask file type

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -458,8 +458,7 @@ downloads:
     splits:
     - functional1
   test_set_always_ask_file_type:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043378
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_telemetry_download_and_open:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -536,14 +536,16 @@
     "groups": []
   },
   "pdf-content-type": {
-    "selectorData": "//*[local-name()='hbox' and @class='typeContainer']//*[local-name()='label' and @class='typeDescription' and text()='Portable Document Format (PDF)']",
-    "strategy": "xpath",
+    "selectorData": "moz-box-item[type='application/pdf']",
+    "strategy": "css",
     "groups": []
   },
   "pdf-actions-menu": {
-    "selectorData": "richlistitem[type='application/pdf'] menulist.actionsMenu",
+    "selectorData": "moz-box-item[type='application/pdf'] moz-select.actionsMenu",
     "strategy": "css",
-    "groups": []
+    "groups": [
+      "doNotCache"
+    ]
   },
   "actions-menu": {
     "selectorData": "richlistitem[type='{.*}'] menulist.actionsMenu",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1114,15 +1114,42 @@ class AboutPrefs(BasePage):
         mime_type_data = json.loads(action_description.get_attribute("data-l10n-args"))
         return mime_type_data["app-name"]
 
+    @BasePage.context_content
     def set_pdf_handling_to_always_ask(self) -> BasePage:
         """
-        Set PDF content type handling to "Always ask" in Applications settings.
+        Set PDF content type handling to "Always ask" in the Applications list.
+
+        Since the Firefox Settings redesign (bug 2043378, ~152/153) the
+        Applications handlers moved to about:preferences#downloads and each row's
+        action control is a moz-select with moz-option children (no native
+        <select>, so Selenium's Select() does not apply). Select the "Always ask"
+        option by its stable l10n id and fire change so preferences persists it.
         """
-        self.click_on("pdf-content-type")
-        self.click_on("pdf-actions-menu")
+        self.element_visible("pdf-actions-menu")
         menu = self.get_element("pdf-actions-menu")
-        menu.send_keys(Keys.DOWN)
-        menu.send_keys(Keys.ENTER)
+        self.driver.execute_script(
+            """
+            const sel = arguments[0];
+            const opt = [...sel.querySelectorAll('moz-option')].find(
+                o => o.getAttribute('data-l10n-id') === 'applications-always-ask'
+            );
+            if (!opt) throw new Error('"Always ask" moz-option not found');
+            sel.value = opt.getAttribute('value');
+            sel.dispatchEvent(new Event('input', { bubbles: true }));
+            sel.dispatchEvent(new Event('change', { bubbles: true }));
+            """,
+            menu,
+        )
+        # Confirm the control settled on the "Always ask" value before leaving.
+        self.wait.until(
+            lambda _: self.driver.execute_script(
+                "const s = arguments[0];"
+                "const o = [...s.querySelectorAll('moz-option')].find("
+                "  e => e.getAttribute('data-l10n-id') === 'applications-always-ask');"
+                "return o && s.value === o.getAttribute('value');",
+                menu,
+            )
+        )
         return self
 
     @BasePage.context_chrome

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1125,8 +1125,7 @@ class AboutPrefs(BasePage):
         <select>, so Selenium's Select() does not apply). Select the "Always ask"
         option by its stable l10n id and fire change so preferences persists it.
         """
-        self.element_visible("pdf-actions-menu")
-        menu = self.get_element("pdf-actions-menu")
+        menu = self.wait.until(lambda _: self.get_element("pdf-actions-menu"))
         self.driver.execute_script(
             """
             const sel = arguments[0];

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1146,7 +1146,7 @@ class AboutPrefs(BasePage):
                 "const o = [...s.querySelectorAll('moz-option')].find("
                 "  e => e.getAttribute('data-l10n-id') === 'applications-always-ask');"
                 "return o && s.value === o.getAttribute('value');",
-                menu,
+                self.get_element("pdf-actions-menu"),
             )
         )
         return self

--- a/tests/downloads/test_set_always_ask_file_type.py
+++ b/tests/downloads/test_set_always_ask_file_type.py
@@ -29,7 +29,9 @@ def test_set_always_ask_file_type(driver: Firefox, delete_files):
 
     # Initialize page objects
     nav = Navigation(driver)
-    about_prefs = AboutPrefs(driver, category="general")
+    # Moved the Applications file-handlers list
+    # from the General pane to about:preferences#downloads.
+    about_prefs = AboutPrefs(driver, category="downloads")
 
     # Set PDF handling to "Always ask"
     about_prefs.open()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [Bug 2043378](https://bugzilla.mozilla.org/show_bug.cgi?id=2043378)


### Description of Code / Doc Changes

- Stabilize : tests/downloads/test_set_always_ask_file_type.py

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
