### PR TITLE
Anca/ Activate all themes directly to fix nondeterministic TestRail "Untested" result

### DIFF
--- a/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
+++ b/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
@@ -11,14 +11,16 @@ def test_case():
     return "118173"
 
 
+COMPACT_DARK = "firefox-compact-dark_mozilla_org-heading"
+COMPACT_LIGHT = "firefox-compact-light_mozilla_org-heading"
+
 THEMES: dict[str, list[str]] = {
-    "firefox-compact-dark_mozilla_org-heading": [
+    COMPACT_DARK: [
         "rgb(43, 42, 51)",  # classic darker tone
         "rgb(143, 143, 148)",  # focused dark
         "rgb(120, 119, 126)",  # dark without focus
     ],
-    # Compact Light
-    "firefox-compact-light_mozilla_org-heading": [
+    COMPACT_LIGHT: [
         "rgb(249, 249, 251)",
     ],
 }
@@ -61,14 +63,6 @@ def test_activate_theme_background_matches_expected(
     nav = Navigation(driver)
     abt_addons = AboutAddons(driver).open()
     abt_addons.choose_sidebar_option("theme")
-
-    # Dynamically detect if running Developer Edition
-    if abt_addons.is_devedition():
-        if theme_name == "firefox-compact-dark_mozilla_org-heading":
-            pytest.skip("Compact Dark is default on DevEdition, skipping.")
-    else:
-        if theme_name == "firefox-compact-light_mozilla_org-heading":
-            pytest.skip("Compact Light is default on Firefox, skipping.")
 
     current_bg = abt_addons.activate_theme(nav, theme_name, "", perform_assert=False)
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2052836](https://bugzilla.mozilla.org/show_bug.cgi?id=2052836)
TestRail: [118173](https://mozilla.testrail.io/index.php?/cases/results/118173)

### Description of Code / Doc Changes

- Test case C118173 covers multiple theme checks (Compact Dark, Compact Light, Alpenglow), which all report to this single case ID. The test skips whichever theme is already the build's default (Compact Light on Firefox/Beta, Dark on Developer Edition), and TestRail never posts skipped checks, only passes/failures.
Because the reporter keeps only the last result written for a case ID, and tests run in parallel in a nondeterministic order, the status is basically a coin flip: if a passing check lands last the case shows Passed, but if the skipped check lands last it overwrites the passes and the case stays Untested. See the history here, where the same case is randomly marked Untested: https://mozilla.testrail.io/index.php?/cases/results/118173.
- Dropped the is_devedition()/pytest.skip default-theme logic. The selected theme on a fresh profile is "System theme – auto" (following the OS dark/light setting), not Compact Light/Dark,  so each theme can be activated and verified directly on any build. All parametrized themes now run and should report a pass, so C118173 no longer lands on an unposted skip and stops flickering to "Untested".

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
