### PR TITLE
Anca/ Fix PB dismiss doorhanger credentials and navigation to about:logins from autocomplete tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -878,8 +878,7 @@ password_manager:
     splits:
     - functional2
   test_navigation_to_about_logins_from_autocomplete:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2055602
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_never_save_login_via_doorhanger:
@@ -940,8 +939,7 @@ password_manager:
     splits:
     - functional2
   test_private_browsing_dismiss_doorhanger_credentials:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2055603
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_save_login_via_doorhanger:

--- a/modules/data/autofill_popup.components.json
+++ b/modules/data/autofill_popup.components.json
@@ -275,7 +275,7 @@
     }
   },
   "manage-passwords": {
-    "selectorData": "richlistitem.autocomplete-richlistitem[ac-value='Manage Passwords']",
+    "selectorData": "#PopupAutoComplete richlistitem[originaltype='loginsFooter']",
     "strategy": "css",
     "groups": [],
     "comment": {

--- a/modules/data/login_autofill.components.json
+++ b/modules/data/login_autofill.components.json
@@ -104,7 +104,7 @@
     }
   },
   "mozilla-github-credentials": {
-    "selectorData": "richlistitem.autocomplete-richlistitem[ac-value='testUser']",
+    "selectorData": "#PopupAutoComplete richlistitem[originaltype='loginWithOrigin']",
     "strategy": "css",
     "groups": [],
     "comment": {


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2055602](https://bugzilla.mozilla.org/show_bug.cgi?id=2055602), [2055603](https://bugzilla.mozilla.org/show_bug.cgi?id=2055603) 
TestRail: N/A

### Description of Code / Doc Changes

- Update selectors
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
