### PR TITLE
Anca/ Stabilize test_fingerprinters_blocked_and_shown_in_panel_and_preferences on Windows

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1335,11 +1335,7 @@ security_and_privacy:
     splits:
     - functional2
   test_fingerprinters_blocked_and_shown_in_panel_and_preferences:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2050617
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
   test_fingerprinters_displayed_subpanel:

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -120,6 +120,8 @@ class TrustPanel(BasePage):
         else:
             self.expect(_check_trustpanel)
 
+        return self
+
     @BasePage.context_chrome
     def assert_connection_information(self, expected_technical_details):
         self.element_clickable("trustpanel-connect-button")

--- a/modules/browser_object_trust_panel.py
+++ b/modules/browser_object_trust_panel.py
@@ -10,6 +10,11 @@ from selenium.webdriver.support.wait import WebDriverWait
 from modules.browser_object_navigation import Navigation
 from modules.page_base import BasePage
 
+# Windows tracker detection can lag several seconds behind a reload; poll slowly so
+# each reload gets time to run detection instead of restarting it every ~0.5s.
+TRACKER_DETECT_TIMEOUT = 30
+TRACKER_DETECT_POLL = 3
+
 
 class TrustPanel(BasePage):
     """
@@ -85,14 +90,20 @@ class TrustPanel(BasePage):
         return self.sites_in_category("detected", *sites)
 
     @BasePage.context_chrome
-    def wait_for_trackers(self) -> BasePage:
-        """Open and close the trust panel until trackers appear"""
+    def wait_for_trackers(self, require_count: bool = False) -> BasePage:
+        """
+        Open and close the trust panel until trackers appear.
+
+        require_count: when True, keep refreshing until the blocker section reports a
+        non-zero count. Needed on slower platforms (Windows) where tracker detection
+        lags the panel opening; otherwise a visible-but-empty panel is accepted.
+        """
         nav = Navigation(self.driver)
         blocker_section = "trustpanel-blocker-section"
 
         def _check_trustpanel(driver):
-            args = self.get_element_args(blocker_section)
-            if args.get("count"):
+            count = self.get_element_args(blocker_section).get("count")
+            if count:
                 return True
 
             nav.click_on("refresh-button")
@@ -100,9 +111,14 @@ class TrustPanel(BasePage):
             self.open_panel()
             if self.get_parent_of(blocker_section).get_attribute("hidden") == "true":
                 return False
-            return True
+            return not require_count
 
-        self.expect(_check_trustpanel)
+        if require_count:
+            self.custom_wait(
+                timeout=TRACKER_DETECT_TIMEOUT, poll_frequency=TRACKER_DETECT_POLL
+            ).until(_check_trustpanel)
+        else:
+            self.expect(_check_trustpanel)
 
     @BasePage.context_chrome
     def assert_connection_information(self, expected_technical_details):

--- a/tests/security_and_privacy/test_fingerprinters_blocked_and_shown_in_panel_and_preferences.py
+++ b/tests/security_and_privacy/test_fingerprinters_blocked_and_shown_in_panel_and_preferences.py
@@ -27,7 +27,7 @@ def test_fingerprinters_blocked_and_shown_in_panel_and_preferences(driver: Firef
     # Open page and check the Information panel
     tracking_page.open()
     trust_panel.open_panel()
-    trust_panel.wait_for_trackers()
+    trust_panel.wait_for_trackers(require_count=True)
 
     # The "Blocked" string is displayed under the Fingerprinters section
     trust_panel.trackers_blocked("fingerprinter")


### PR DESCRIPTION
Bugzilla: [2050617](https://bugzilla.mozilla.org/show_bug.cgi?id=2050617)
TestRail: N/A

### Description of Code / Doc Changes

- I looked into the full trust-panel / subpanel test family, since any fix here touches shared code that affects the whole family, not just the tests currently marked unstable. This PR, however, intentionally fixes only `fingerprinters_blocked`, because it's the one test that can be fully stabilized in isolation: it depends solely on the tracker count, so the opt-in `require_count` wait resolves it completely without touching any shared subview code and without affecting any other test.
- The remaining subpanel tests fail for a different, deeper reason: flakiness in the See-All → `open_detected_category` subview path, which is worse under parallel CI and needs its own dedicated fix. I've kept those out of this PR so a clean, low-risk change isn't held up by or entangled with that larger effort. I did attempt to reduce their flakiness, and locally it improved substantially, but not enough to confidently drop the `win: unstable` flag; CI reinforced this, showing how fragile these tests are to even small changes.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
