### PR TITLE
Tracy/ Re-enable print-to-PDF test and drop stale headed markers

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1125,8 +1125,7 @@ printing_ui:
     - smoke
     - ci
   test_print_to_pdf:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1974011
-    result: unstable
+    result: pass
     splits:
     - functional2
 profile:

--- a/modules/browser_object_print_preview.py
+++ b/modules/browser_object_print_preview.py
@@ -1,17 +1,7 @@
-from selenium.common import NoAlertPresentException
 from selenium.webdriver.common.keys import Keys
 
 from modules.browser_object_panel_ui import PanelUi
 from modules.page_base import BasePage
-from modules.util import BrowserActions
-
-
-def _get_alert(d):
-    try:
-        alert = d.switch_to.alert
-    except NoAlertPresentException:
-        return False
-    return alert
 
 
 class PrintPreview(BasePage):
@@ -44,22 +34,31 @@ class PrintPreview(BasePage):
         return self
 
     @BasePage.context_chrome
-    def switch_to_preview_window(self) -> BasePage:
-        """Switch to the iframe holding the Print Preview settings."""
-        ba = BrowserActions(self.driver)
-        ba.switch_to_iframe_context(self.get_element("print-settings-browser"))
-        # Wait for print button to be present as indicator of readiness
-        self.element_exists("print-button")
-        return self
+    def click_primary_button(self) -> BasePage:
+        """
+        Click the primary action button in the print settings dialog.
 
-    @BasePage.context_content
-    def start_print(self) -> BasePage:
-        """Press Enter in Print Preview Page."""
-        self.switch_to_preview_window()
-        self.get_element("print-button").click()
-        # Wait for print dialog to appear
-        self.custom_wait(timeout=5).until(lambda d: _get_alert(d))
-        self.gui.press("enter")
+        With the "Mozilla Save to PDF" destination this button is labelled
+        "Save" and opens the native file picker (nsIFilePicker); install a mock
+        file picker beforehand to capture the save location.
+
+        The print settings live in a XUL <browser> (printSettingsBrowser) whose
+        content cannot be entered with Selenium frame switching, so the button
+        is clicked through the browser's contentDocument, the same way
+        _click_pagination_button reaches through the shadow root.
+        """
+        settings_browser = self.get_element("print-settings-browser")
+        self.custom_wait(timeout=10).until(
+            lambda _: self.driver.execute_script(
+                "return !!arguments[0].contentDocument"
+                "?.getElementById('print-button');",
+                settings_browser,
+            )
+        )
+        self.driver.execute_script(
+            "arguments[0].contentDocument.getElementById('print-button').click();",
+            settings_browser,
+        )
         return self
 
     @BasePage.context_chrome

--- a/modules/data/generic_page.components.json
+++ b/modules/data/generic_page.components.json
@@ -239,11 +239,11 @@
     "groups": []
   },
   "download-malicious-warning": {
-    "selectorData": "a[href='https://testsafebrowsing.appspot.com/s/content.exe']",
+    "selectorData": "a[href='https://testsafebrowsing.appspot.com/s/badrep.exe']",
     "strategy": "css",
     "groups": [],
     "comment": {
-      "description": "A link to download a file with malicious warning",
+      "description": "A link to download a file with malicious warning. Uses badrep.exe because content.exe now serves text/html and no longer triggers a download.",
       "location": "testsafebrowsing website"
     }
   },

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 from time import sleep, time
 from typing import Optional
 
@@ -203,13 +202,11 @@ class AboutLogins(BasePage):
         else:
             assert expected_logins == actual_logins
 
