### PR TITLE
Anca/Glean serp abandonment second batch

### DIFF
--- a/tests/glean/flows.py
+++ b/tests/glean/flows.py
@@ -363,7 +363,7 @@ def _abandonment_navigation(driver: Firefox, search_term: str, params: dict = No
     glean = Glean(driver)
     tabs = TabBar(driver)
 
-    # Open the search in a new tab so the abandonment leaves the original tab (and session) alive
+    # Open the search in a new tab so it starts from the new-tab page, then navigate away in that tab
     tabs.open_and_switch_to_new_tab()
     nav.search(search_term)
 

--- a/tests/glean/flows.py
+++ b/tests/glean/flows.py
@@ -378,6 +378,32 @@ def _abandonment_navigation(driver: Firefox, search_term: str, params: dict = No
     page.url_contains("example.com")
 
 
+@_abandonment("back_navigation")
+def _abandonment_back_navigation(
+    driver: Firefox, search_term: str, params: dict = None
+):
+    """Open a SERP in a new tab and leave it via the back button, returning to the new-tab page,
+    so Firefox records a serp.abandonment with reason='navigation'."""
+    # Instantiate objects
+    page = GenericPage(driver)
+    nav = Navigation(driver)
+    glean = Glean(driver)
+    tabs = TabBar(driver)
+
+    # Open the search in a new tab so the back button returns to the new-tab page, not a prior SERP
+    tabs.open_and_switch_to_new_tab()
+    nav.search(search_term)
+
+    # Wait for the SERP impression so the abandonment has an impression to reference; leaving
+    # before Firefox categorizes the SERP records no abandonment
+    page.url_contains(search_term)
+    glean.poll_glean_metric("serp.impression", {"source": "urlbar"})
+
+    # Leave the SERP via the back button -> serp.abandonment reason='navigation'
+    nav.click_back_button()
+    page.url_contains("about:newtab")
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------

--- a/tests/glean/flows.py
+++ b/tests/glean/flows.py
@@ -353,6 +353,31 @@ def _abandonment_tab_close(driver: Firefox, search_term: str, params: dict = Non
     page.switch_to_new_tab()
 
 
+@_abandonment("navigation")
+def _abandonment_navigation(driver: Firefox, search_term: str, params: dict = None):
+    """Open a SERP and navigate away in the same tab by loading another page from the address
+    bar, so Firefox records a serp.abandonment with reason='navigation'."""
+    # Instantiate objects
+    page = GenericPage(driver)
+    nav = Navigation(driver)
+    glean = Glean(driver)
+    tabs = TabBar(driver)
+
+    # Open the search in a new tab so the abandonment leaves the original tab (and session) alive
+    tabs.open_and_switch_to_new_tab()
+    nav.search(search_term)
+
+    # Wait for the SERP impression so the abandonment has an impression to reference; navigating
+    # before Firefox categorizes the SERP records no abandonment
+    page.url_contains(search_term)
+    glean.poll_glean_metric("serp.impression", {"source": "urlbar"})
+
+    # Navigate away from the SERP in the same tab via the address bar -> serp.abandonment
+    # reason='navigation'
+    nav.type_in_awesome_bar(ExamplePage.URL_TEMPLATE + Keys.ENTER)
+    page.url_contains("example.com")
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------

--- a/tests/glean/serp_abandonment/cases.json
+++ b/tests/glean/serp_abandonment/cases.json
@@ -10,7 +10,13 @@
     {"id": "3255503", "entry": "urlbar", "action": "navigation", "params": {"engine": "Google"}, "prefs": [], "expected": {"reason": "navigation"}},
     {"id": "3255508", "entry": "urlbar", "action": "navigation", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "navigation"}},
     {"id": "3255513", "entry": "urlbar", "action": "navigation", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "navigation"}},
-    {"id": "3255518", "entry": "urlbar", "action": "navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
-    {"id": "3255522", "entry": "urlbar", "action": "navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}}
+    {"id": "TBD-ecosia-navigation", "entry": "urlbar", "action": "navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
+    {"id": "3255522", "entry": "urlbar", "action": "navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}},
+
+    {"id": "3255504", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Google"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255509", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255514", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255518", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
+    {"id": "3255523", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}}
   ]
 }

--- a/tests/glean/serp_abandonment/cases.json
+++ b/tests/glean/serp_abandonment/cases.json
@@ -10,7 +10,7 @@
     {"id": "3255503", "entry": "urlbar", "action": "navigation", "params": {"engine": "Google"}, "prefs": [], "expected": {"reason": "navigation"}},
     {"id": "3255508", "entry": "urlbar", "action": "navigation", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "navigation"}},
     {"id": "3255513", "entry": "urlbar", "action": "navigation", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "navigation"}},
-    {"id": "TBD-ecosia-navigation", "entry": "urlbar", "action": "navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
+    {"id": "4162725", "entry": "urlbar", "action": "navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
     {"id": "3255522", "entry": "urlbar", "action": "navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}},
 
     {"id": "3255504", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Google"}, "prefs": [], "expected": {"reason": "navigation"}},

--- a/tests/glean/serp_abandonment/cases.json
+++ b/tests/glean/serp_abandonment/cases.json
@@ -5,6 +5,12 @@
     {"id": "3255507", "entry": "urlbar", "action": "tab_close", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "tab_close"}},
     {"id": "3255512", "entry": "urlbar", "action": "tab_close", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "tab_close"}},
     {"id": "3255517", "entry": "urlbar", "action": "tab_close", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "tab_close"}},
-    {"id": "3255521", "entry": "urlbar", "action": "tab_close", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "tab_close"}}
+    {"id": "3255521", "entry": "urlbar", "action": "tab_close", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "tab_close"}},
+
+    {"id": "3255503", "entry": "urlbar", "action": "navigation", "params": {"engine": "Google"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255508", "entry": "urlbar", "action": "navigation", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255513", "entry": "urlbar", "action": "navigation", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255518", "entry": "urlbar", "action": "navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
+    {"id": "3255522", "entry": "urlbar", "action": "navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}}
   ]
 }

--- a/tests/glean/serp_abandonment/test_serp_abandonment.py
+++ b/tests/glean/serp_abandonment/test_serp_abandonment.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from selenium.webdriver import Firefox
 
@@ -8,6 +10,11 @@ from tests.glean.utils import load_cases
 
 data = load_cases(__file__)
 METRIC = data["metric"]
+
+# Each SERP event carries a UUID impression_id, e.g. "c85ccabf-7481-402e-b28d-22b4dc85561e"
+IMPRESSION_ID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
 
 
 @pytest.fixture(
@@ -46,4 +53,17 @@ def test_serp_abandonment(driver: Firefox, case: dict):
 
     run_abandonment(driver, case["action"], SEARCH_TERM, params)
 
-    glean.poll_glean_metric(METRIC, case["expected"])
+    events = glean.poll_glean_metric(METRIC, case["expected"])
+
+    # The matched abandonment must carry a well-formed UUID impression_id
+    impression_ids = [
+        event.get("extra", {}).get("impression_id", "")
+        for event in events
+        if all(
+            event.get("extra", {}).get(key) == value
+            for key, value in case["expected"].items()
+        )
+    ]
+    assert any(IMPRESSION_ID_RE.match(i) for i in impression_ids), (
+        f"Expected a UUID impression_id in {METRIC}, got {impression_ids!r}"
+    )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [10 test cases](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=2032792%2C%202032793%2C%202032797%2C%202032798%2C%202032802%2C%202032803%2C%202032807%2C%202032811%2C%202032812%2C%202053714&list_id=18037527)
TestRail: [S70197](https://mozilla.testrail.io/index.php?/suites/view/70197&group_by=cases:section_id&group_order=asc&display=tree&display_deleted_cases=0)

### Description of Code / Doc Changes

- Add navigation and back_navigation abandonment 
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
