### PR TITLE
Anca/ Fix commit-test hook crash on Windows due to path separator

### DIFF
--- a/manifests/testkey.py
+++ b/manifests/testkey.py
@@ -192,7 +192,7 @@ class TestKey:
         Given a filename, get a partial dict that represents
         the test's location in the manifest
         """
-        segments = filename.split(os.path.sep)
+        segments = re.split(r"[\\/]", filename)
         i = 0
         if segments[i] == ".":
             i += 1


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: N/A

### Description of Code / Doc Changes

- Fix path separator handling in TestKey on Windows
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
