### PR TITLE
Vs/context menu stabilization

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -435,8 +435,7 @@ downloads:
     - smoke
     - ci
   test_download_pdf_from_context_menu:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2042660
-    result: unstable
+    result: pass
     splits:
     - smoke
   test_download_telemetry_recorded:

--- a/tests/downloads/test_download_pdf_from_context_menu.py
+++ b/tests/downloads/test_download_pdf_from_context_menu.py
@@ -24,11 +24,11 @@ PDF_TELEMETRY_DATA = ["downloads", "added", "fileExtension", "pdf"]
 
 @pytest.mark.headed
 def test_download_pdf_from_context_menu(
-    driver: Firefox,
-    fillable_pdf_url: str,
-    downloads_folder: str,
-    sys_platform,
-    delete_files,
+        driver: Firefox,
+        fillable_pdf_url: str,
+        downloads_folder: str,
+        sys_platform,
+        delete_files,
 ):
     """
     C1756790: Verify that Telemetry is recorded when Saving a PDF from the Context menu
@@ -49,7 +49,6 @@ def test_download_pdf_from_context_menu(
     nav = Navigation(driver)
 
     # Right-click on the body of the file and select Save page as
-    pdf_page.open()
     body = pdf_page.get_element("pdf-body")
     pdf_page.context_click(body)
     context_menu.click_and_hide_menu("context-menu-save-page-as")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2042660](https://bugzilla.mozilla.org/show_bug.cgi?id=2042660)
TestRail: N/A

### Description of Code / Doc Changes

Small cleanup. The test has passed 100% times for me locally with just this small .open() removal. 
Even if it's not passing 100%, a rerun should still make it stable enough.
Will follow-up if failing again.

Thank you!
