### PR TITLE
open the downloads pane instead of general

### DIFF
--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -526,14 +526,18 @@
     "groups": []
   },
   "mime-type-item": {
-    "selectorData": "richlistitem[type='{item}']",
+    "selectorData": "moz-box-item[type='{item}']",
     "strategy": "css",
-    "groups": []
+    "groups": [
+      "doNotCache"
+    ]
   },
   "mime-type-item-description": {
-    "selectorData": "label[data-l10n-id='applications-use-app-default-label']",
+    "selectorData": "moz-option[data-l10n-id='applications-use-app-default']",
     "strategy": "css",
-    "groups": []
+    "groups": [
+      "doNotCache"
+    ]
   },
   "pdf-content-type": {
     "selectorData": "//*[local-name()='hbox' and @class='typeContainer']//*[local-name()='label' and @class='typeDescription' and text()='Portable Document Format (PDF)']",

--- a/tests/downloads/test_add_mime_type_doc.py
+++ b/tests/downloads/test_add_mime_type_doc.py
@@ -36,7 +36,9 @@ def test_mime_type_doc(driver: Firefox, sys_platform: str, opt_ci: bool, delete_
     # Instantiate objects
     page = GenericPage(driver, url=DOC_LINK)
     nav = Navigation(driver)
-    about_prefs = AboutPrefs(driver, category="general")
+    # Settings redesign (bug 2043378) moved the Applications file-handlers list
+    # from the General pane to about:preferences#downloads.
+    about_prefs = AboutPrefs(driver, category="downloads")
 
     # Open the test page with the .doc download link
     page.open()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [Bug 2043378](https://bugzilla.mozilla.org/show_bug.cgi?id=2043378)
TestRail: _

### Description of Code / Doc Changes

- Stabilize: tests/downloads/test_add_mime_type_doc.py
- The fix is supposed to work on linux/mac

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
