### PR TITLE
tracy/ Use mock file picker for PDF download tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -429,14 +429,12 @@ downloads:
     splits:
     - functional1
   test_download_pdf:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2042659
-    result: unstable
+    result: pass
     splits:
     - smoke
     - ci
   test_download_pdf_from_context_menu:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2042660
-    result: unstable
+    result: pass
     splits:
     - smoke
   test_download_telemetry_recorded:

--- a/tests/downloads/conftest.py
+++ b/tests/downloads/conftest.py
@@ -1,6 +1,28 @@
+import os
 import subprocess
+import time
 
 import pytest
+
+DOWNLOAD_TIMEOUT_SEC = 10.0
+POLL_INTERVAL_SEC = 0.5
+
+
+@pytest.fixture()
+def wait_for_file_download():
+    """Return a helper that blocks until a file finishes downloading."""
+
+    def _wait_for_file_download(
+        file_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
+    ) -> bool:
+        start = time.time()
+        while time.time() - start < timeout:
+            if os.path.exists(file_path):
+                return True
+            time.sleep(interval)
+        return False
+
+    return _wait_for_file_download
 
 
 @pytest.fixture()

--- a/tests/downloads/test_download_pdf.py
+++ b/tests/downloads/test_download_pdf.py
@@ -31,34 +31,33 @@ def test_download_pdf(
     driver: Firefox,
     fillable_pdf_url: str,
     downloads_folder: str,
-    sys_platform,
     delete_files,
 ):
     """
     C1756769: Verify that the user can Download a PDF
 
     Notes:
-        - Firefox is launched with a new profile that has default download settings.
-        - This means the OS-level "Save File" dialog will appear for every download.
-        - Selenium cannot interact with this native dialog directly, so the test
-          must rely on fixed waits to give the OS time to render the dialog and to
-          finish writing the file.
+        - The native "Save File" picker is mocked on all platforms so the
+          download runs headlessly in CI. Driving the OS file dialog is
+          unreliable there (Linux Wayland cannot drive GTK pickers through
+          desktop input, and Windows image-matching depends on the CI
+          resolution/DPI/theme).
     """
-
-    # Initialize objects
-    pdf_page = GenericPdf(driver, pdf_url=fillable_pdf_url)
-
-    # Click the download button
-    pdf_page.open()
-    pdf_page.click_download_button()
-
-    # Allow time for the download dialog to appear and pressing handle the prompt
-    time.sleep(2)
-    pdf_page.handle_os_download_confirmation()
 
     # Set the expected download path and the expected PDF name
     file_name = "i-9.pdf"
     saved_pdf_location = os.path.join(downloads_folder, file_name)
