### PR TITLE
Anca/ Fix mis-nested glean test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -605,15 +605,16 @@ glean:
       result: pass
       splits:
       - glean
+  serp_engagement:
+    test_serp_engagement:
+      result: pass
+      splits:
+      - glean
   serp_impression:
     test_serp_impression:
       result: pass
       splits:
       - glean
-  test_serp_engagement:
-    result: pass
-    splits:
-    - glean
 language_packs:
   test_language_pack_install_addons:
     result: pass


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: N/A

### Description of Code / Doc Changes

- Fixed the mis-nested test_serp_engagement entry in key.yaml (originally added automatically): moved it under a serp_engagement: folder key so it matches its file path and its sibling glean suites, since the incorrect nesting is now causing errors.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
