### PR TITLE
Tracy/Fix flaky lang pack test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1113,8 +1113,7 @@ preferences:
     splits:
     - functional2
   test_lang_pack_changed_from_about_prefs:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2056529
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_manage_cookie_data:

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -212,8 +212,20 @@ class AboutPrefs(BasePage):
     def set_alternative_language(self, lang_code: str) -> BasePage:
         """Sets the browser language via the Preferred language moz-select.
 
-        Firefox applies the locale live once the dropdown value changes.
+        The available-languages list is hydrated asynchronously — Firefox
+        appends the installable locales fetched from a remote source after the
+        pane opens — so the target option may be missing the instant we look.
+        Wait for it before selecting. Firefox applies the locale live once the
+        dropdown value changes.
         """
+        self.wait.until(
+            lambda _: any(
+                opt.get_attribute("value") == lang_code
+                for opt in self.get_element(
+                    "browser-language-preferred-select"
+                ).find_elements(By.TAG_NAME, "option")
+            )
+        )
         Select(self.get_element("browser-language-preferred-select")).select_by_value(
             lang_code
         )


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2056529

#### Description of Code / Doc Changes
Fix flaky lang pack test: wait for locale option before selecting
- set_alternative_language selected the target locale immediately, but Firefox appends the installable-locale list to the language <select> asynchronously.                                  
- On CI the option was occasionally absent, raising NoSuchElementException. Wait for the option to appear before selecting, mirroring the select_doh_provider guard. 
- Re-enable test_lang_pack_changed_from_about_prefs (unstable -> pass).                                  

Co-Authored-By: Claude Opus 4.8

#### Process Changes Required
- [X] Changes or creates a BOM/POM (name the object model): _

#### Workflow Checklist
- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.

Thank you!