-    def remove_password_csv(self, downloads_dir):
-        # Delete password.csv, if there is one in the export location
-        passwords_csv = os.path.join(downloads_dir, "passwords.csv")
-        for file in os.listdir(downloads_dir):
-            delete_files_regex = re.compile(r"\bpasswords.csv\b")
-            if delete_files_regex.match(file):
-                os.remove(passwords_csv)
+    def remove_password_csv(self, downloads_dir, filename: str = "passwords.csv"):
+        # Delete the exported CSV, if there is one in the export location
+        passwords_csv = os.path.join(downloads_dir, filename)
+        if os.path.exists(passwords_csv):
+            os.remove(passwords_csv)
 
     def verify_csv_export(
         self, downloads_folder: str, filename: str, timeout: int = 20

--- a/tests/downloads/test_download_pdf.py
+++ b/tests/downloads/test_download_pdf.py
@@ -16,7 +16,6 @@ def delete_files_regex_string():
     return r".*i-9.pdf"
 
 
-@pytest.mark.headed
 def test_download_pdf(
     driver: Firefox,
     fillable_pdf_url: str,

--- a/tests/downloads/test_download_pdf.py
+++ b/tests/downloads/test_download_pdf.py
@@ -13,7 +13,7 @@ def test_case():
 
 @pytest.fixture()
 def delete_files_regex_string():
-    return r".*i-9.pdf"
+    return r".*i-9-downloads\.pdf"
 
 
 def test_download_pdf(
@@ -35,7 +35,7 @@ def test_download_pdf(
     """
 
     # Set the expected download path and the expected PDF name
-    file_name = "i-9.pdf"
+    file_name = "i-9-downloads.pdf"
     saved_pdf_location = os.path.join(downloads_folder, file_name)
 
     # Initialize objects

--- a/tests/downloads/test_download_pdf_from_context_menu.py
+++ b/tests/downloads/test_download_pdf_from_context_menu.py
@@ -22,7 +22,6 @@ def delete_files_regex_string():
 PDF_TELEMETRY_DATA = ["downloads", "added", "fileExtension", "pdf"]
 
 
-@pytest.mark.headed
 def test_download_pdf_from_context_menu(
     driver: Firefox,
     fillable_pdf_url: str,

--- a/tests/downloads/test_download_pdf_from_context_menu.py
+++ b/tests/downloads/test_download_pdf_from_context_menu.py
@@ -16,7 +16,7 @@ def test_case():
 
 @pytest.fixture()
 def delete_files_regex_string():
-    return r".*i-9.pdf"
+    return r".*i-9-context-menu\.pdf"
 
 
 PDF_TELEMETRY_DATA = ["downloads", "added", "fileExtension", "pdf"]
@@ -41,7 +41,7 @@ def test_download_pdf_from_context_menu(
     """
 
     # Set the expected download path and the expected PDF name
-    file_name = "i-9.pdf"
+    file_name = "i-9-context-menu.pdf"
     saved_pdf_location = os.path.join(downloads_folder, file_name)
 
     # Initialize objects

--- a/tests/password_manager/test_password_csv_correctness.py
+++ b/tests/password_manager/test_password_csv_correctness.py
@@ -21,8 +21,6 @@ def add_to_prefs_list():
     return [("signon.management.page.os-auth.locked.enabled", False)]
 
 
-@pytest.mark.headed
-@pytest.mark.noxvfb
 def test_password_csv_correctness(
     driver_and_saved_logins, downloads_folder, sys_platform
 ):

--- a/tests/password_manager/test_password_csv_correctness.py
+++ b/tests/password_manager/test_password_csv_correctness.py
@@ -6,7 +6,7 @@ import pytest
 
 from modules.page_object import AboutLogins
 
-PASSWORDS_FILE = "passwords.csv"
+PASSWORDS_FILE = "passwords_correctness.csv"
 
 
 @pytest.fixture()
@@ -31,14 +31,14 @@ def test_password_csv_correctness(
     (driver, usernames, logins) = driver_and_saved_logins
     about_logins = AboutLogins(driver)
 
-    # Ensure the export target folder doesn't contain a passwords.csv file
-    about_logins.remove_password_csv(downloads_folder)
+    # Ensure the export target folder doesn't contain the exported CSV yet
+    about_logins.remove_password_csv(downloads_folder, PASSWORDS_FILE)
 
     # Export the passwords CSV
-    about_logins.export_passwords_csv(downloads_folder, "passwords.csv")
+    about_logins.export_passwords_csv(downloads_folder, PASSWORDS_FILE)
 
     # Verify the exported csv file is present in the target folder
-    csv_file = about_logins.verify_csv_export(downloads_folder, "passwords.csv")
+    csv_file = about_logins.verify_csv_export(downloads_folder, PASSWORDS_FILE)
     assert os.path.exists(csv_file)
 
     # Verify the contents of the exported csv file
@@ -59,5 +59,5 @@ def test_password_csv_correctness(
         assert "formActionOrigin" in row.keys()
     about_logins.check_logins_present(actual_logins, logins)
 
-    # Delete the password.csv created
-    about_logins.remove_password_csv(downloads_folder)
+    # Delete the exported CSV
+    about_logins.remove_password_csv(downloads_folder, PASSWORDS_FILE)

--- a/tests/password_manager/test_password_csv_export.py
+++ b/tests/password_manager/test_password_csv_export.py
@@ -19,8 +19,6 @@ def add_to_prefs_list():
     return [("signon.management.page.os-auth.locked.enabled", False)]
 
 
-@pytest.mark.headed
-@pytest.mark.noxvfb
 def test_password_csv_export(driver_and_saved_logins, downloads_folder, opt_ci):
     """
     C2241521: Verify that a password.csv file can be exported from about:logins

--- a/tests/password_manager/test_password_csv_export.py
+++ b/tests/password_manager/test_password_csv_export.py
@@ -4,7 +4,7 @@ import pytest
 
 from modules.page_object import AboutLogins
 
-PASSWORDS_FILE = "passwords.csv"
+PASSWORDS_FILE = "passwords_export.csv"
 
 
 @pytest.fixture()
@@ -27,15 +27,15 @@ def test_password_csv_export(driver_and_saved_logins, downloads_folder, opt_ci):
     (driver, usernames, logins) = driver_and_saved_logins
     about_logins = AboutLogins(driver)
 
-    # Ensure the export target folder doesn't contain a passwords.csv file
-    about_logins.remove_password_csv(downloads_folder)
+    # Ensure the export target folder doesn't contain the exported CSV yet
+    about_logins.remove_password_csv(downloads_folder, PASSWORDS_FILE)
 
     # Export the passwords CSV
-    about_logins.export_passwords_csv(downloads_folder, "passwords.csv")
+    about_logins.export_passwords_csv(downloads_folder, PASSWORDS_FILE)
 
     # Verify the exported csv file is present in the target folder
-    csv_file = about_logins.verify_csv_export(downloads_folder, "passwords.csv")
+    csv_file = about_logins.verify_csv_export(downloads_folder, PASSWORDS_FILE)
     assert os.path.exists(csv_file)
 
-    # Delete the password.csv created
-    about_logins.remove_password_csv(downloads_folder)
+    # Delete the exported CSV
+    about_logins.remove_password_csv(downloads_folder, PASSWORDS_FILE)

--- a/tests/pdf_viewer/test_pdf_download.py
+++ b/tests/pdf_viewer/test_pdf_download.py
@@ -34,7 +34,6 @@ def test_pdf_download(
     downloads_folder: str,
     sys_platform,
     delete_files,
-    file_name,
     delete_files_regex_string,
 ):
     """
@@ -46,7 +45,6 @@ def test_pdf_download(
         pdf_viewer: Fixture returning instance of GenericPdf with correct path.
         downloads_folder: Fixture returning downloads folder path
         delete_files: Fixture to remove the files after the test finishes
-        file_name: pdf file name
     """
 
     saved_pdf_location = os.path.join(downloads_folder, DOWNLOADED_PDF_NAME)

--- a/tests/pdf_viewer/test_pdf_download.py
+++ b/tests/pdf_viewer/test_pdf_download.py
@@ -25,7 +25,6 @@ def file_name():
     return PDF_FILE_NAME
 
 
-@pytest.mark.headed
 def test_pdf_download(
     driver: Firefox,
     pdf_viewer: GenericPdf,

--- a/tests/pdf_viewer/test_pdf_download.py
+++ b/tests/pdf_viewer/test_pdf_download.py
@@ -6,8 +6,11 @@ from selenium.webdriver import Firefox
 
 from modules.page_object import GenericPdf
 
+# Source PDF in data/ opened by the viewer; the saved copy uses a unique name
+# so this test can run in parallel without colliding with other PDF downloads.
 PDF_FILE_NAME = "i-9.pdf"
-DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
+DOWNLOADED_PDF_NAME = "i-9-viewer.pdf"
+DOWNLOADED_PDF_REGEX = r"i-9-viewer\.pdf"
 
 
 @pytest.fixture()
@@ -46,7 +49,7 @@ def test_pdf_download(
         file_name: pdf file name
     """
 
-    saved_pdf_location = os.path.join(downloads_folder, file_name)
+    saved_pdf_location = os.path.join(downloads_folder, DOWNLOADED_PDF_NAME)
 
     # Mock the native Save As picker so the download runs headlessly on all
     # platforms (driving the OS file dialog is unreliable in CI).
@@ -66,6 +69,6 @@ def test_pdf_download(
     )
 
     logging.info(
-        f"Test passed: The file {file_name} has been"
+        f"Test passed: The file {DOWNLOADED_PDF_NAME} has been"
         f" downloaded and is present at {saved_pdf_location}."
     )

--- a/tests/printing_ui/conftest.py
+++ b/tests/printing_ui/conftest.py
@@ -1,6 +1,29 @@
+import os
+import time
+
 import pytest
 
 from modules.browser_object import PrintPreview
+
+DOWNLOAD_TIMEOUT_SEC = 10.0
+POLL_INTERVAL_SEC = 0.5
+
+
+@pytest.fixture()
+def wait_for_file_download():
+    """Return a helper that blocks until a file finishes downloading."""
+
+    def _wait_for_file_download(
+        file_path, timeout=DOWNLOAD_TIMEOUT_SEC, interval=POLL_INTERVAL_SEC
+    ) -> bool:
+        start = time.time()
+        while time.time() - start < timeout:
+            if os.path.exists(file_path):
+                return True
+            time.sleep(interval)
+        return False
+
+    return _wait_for_file_download
 
 
 @pytest.fixture()

--- a/tests/printing_ui/test_print_to_pdf.py
+++ b/tests/printing_ui/test_print_to_pdf.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import pytest
 from selenium.webdriver import Firefox
@@ -29,20 +28,12 @@ TEST_PAGE = "https://example.com"
 DEFAULT_NAME = "Example Domain.pdf"
 
 
-def wait_for_file_download(file_path, timeout=10, interval=0.5) -> bool:
-    start = time.time()
-    while time.time() - start < timeout:
-        if os.path.exists(file_path):
-            return True
-        time.sleep(interval)
-    return False
-
-
 def test_print_to_pdf(
     driver: Firefox,
     downloads_folder: str,
     delete_files,
     print_preview: PrintPreview,
+    wait_for_file_download,
 ):
     """
     C965142 - Verify that the user can print a webpage to PDF

--- a/tests/printing_ui/test_print_to_pdf.py
+++ b/tests/printing_ui/test_print_to_pdf.py
@@ -1,5 +1,5 @@
-import logging
 import os
+import time
 
 import pytest
 from selenium.webdriver import Firefox
@@ -22,7 +22,6 @@ def add_to_prefs_list():
     return [
         ("print_printer", "Mozilla Save to PDF"),
         ("print.save_print_settings", False),
-        ("print.print_to_file", True),
     ]
 
 
@@ -30,37 +29,45 @@ TEST_PAGE = "https://example.com"
 DEFAULT_NAME = "Example Domain.pdf"
 
 
-def file_is_somewhere():
-    locs = [
-        os.getcwd(),
-        os.path.join(os.path.expanduser("~"), "Documents"),
-        os.path.join(os.path.expanduser("~"), "Downloads"),
-    ]
-    for loc in locs:
-        for _, _, files in os.walk(loc):
-            if DEFAULT_NAME in files:
-                logging.warning(f"File found in {loc}")
-                return True
+def wait_for_file_download(file_path, timeout=10, interval=0.5) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        if os.path.exists(file_path):
+            return True
+        time.sleep(interval)
     return False
 
 
-# Test is unstable in Windows GHA and Linux Taskcluster for now: Bug 1974011
-@pytest.mark.headed
 def test_print_to_pdf(
     driver: Firefox,
     downloads_folder: str,
-    sys_platform,
     delete_files,
     print_preview: PrintPreview,
 ):
     """
     C965142 - Verify that the user can print a webpage to PDF
+
+    Notes:
+        - The native "Save" picker is mocked on all platforms so the print-to-PDF
+          save runs headlessly in CI. Driving the OS file dialog is unreliable
+          there (Linux Wayland cannot drive GTK pickers through desktop input,
+          and Windows image-matching depends on the CI resolution/DPI/theme).
     """
+    saved_pdf_location = os.path.join(downloads_folder, DEFAULT_NAME)
 
     driver.get(TEST_PAGE)
 
-    # Select Print option from Hamburger Menu in order to trigger the silent printing
+    # Open Print via the Hamburger Menu; destination defaults to Save to PDF
     print_preview.open_and_load_print_from_panelui()
-    print_preview.start_print()
 
-    print_preview.expect(lambda _: file_is_somewhere())
+    # Replace the native save dialog with a mock that returns our target path
+    print_preview.install_mock_file_picker(saved_pdf_location)
+    try:
+        print_preview.click_primary_button()
+        print_preview.wait_for_mock_file_picker()
+    finally:
+        print_preview.cleanup_mock_file_picker()
+
+    assert wait_for_file_download(saved_pdf_location), (
+        f"File not found: {saved_pdf_location}"
+    )


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1974011

#### Description of Code / Doc Changes
  - Re-enable test_print_to_pdf via mock file picker: click the "Save" primary             
    button through the print browser's contentDocument (frame-switch can't enter           
    the XUL printSettingsBrowser) and capture the save path with the picker mock           
  - Replace pyautogui/native-dialog flow: PrintPreview.click_primary_button()              
    supersedes start_print/switch_to_preview_window; assert PDF at a known path            
  - key.yaml: test_print_to_pdf unstable -> pass                                           
  - Remove @pytest.mark.headed from mock-picker tests that no longer drive the             
    desktop (download_pdf, download_pdf_from_context_menu, pdf_download,                   
    password_csv_export, password_csv_correctness)                                         
  - Also drop @pytest.mark.noxvfb from the two password CSV tests (no pyautogui            
    left in their path); all verified passing headless
  - Unique output filenames for the five file-writing tests (+ remove_password_csv         
  parameterized) so they're safe in the -n auto parallel lane

#### Workflow Checklist
- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.

Thank you!