### PR TITLE
Tracy/fix bug 2056526

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -12,8 +12,7 @@ address_bar_and_search:
     splits:
     - smoke
   test_added_open_search_engine_default:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2056526
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_addon_suggestion:
@@ -141,8 +140,7 @@ address_bar_and_search:
     splits:
     - functional1
   test_search_mode_exits_correctly:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2056526
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_search_mode_persists_mixed_with_bing:
@@ -915,7 +913,9 @@ password_manager:
     splits:
     - functional2
   test_password_manager_on_google_US:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2056524, mac was unstable before this issue was filed, no comment on the reason, keet this in mind when reverting the status
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2056524, mac was unstable
+      before this issue was filed, no comment on the reason, keep this in mind when
+      reverting the status
     result:
       linux: unstable
       mac: unstable

--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -312,8 +312,28 @@ class Navigation(BasePage):
 
     @BasePage.context_chrome
     def click_search_mode_switcher(self) -> BasePage:
+        """Open the Unified Search Button (USB) popup.
+
+        The switcher is a toolbar button that toggles the search-mode
+        panel-list. When clicked right after typing in the urlbar, the first
+        click is occasionally swallowed while the urlbar is still settling, so
+        the popup never opens and callers time out waiting for an engine
+        option. Re-click until the popup is actually open, checking its state
+        first each poll so an already-open popup is never toggled shut.
+        """
         self.element_visible("searchmode-switcher")
-        self.click_on("searchmode-switcher")
+
+        def _popup_open() -> bool:
+            popups = self.get_elements("legacy-searchbar-switcher-popup")
+            return bool(popups) and popups[0].is_displayed()
+
+        def _open_popup(_) -> bool:
+            if _popup_open():
+                return True
+            self.click_on("searchmode-switcher")
+            return _popup_open()
+
+        self.expect(_open_popup)
         return self
 
     @BasePage.context_chrome

--- a/tests/address_bar_and_search/test_added_open_search_engine_default.py
+++ b/tests/address_bar_and_search/test_added_open_search_engine_default.py
@@ -38,7 +38,7 @@ def test_added_open_search_engine_default(driver: Firefox, engine):
     # "Add + name_of_search_engine"
     nav.add_search_mode(engine)
 
-    # Open in a new tab about:preferences#search
+    # Open about:preferences#search in a new tab
     prefs.open()
 
     # Set the newly added engine as a default engine.


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2056526

### Description of Code / Doc Changes
Fixes:
- tests/address_bar_and_search/test_search_mode_exits_correctly.py
- tests/address_bar_and_search/test_added_open_search_engine_default.py

Confirm search-mode switcher popup opened before interacting (bug 2056526)                                    
-   click_search_mode_switcher now confirms the USM popup actually opened and                                     
-   re-clicks if the first click was swallowed while the urlbar was still                                         
-   settling. Re-enable test_search_mode_exits_correctly and                                                      
-   test_added_open_search_engine_default (unstable -> pass).

### Process Changes Required
- [X] Changes or creates a BOM/POM (name the object model): _

### Workflow Checklist
- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.

Thank you!