### PR TITLE
Anca/ Glean - serp abandonment third batch

### DIFF
--- a/tests/glean/flows.py
+++ b/tests/glean/flows.py
@@ -430,6 +430,31 @@ def _abandonment_refresh_navigation(
     page.url_contains(search_term)
 
 
+@_abandonment("window_close")
+def _abandonment_window_close(driver: Firefox, search_term: str, params: dict = None):
+    """Open a SERP in a new window and close that window without engaging, so Firefox records a
+    serp.abandonment with reason='window_close'."""
+    # Instantiate objects
+    page = GenericPage(driver)
+    nav = Navigation(driver)
+    glean = Glean(driver)
+
+    # Open the search in a new window so closing it leaves the original window (and session) alive
+    original_window_count = len(driver.window_handles)
+    nav.open_and_switch_to_new_window("window")
+    nav.search(search_term)
+
+    # Wait for the SERP impression so the abandonment has an impression to reference; closing
+    # before Firefox categorizes the SERP records no abandonment
+    page.url_contains(search_term)
+    glean.poll_glean_metric("serp.impression", {"source": "urlbar"})
+
+    # Close the window without engaging
+    driver.close()
+    page.wait_for_num_tabs(original_window_count)
+    page.switch_to_new_window()
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------

--- a/tests/glean/flows.py
+++ b/tests/glean/flows.py
@@ -404,6 +404,32 @@ def _abandonment_back_navigation(
     page.url_contains("about:newtab")
 
 
+@_abandonment("refresh_navigation")
+def _abandonment_refresh_navigation(
+    driver: Firefox, search_term: str, params: dict = None
+):
+    """Open a SERP and refresh it in the same tab via the refresh button, so Firefox records a
+    serp.abandonment with reason='navigation'."""
+    # Instantiate objects
+    page = GenericPage(driver)
+    nav = Navigation(driver)
+    glean = Glean(driver)
+    tabs = TabBar(driver)
+
+    # Open the search in a new tab so it starts from the new-tab page, then refresh in that tab
+    tabs.open_and_switch_to_new_tab()
+    nav.search(search_term)
+
+    # Wait for the SERP impression so the abandonment has an impression to reference; refreshing
+    # before Firefox categorizes the SERP records no abandonment
+    page.url_contains(search_term)
+    glean.poll_glean_metric("serp.impression", {"source": "urlbar"})
+
+    # Refresh the SERP in the same tab -> serp.abandonment reason='navigation'
+    nav.refresh_page()
+    page.url_contains(search_term)
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------

--- a/tests/glean/serp_abandonment/cases.json
+++ b/tests/glean/serp_abandonment/cases.json
@@ -17,6 +17,12 @@
     {"id": "3255509", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "navigation"}},
     {"id": "3255514", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "navigation"}},
     {"id": "3255518", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
-    {"id": "3255523", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}}
+    {"id": "3255523", "entry": "urlbar", "action": "back_navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}},
+
+    {"id": "3255505", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "Google"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255510", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255515", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "navigation"}},
+    {"id": "3255519", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
+    {"id": "3255524", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}}
   ]
 }

--- a/tests/glean/serp_abandonment/cases.json
+++ b/tests/glean/serp_abandonment/cases.json
@@ -23,6 +23,12 @@
     {"id": "3255510", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "navigation"}},
     {"id": "3255515", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "navigation"}},
     {"id": "3255519", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "navigation"}},
-    {"id": "3255524", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}}
+    {"id": "3255524", "entry": "urlbar", "action": "refresh_navigation", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "navigation"}},
+
+    {"id": "3255506", "entry": "urlbar", "action": "window_close", "params": {"engine": "Google"}, "prefs": [], "expected": {"reason": "window_close"}},
+    {"id": "3255511", "entry": "urlbar", "action": "window_close", "params": {"engine": "Bing"}, "prefs": [], "expected": {"reason": "window_close"}},
+    {"id": "3255516", "entry": "urlbar", "action": "window_close", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"reason": "window_close"}},
+    {"id": "3255520", "entry": "urlbar", "action": "window_close", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"reason": "window_close"}},
+    {"id": "3255525", "entry": "urlbar", "action": "window_close", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"reason": "window_close"}}
   ]
 }


### PR DESCRIPTION
### Relevant Links

Bugzilla: [10 test cases](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=2032794%2C%202032795%2C%202032814%2C%202032813%2C%202032809%2C%202032808%2C%202032805%2C%202032804%2C%202032800%2C%202032799&list_id=18038819)
TestRail: [S70197](https://mozilla.testrail.io/index.php?/suites/view/70197&group_by=cases:section_id&group_order=asc&display=tree&display_deleted_cases=0)

### Description of Code / Doc Changes

- Add refresh_navigation and window_close abandonment actions
- 
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