+
+    # Initialize objects
+    pdf_page = GenericPdf(driver, pdf_url=fillable_pdf_url)
+
+    # Replace the native save dialog with a mock that returns our target path
+    pdf_page.install_mock_file_picker(saved_pdf_location)
+    try:
+        pdf_page.click_download_button()
+        pdf_page.wait_for_mock_file_picker()
+    finally:
+        pdf_page.cleanup_mock_file_picker()
 
     # Wait up to 10 seconds for the file to appear and finish downloading
     assert wait_for_file_download(saved_pdf_location, timeout=10), (

--- a/tests/downloads/test_download_pdf.py
+++ b/tests/downloads/test_download_pdf.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import pytest
 from selenium.webdriver import Firefox
@@ -17,21 +16,13 @@ def delete_files_regex_string():
     return r".*i-9.pdf"
 
 
-def wait_for_file_download(file_path, timeout=10, interval=0.5):
-    start = time.time()
-    while time.time() - start < timeout:
-        if os.path.exists(file_path):
-            return True
-        time.sleep(interval)
-    return False
-
-
 @pytest.mark.headed
 def test_download_pdf(
     driver: Firefox,
     fillable_pdf_url: str,
     downloads_folder: str,
     delete_files,
+    wait_for_file_download,
 ):
     """
     C1756769: Verify that the user can Download a PDF
@@ -59,7 +50,7 @@ def test_download_pdf(
     finally:
         pdf_page.cleanup_mock_file_picker()
 
-    # Wait up to 10 seconds for the file to appear and finish downloading
-    assert wait_for_file_download(saved_pdf_location, timeout=10), (
+    # Wait for the file to appear and finish downloading
+    assert wait_for_file_download(saved_pdf_location), (
         f"File not found: {saved_pdf_location}"
     )

--- a/tests/downloads/test_download_pdf_from_context_menu.py
+++ b/tests/downloads/test_download_pdf_from_context_menu.py
@@ -1,4 +1,5 @@
-from time import sleep
+import os
+import time
 
 import pytest
 from selenium.webdriver import Firefox
@@ -22,24 +23,36 @@ def delete_files_regex_string():
 PDF_TELEMETRY_DATA = ["downloads", "added", "fileExtension", "pdf"]
 
 
+def wait_for_file_download(file_path, timeout=10, interval=0.5):
+    start = time.time()
+    while time.time() - start < timeout:
+        if os.path.exists(file_path):
+            return True
+        time.sleep(interval)
+    return False
+
+
 @pytest.mark.headed
 def test_download_pdf_from_context_menu(
     driver: Firefox,
     fillable_pdf_url: str,
     downloads_folder: str,
-    sys_platform,
     delete_files,
 ):
     """
     C1756790: Verify that Telemetry is recorded when Saving a PDF from the Context menu
 
-     Notes:
-        - Firefox is launched with a new profile that has default download settings.
-        - This means the OS-level "Save File" dialog will appear for every download.
-        - Selenium cannot interact with this native dialog directly, so the test
-          must rely on fixed waits to give the OS time to render the dialog and to
-          finish writing the file.
+    Notes:
+        - The native "Save File" picker is mocked on all platforms so the
+          download runs headlessly in CI. Driving the OS file dialog is
+          unreliable there (Linux Wayland cannot drive GTK pickers through
+          desktop input, and Windows image-matching depends on the CI
+          resolution/DPI/theme).
     """
+
+    # Set the expected download path and the expected PDF name
+    file_name = "i-9.pdf"
+    saved_pdf_location = os.path.join(downloads_folder, file_name)
 
     # Initialize objects
     pdf_page = GenericPdf(driver, pdf_url=fillable_pdf_url)
@@ -48,19 +61,22 @@ def test_download_pdf_from_context_menu(
     tabs = TabBar(driver)
     nav = Navigation(driver)
 
-    # Right-click on the body of the file and select Save page as
-    pdf_page.open()
-    body = pdf_page.get_element("pdf-body")
-    pdf_page.context_click(body)
-    context_menu.click_and_hide_menu("context-menu-save-page-as")
+    # Replace the native save dialog with a mock that returns our target path
+    pdf_page.install_mock_file_picker(saved_pdf_location)
+    try:
+        # Right-click on the body of the file and select Save page as
+        body = pdf_page.get_element("pdf-body")
+        pdf_page.context_click(body)
+        context_menu.click_and_hide_menu("context-menu-save-page-as")
+        pdf_page.wait_for_mock_file_picker()
+    finally:
+        pdf_page.cleanup_mock_file_picker()
 
-    # Allow time for the save dialog to appear and handle prompt
-    sleep(2)
-    context_menu.hide_popup_by_child_node("context-menu-save-page-as")
-    pdf_page.handle_os_download_confirmation()
-
-    # Allow time for the download to complete
+    # Allow the download to complete
     nav.wait_for_download_animation_finish()
+    assert wait_for_file_download(saved_pdf_location, timeout=10), (
+        f"File not found: {saved_pdf_location}"
+    )
 
     # Open about:telemetry in a new tab and go to the Events tab
     tabs.new_tab_by_button()

--- a/tests/downloads/test_download_pdf_from_context_menu.py
+++ b/tests/downloads/test_download_pdf_from_context_menu.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import pytest
 from selenium.webdriver import Firefox
@@ -23,21 +22,13 @@ def delete_files_regex_string():
 PDF_TELEMETRY_DATA = ["downloads", "added", "fileExtension", "pdf"]
 
 
-def wait_for_file_download(file_path, timeout=10, interval=0.5):
-    start = time.time()
-    while time.time() - start < timeout:
-        if os.path.exists(file_path):
-            return True
-        time.sleep(interval)
-    return False
-
-
 @pytest.mark.headed
 def test_download_pdf_from_context_menu(
     driver: Firefox,
     fillable_pdf_url: str,
     downloads_folder: str,
     delete_files,
+    wait_for_file_download,
 ):
     """
     C1756790: Verify that Telemetry is recorded when Saving a PDF from the Context menu
@@ -74,7 +65,7 @@ def test_download_pdf_from_context_menu(
 
     # Allow the download to complete
     nav.wait_for_download_animation_finish()
-    assert wait_for_file_download(saved_pdf_location, timeout=10), (
+    assert wait_for_file_download(saved_pdf_location), (
         f"File not found: {saved_pdf_location}"
     )
 


### PR DESCRIPTION
#### Relevant Links
Bugzilla: 
- https://bugzilla.mozilla.org/show_bug.cgi?id=2042660
- https://bugzilla.mozilla.org/show_bug.cgi?id=2042659

#### Description of Code / Doc Changes
  Both tests/downloads/test_download_pdf.py and
  test_download_pdf_from_context_menu.py drove the native OS "Save File"
  dialog via handle_os_download_confirmation (pyautogui). This passed on
  Mac but failed on Windows and Linux CI: Wayland can't drive GTK pickers
  through synthetic input, and Windows image-matching depends on the CI
  resolution/DPI/theme.

  Replace native-dialog handling with install_mock_file_picker on all
  platforms (same approach as the passwords CSV export and the Linux path
  in test_download_pdf_data.py). Drop the pyautogui calls and fixed sleeps,
  and flip both key.yaml entries from unstable to pass.

  Co-Authored-By: Claude Opus 4.8

#### Workflow Checklist
- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.

Thank you!