### PR TITLE
Tracy/ Adapt l10n_CM tests to Firefox 154 autofill/preferences redesigns

### DIFF
--- a/l10n_CM/Unified/test_demo_ad_2a_preview_name_org_fields.py
+++ b/l10n_CM/Unified/test_demo_ad_2a_preview_name_org_fields.py
@@ -25,10 +25,7 @@ def test_demo_ad_hover_name_org(
     # scroll to first form field
     address_autofill.scroll_to_form_field()
 
-    # created fake data
-    autofill_data = fill_and_save_address
-
     # Hover over each field and check data preview
     fields_to_test = ["name", "given_name", "family_name", "organization"]
     for field in fields_to_test:
-        address_autofill.check_autofill_preview_for_field(field, autofill_data, region)
+        address_autofill.check_autofill_preview_for_field(field, region)

--- a/l10n_CM/Unified/test_demo_ad_2b_preview_address_fields.py
+++ b/l10n_CM/Unified/test_demo_ad_2b_preview_address_fields.py
@@ -35,9 +35,6 @@ def test_hover_address_is_previewed(
     # scroll to first form field
     address_autofill.scroll_to_form_field()
 
-    # created fake data
-    autofill_data = fill_and_save_address
-
     # Hover over each field and check data preview
     fields_to_test = [
         "street_address",
@@ -47,4 +44,4 @@ def test_hover_address_is_previewed(
         "country_code",
     ]
     for field in fields_to_test:
-        address_autofill.check_autofill_preview_for_field(field, autofill_data, region)
+        address_autofill.check_autofill_preview_for_field(field, region)

--- a/l10n_CM/Unified/test_demo_ad_2c_preview_phone_email_fields.py
+++ b/l10n_CM/Unified/test_demo_ad_2c_preview_phone_email_fields.py
@@ -27,10 +27,7 @@ def test_hover_email_and_phone_autofill_preview(
     # scroll to first form field
     address_autofill.scroll_to_form_field()
 
-    # created fake data
-    autofill_data = fill_and_save_address
-
     # Hover over each field and check data preview
     fields_to_test = ["email", "telephone"]
     for field in fields_to_test:
-        address_autofill.check_autofill_preview_for_field(field, autofill_data, region)
+        address_autofill.check_autofill_preview_for_field(field, region)

--- a/l10n_CM/Unified/test_demo_ad_7a_capture_doorhanger_stored_data_name_org_fields.py
+++ b/l10n_CM/Unified/test_demo_ad_7a_capture_doorhanger_stored_data_name_org_fields.py
@@ -52,17 +52,20 @@ def test_demo_ad_name_org_captured_in_doorhanger_and_stored(
         about_prefs_privacy.open()
         about_prefs_privacy.open_and_switch_to_saved_addresses_popup()
 
-        # Get the first saved address profile
-        saved_address_profiles = about_prefs_privacy.get_all_saved_address_profiles()
-        assert saved_address_profiles, "No saved address profiles found"
+        # The Fx 154 saved-address tile only shows a name + address summary, so read
+        # the stored organization field from the address edit view.
+        stored = about_prefs_privacy.get_stored_address_values()
+        assert stored.get("name"), "No saved address profile found"
 
-        saved_address_profile = saved_address_profiles[0].text
-
-        # Verify each field is present in the saved profile
-        missing_fields = []
-        for field_name, field_value in expected_fields.items():
-            if field_value not in saved_address_profile:
-                missing_fields.append(f"{field_name}: {field_value}")
+        expected_stored = {
+            "name": address_autofill_data.name,
+            "organization": address_autofill_data.organization,
+        }
+        missing_fields = [
+            f"{field_id}: {value}"
+            for field_id, value in expected_stored.items()
+            if value not in (stored.get(field_id) or "")
+        ]
 
         assert not missing_fields, (
             f"The following fields were not found in the saved address: {', '.join(missing_fields)}"

--- a/l10n_CM/Unified/test_demo_ad_7c_capture_doorhanger_stored_data_phone_email.py
+++ b/l10n_CM/Unified/test_demo_ad_7c_capture_doorhanger_stored_data_phone_email.py
@@ -53,17 +53,20 @@ def test_demo_ad_email_phone_captured_in_doorhanger_and_stored(
         about_prefs_privacy.open()
         about_prefs_privacy.open_and_switch_to_saved_addresses_popup()
 
-        # Get the first saved address profile
-        saved_address_profiles = about_prefs_privacy.get_all_saved_address_profiles()
-        assert saved_address_profiles, "No saved address profiles found"
+        # The Fx 154 saved-address tile only shows a name + address summary, so read
+        # the stored email/telephone fields from the address edit view.
+        stored = about_prefs_privacy.get_stored_address_values()
+        assert stored.get("name"), "No saved address profile found"
 
-        saved_address_profile = saved_address_profiles[0].text
-
-        # Verify each field is present in the saved profile
-        missing_fields = []
-        for field_name, field_value in expected_fields.items():
-            if field_value not in saved_address_profile:
-                missing_fields.append(f"{field_name}: {field_value}")
+        expected_stored = {
+            "email": address_autofill_data.email,
+            "tel": address_autofill_data.telephone,
+        }
+        missing_fields = [
+            f"{field_id}: {value}"
+            for field_id, value in expected_stored.items()
+            if value not in (stored.get(field_id) or "")
+        ]
 
         assert not missing_fields, (
             f"The following fields were not found in the saved address: {', '.join(missing_fields)}"

--- a/l10n_CM/Unified/test_demo_cc_2_preview.py
+++ b/l10n_CM/Unified/test_demo_cc_2_preview.py
@@ -35,9 +35,6 @@ def test_cc_preview(
     # scroll to first form field
     credit_card_autofill.scroll_to_form_field()
 
-    # fake data
-    credit_card_sample_data = fill_and_save_payments
-
     # Hover over each field and check data preview
     fields_to_test = [
         "name",
@@ -49,8 +46,6 @@ def test_cc_preview(
         "expiration_date",
     ]
     for field in fields_to_test:
-        credit_card_autofill.check_autofill_preview_for_field(
-            field, credit_card_sample_data
-        )
+        credit_card_autofill.check_autofill_preview_for_field(field)
 
     credit_card_autofill.verify_no_dropdown_on_field_interaction("cvv")

--- a/l10n_CM/Unified/test_demo_cc_7_capture_doorhanger_capture_and_stored_data.py
+++ b/l10n_CM/Unified/test_demo_cc_7_capture_doorhanger_capture_and_stored_data.py
@@ -56,20 +56,21 @@ def test_demo_cc_data_captured_in_doorhanger_and_stored(
         about_prefs_privacy.open()
         about_prefs_privacy.open_and_switch_to_saved_payments_popup()
 
-        # Get stored values
-        saved_cc_profiles = about_prefs_privacy.get_all_saved_cc_profiles()
-        assert saved_cc_profiles, "No saved cc profiles found"
-
-        saved_cc_profile = [x.strip() for x in saved_cc_profiles[0].text.split(",")]
+        # The Fx 154 saved-payment tile only shows a masked number + expiry (no
+        # cardholder name), so read the stored values from the payment edit view.
+        stored = about_prefs_privacy.get_stored_payment_values()
+        assert stored.get("cc-number"), "No saved cc profiles found"
 
         # Validate stored values match expected values
-        assert saved_cc_profile[0].endswith(credit_card_sample_data.card_number[-4:]), (
-            f"Expected last 4 digits '{credit_card_sample_data.card_number[-4:]}' but got '{saved_cc_profile[0]}'"
+        assert stored["cc-number"].endswith(credit_card_sample_data.card_number[-4:]), (
+            f"Expected last 4 digits '{credit_card_sample_data.card_number[-4:]}' but got '{stored['cc-number']}'"
         )
-        assert saved_cc_profile[1] == credit_card_sample_data.name, (
-            f"Expected name '{credit_card_sample_data.name}' but got '{saved_cc_profile[1]}'"
+        assert stored["cc-name"] == credit_card_sample_data.name, (
+            f"Expected name '{credit_card_sample_data.name}' but got '{stored['cc-name']}'"
         )
-        assert credit_card_sample_data.cvv not in saved_cc_profile, (
+        assert not any(
+            credit_card_sample_data.cvv in (value or "") for value in stored.values()
+        ), (
             f"CVV '{credit_card_sample_data.cvv}' should not be saved, but found in stored values."
         )
     else:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -535,8 +535,7 @@ form_autofill:
     splits:
     - functional1
   test_create_profile_autofill:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047884
-    result: unstable
+    result: pass
     splits:
     - smoke
   test_delete_cc_profile:

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import List, Optional
 
@@ -465,56 +464,27 @@ class Autofill(BasePage):
             if field_element.tag_name.lower() != "select":
                 assert not value, f"Field '{field_name}' is not empty: Found '{value}'"
 
-    @BasePage.context_chrome
-    def verify_autofill_data_on_hover(
-        self, autofill_data: CreditCardBase | AutofillAddressBase, region: str
-    ):
+    def verify_autofill_data_on_hover(self):
         """
-        Verifies that the autofill preview data matches the expected values when hovering
+        Verify that hovering an autocomplete entry previews the fill on the form.
 
-        Arguments:
-            autofill_data: CreditCardBase | AutofillAddressBase object containing expected fake data.
+        Firefox 154 removed the ``ac-comment`` JSON attribute that exposed the
+        previewed profile, and the previewed values are not readable from the content
+        fields either (``value`` stays empty during preview). The observable signal
+        is that hovering an entry puts the *other* form fields into the ``:autofill``
+        preview state while they are still empty, so assert at least one field is in
+        that state. ``:autofill`` matching has no Selenium API, so it is evaluated
+        with ``matches()`` via ``execute_script`` in the content context (the
+        preceding hover leaves Marionette in the chrome context).
         """
-        # Get preview data from hovering through the chrome context
-        try:
-            # Attempt to parse the string as JSON
-            container = json.loads(
-                self.autofill_popup.get_element("preview-form-container").get_attribute(
-                    "ac-comment"
+        with self.driver.context(self.driver.CONTEXT_CONTENT):
+            self.wait.until(
+                lambda _: self.driver.execute_script(
+                    "return [...document.querySelectorAll('input, textarea')]"
+                    ".some(e => e.matches(':autofill') && !e.value);"
                 )
             )
-        except json.JSONDecodeError:
-            # If parsing fails, raise ValueError.
-            raise ValueError("Given preview data is incomplete.")
-        container_data = container.get("fillMessageData", {}).get("profile", {})
-        assert container_data, "No preview data available."
-        assert all(field in container_data.keys() for field in self.preview_fields), (
-            "Not all fields present in preview data."
-        )
-
-        # sanitize data
-        if autofill_data.__class__ == CreditCardBase:
-            autofill_data.card_number = autofill_data.card_number[-4:]
-        else:
-            if autofill_data.country_code in {"US", "CA"} and (
-                len(container_data["address-level1"]) == 2
-                and len(autofill_data.address_level_1) > 2
-            ):
-                autofill_data.address_level_1 = (
-                    self.util.get_state_province_abbreviation(
-                        autofill_data.address_level_1
-                    )
-                )
-        for field, value in container_data.items():
-            if field in self.preview_fields:
-                value = self.sanitize_preview_data(field, str(value), region)
-                # Check if this value exists in our CreditCardBase | AutofillAddressBase object
-                is_present = any(
-                    [value in val for val in autofill_data.__dict__.values()]
-                )
-                assert is_present, (
-                    f"Mismatched data: {(field, value)} not in {autofill_data.__dict__.values()}."
-                )
+        return self
 
     def sanitize_preview_data(self, field, value, region):
         if field == "cc-number":
@@ -610,8 +580,11 @@ class Autofill(BasePage):
                 self.double_click("form-field", labels=[field])
                 self.autofill_popup.ensure_autofill_dropdown_visible()
                 self.autofill_popup.hover_over_autofill_panel()
-                self.verify_autofill_data_on_hover(sample_data, region)
-                self.click_on("form-field", labels=[field])
+                self.verify_autofill_data_on_hover()
+                # Dismiss the dropdown WITHOUT committing the fill: once a form is
+                # autofilled, Firefox 154 suppresses further previews, which would
+                # break the preview check for the remaining fields.
+                autofill_field.send_keys(Keys.ESCAPE)
             else:
                 logging.info(
                     f"Field: {field_label} is a select element. No autofill option."

--- a/modules/page_object_autofill.py
+++ b/modules/page_object_autofill.py
@@ -48,24 +48,6 @@ base_address_fields = [
     "tel",
 ]
 
-# Preview field mappings
-base_preview_address_mapping = {
-    "family_name": "family-name",
-    "given_name": "given-name",
-    "street_address": "street-address",
-    "address_level_2": "address-level2",
-    "address_level_1": "address-level1",
-    "postal_code": "postal-code",
-    "country_code": "country",
-    "telephone": "tel",
-}
-base_preview_cc_mapping = {
-    "name": "cc-name",
-    "card_number": "cc-number",
-    "expiration_month": "cc-exp-month",
-    "expiration_year": "cc-exp-year",
-}
-
 
 class Autofill(BasePage):
     """
@@ -76,7 +58,6 @@ class Autofill(BasePage):
     # Default; subclasses will override
     field_mapping = {}
     fields = {}
-    preview_fields = {}
 
     URL_TEMPLATE = "https://mozilla.github.io/form-fill-examples/"
 
@@ -486,15 +467,6 @@ class Autofill(BasePage):
             )
         return self
 
-    def sanitize_preview_data(self, field, value, region):
-        if field == "cc-number":
-            value = value[-4:]
-        elif field == "cc-exp-year":
-            value = value[-2:]
-        elif field == "tel" or value[0] == "+":
-            value = self.util.normalize_regional_phone_numbers(value, region)
-        return value
-
     def select_autofill_option(self, field):
         """
         Presses the autofill panel that pops up after you double-click an input field
@@ -555,7 +527,6 @@ class Autofill(BasePage):
     def check_autofill_preview_for_field(
         self,
         field_label: str,
-        sample_data: CreditCardBase | AutofillAddressBase,
         region: str = None,
     ):
         """
@@ -563,8 +534,7 @@ class Autofill(BasePage):
 
         Arguments:
             field_label: field name.
-            sample_data: autofill sample data.
-            region: region being tested.
+            region: region being tested (used to skip address-level1 outside US/CA).
         """
         if (
             self.__class__ == AddressFill
@@ -707,12 +677,6 @@ class AddressFill(Autofill):
             field_mapping if field_mapping else base_address_field_mapping
         )
         self.fields = fields if fields else base_address_fields
-        self.preview_fields = set(
-            map(
-                lambda field: base_preview_address_mapping.get(field, field),
-                self.field_mapping.keys(),
-            )
-        )
         self.URL_TEMPLATE = url_template if url_template else BASE_ADDRESS_URL_TEMPLATE
 
 
@@ -733,15 +697,6 @@ class CreditCardFill(Autofill):
         super().__init__(driver, **kwargs)
         self.field_mapping = field_mapping if field_mapping else base_cc_field_mapping
         self.fields = fields if fields else base_cc_fields
-        self.preview_fields = set(
-            map(
-                lambda field: base_preview_cc_mapping.get(field),
-                self.field_mapping.keys(),
-            )
-        )
-        self.preview_fields = {
-            field for field in self.preview_fields if field is not None
-        }
         self.URL_TEMPLATE = url_template if url_template else BASE_CC_URL_TEMPLATE
 
 

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -2,6 +2,7 @@ import json
 from time import sleep
 from typing import List, Literal
 
+from selenium.common.exceptions import NoSuchElementException, WebDriverException
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -617,33 +618,67 @@ class AboutPrefs(BasePage):
 
     def open_and_switch_to_saved_payments_popup(self) -> BasePage:
         """
-        Open and Switch to saved payments popup frame.
+        Reveal the Saved Payment Methods management list.
+
+        Firefox 154 renders this list inline in about:preferences#privacy (default
+        frame) instead of in a dialog iframe, so click its moz-box-button to expand
+        the list and stay in the default frame — there is no frame to switch into.
+        The button's interactable target is a <button> in its shadow DOM whose host
+        has no clickable rect, so use a JS click.
         """
-        saved_payments_iframe = self.get_saved_payments_popup_iframe()
-        self.driver.switch_to.frame(saved_payments_iframe)
+        self.js_click_on("saved-payments-button")
         return self
 
     def _moz_field_inner(self, host: WebElement) -> WebElement:
         """
         Return the editable inner node of an about:preferences form field.
 
-        Firefox 154 wraps the Saved Payment Methods dialog fields in ``moz-input-text``
-        and ``moz-select`` custom elements whose real ``<input>``/``<select>`` lives in
-        the shadow DOM (Marionette cannot serialize a ShadowRoot, so reach the inner
-        node with ``execute_script``). Falls back to the host for plain form fields.
+        Firefox 154 wraps the Saved Payment Methods and Saved Addresses dialog fields
+        in ``moz-input-text``, ``moz-textarea`` and ``moz-select`` custom elements whose
+        real ``<input>``/``<textarea>``/``<select>`` lives in the shadow DOM (Marionette
+        cannot serialize a ShadowRoot, so reach the inner node with ``execute_script``).
+        Falls back to the host for plain form fields.
         """
         inner = self.driver.execute_script(
             "return arguments[0].shadowRoot"
-            " ? arguments[0].shadowRoot.querySelector('input, select')"
+            " ? arguments[0].shadowRoot.querySelector('input, select, textarea')"
             " : arguments[0];",
             host,
         )
         if inner is None:
             raise RuntimeError(
-                "No inner <input>/<select> found in the shadow root of "
+                "No inner <input>/<select>/<textarea> found in the shadow root of "
                 f"{host.get_attribute('id') or host.tag_name!r}"
             )
         return inner
+
+    def _select_moz_option(self, select_el: WebElement, value: str) -> None:
+        """Select an ``<option>`` inside a ``moz-select`` shadow DOM by value, or by
+        normalized visible text as a fallback.
+
+        The moz-select option values are region codes (e.g. ``WV``) while sample data
+        may carry the full name (``West Virginia``). ``Select.select_by_visible_text``
+        can't be used here because it queries by XPath, which does not descend into the
+        shadow ``<select>``.
+
+        Match in a single pass over the options and re-select by the matched value.
+        Do NOT probe with ``select_by_value(value)`` first: when the value is absent
+        (the usual full-name-vs-code case) its underlying ``find_elements`` blocks for
+        the entire implicit-wait timeout (10s locally, 30s in CI) before returning
+        empty. Iterating ``select.options`` returns a non-empty list immediately, so
+        the only ``select_by_value`` we issue is one we know will hit.
+        """
+        select = Select(select_el)
+        target = value.strip().casefold()
+        for option in select.options:
+            opt_value = option.get_attribute("value")
+            opt_text = (option.get_attribute("textContent") or "").strip()
+            if opt_value == value or opt_text.casefold() == target:
+                select.select_by_value(opt_value)
+                return
+        raise NoSuchElementException(
+            f"No <option> matching value or visible text {value!r}"
+        )
 
     def _set_cc_panel_field(self, field_id: str, value: str | int) -> None:
         """
@@ -740,10 +775,15 @@ class AboutPrefs(BasePage):
 
     def open_and_switch_to_saved_addresses_popup(self) -> BasePage:
         """
-        Open and Switch to saved addresses popup frame.
+        Reveal the Saved Addresses management list.
+
+        Firefox 154 renders this list inline in about:preferences#privacy (default
+        frame) instead of in a dialog iframe, so click its moz-box-button to expand
+        the list and stay in the default frame — there is no frame to switch into.
+        The button's interactable target is a <button> in its shadow DOM whose host
+        has no clickable rect, so use a JS click.
         """
-        saved_address_iframe = self.get_saved_addresses_popup_iframe()
-        self.driver.switch_to.frame(saved_address_iframe)
+        self.js_click_on("saved-addresses-button")
         return self
 
     def add_entry_to_saved_addresses(self, address_data: AutofillAddressBase):
@@ -782,6 +822,87 @@ class AboutPrefs(BasePage):
         json_out = {"name": tile.get_attribute("label")}
         json_out["address"] = tile.get_attribute("description")
         return json_out
+
+    # Field ids of the Saved Addresses add/edit dialog form.
+    _ADDRESS_EDIT_FIELD_IDS = (
+        "name",
+        "organization",
+        "street-address",
+        "address-level2",
+        "address-level1",
+        "postal-code",
+        "tel",
+        "email",
+    )
+
+    def _read_saved_entry_edit_fields(
+        self, edit_ref: str, field_ids, idx: int = 0
+    ) -> dict:
+        """Open a saved entry's edit dialog and read its form field values.
+
+        Firefox 154 renders these edit forms in an about:preferences subdialog iframe
+        that appears a beat after the (moz-button, no clickable rect) edit control is
+        JS-clicked; several ``dialogFrame`` iframes coexist, so switch by locating the
+        one that actually contains the form (identified by the first field id) rather
+        than by a fixed index. Returns the moz-input/moz-select/moz-textarea values
+        keyed by field id.
+        """
+        probe_field_id = field_ids[0]
+        edit_buttons = self.get_elements(edit_ref)
+        self.driver.execute_script("arguments[0].click();", edit_buttons[idx])
+
+        def _entered_edit_frame(_):
+            self.switch_to_default_frame()
+            for frame in self.get_elements("browser-popup"):
+                try:
+                    self.driver.switch_to.frame(frame)
+                except WebDriverException:
+                    self.switch_to_default_frame()
+                    continue
+                if self.driver.execute_script(
+                    "return !!document.getElementById(arguments[0]);", probe_field_id
+                ):
+                    return True
+                self.switch_to_default_frame()
+            return False
+
+        self.wait.until(_entered_edit_frame)
+        values = {}
+        for field_id in field_ids:
+            try:
+                inner = self._moz_field_inner(self.find_element(By.ID, field_id))
+                values[field_id] = inner.get_attribute("value")
+            except (NoSuchElementException, RuntimeError):
+                values[field_id] = None
+        self.switch_to_default_frame()
+        return values
+
+    def get_stored_address_values(self, idx=0) -> dict:
+        """Read a saved address's field values from its edit dialog.
+
+        Firefox 154's saved-address tile shows only a name + address summary, so
+        fields such as organization, tel and email are not on the tile and must be
+        read from the edit view. Assumes the Saved Addresses management list is
+        already revealed (see :meth:`open_and_switch_to_saved_addresses_popup`).
+        """
+        return self._read_saved_entry_edit_fields(
+            "edit-address", self._ADDRESS_EDIT_FIELD_IDS, idx
+        )
+
+    # Field ids of the Saved Payment Methods add/edit dialog form.
+    _PAYMENT_EDIT_FIELD_IDS = ("cc-number", "cc-name", "cc-exp-month", "cc-exp-year")
+
+    def get_stored_payment_values(self, idx=0) -> dict:
+        """Read a saved payment's field values from its edit dialog.
+
+        Firefox 154's saved-payment tile shows only a masked card number and expiry
+        (no cardholder name), so the name and the full card number must be read from
+        the edit view. Assumes the Saved Payment Methods management list is already
+        revealed (see :meth:`open_and_switch_to_saved_payments_popup`).
+        """
+        return self._read_saved_entry_edit_fields(
+            "edit-payment", self._PAYMENT_EDIT_FIELD_IDS, idx
+        )
 
     def get_data_from_saved_payment(self, idx=0) -> dict:
         """Get data-l10n-args from the saved payment card"""
@@ -877,14 +998,6 @@ class AboutPrefs(BasePage):
         )
 
     # UI Navigation and Iframe Handling
-    def get_saved_payments_popup_iframe(self) -> WebElement:
-        """
-        Returns the iframe object for the dialog panel in the popup
-        """
-        self.click_on("saved-payments-button")
-        iframe = self.get_element("browser-popup")
-        return iframe
-
     def switch_to_edit_saved_payments_popup_iframe(self) -> BasePage:
         """
         Switch to form iframe to edit saved payments.
@@ -913,14 +1026,6 @@ class AboutPrefs(BasePage):
         self.scroll_to_element("clear-site-data-button")
         self.click_on("clear-site-data-button")
         return self.get_element("browser-popup")
-
-    def get_saved_addresses_popup_iframe(self) -> WebElement:
-        """
-        Returns the iframe object for the dialog panel in the popup
-        """
-        self.click_on("saved-addresses-button")
-        iframe = self.get_element("browser-popup")
-        return iframe
 
     def switch_to_saved_addresses_popup_iframe(self) -> BasePage:
         """
@@ -973,9 +1078,13 @@ class AboutPrefs(BasePage):
 
     # Data Extraction and Processing
     def set_country_autofill_panel(self, country: str) -> BasePage:
-        """Sets the country value in the autofill view"""
-        select_country = Select(self.driver.find_element(By.ID, "country"))
-        select_country.select_by_value(country)
+        """Sets the country value in the autofill view.
+
+        Firefox 154 turned the country field into a ``moz-select`` custom element,
+        so operate on the inner ``<select>`` in its shadow DOM.
+        """
+        inner = self._moz_field_inner(self.find_element(By.ID, "country"))
+        Select(inner).select_by_value(country)
         return self
 
     def fill_and_save_address_panel_information(
@@ -1007,9 +1116,17 @@ class AboutPrefs(BasePage):
             for x in form_element.find_elements(By.CSS_SELECTOR, "*")
         ]
 
+        # Firefox 154 wraps these fields in moz-input-text / moz-textarea / moz-select
+        # custom elements; write to the inner node in the shadow DOM (falls back to the
+        # host for plain inputs). address-level1 (state) is now a moz-select, handled by
+        # _select_moz_option (value or visible-text match).
         for key, val in fields.items():
             if key in children:
-                form_element.find_element(By.ID, key).send_keys(val)
+                inner = self._moz_field_inner(form_element.find_element(By.ID, key))
+                if inner.tag_name.lower() == "select":
+                    self._select_moz_option(inner, str(val))
+                else:
+                    inner.send_keys(val)
         self.get_element("save-button").click()
         return self
 


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2057002

#### Description of Code / Doc Changes
The l10n_CM Credential Management suite failed wholesale on Fx 154; the                                        
  breakage was in the shared POMs it reuses (AboutPrefs, Autofill), not the                                      
  tests themselves.                                                                                              
                                                                                                                 
  - Saved Addresses seeding: handle moz-select (country/state) and                                               
    moz-textarea (street) via _moz_field_inner + _select_moz_option, matching                                    
    state by visible text then selecting its region-code value. Avoid a                                          
    speculative Select.select_by_value miss that stalled for the full implicit                                   
    wait (10s local / 30s CI).                                                                                   
  - Saved Addresses/Payments lists now render inline in the privacy pane, not                                    
    a dialog iframe: reveal them with a JS click on the moz-box-button and drop                                  
    the obsolete get_*_popup_iframe frame-switching.                                                             
  - Saved tiles only show a summary, so read org/email/phone/cardholder name                                     
    from the edit dialog (get_stored_{address,payment}_values +                                                  
    _read_saved_entry_edit_fields).  
   - Preview-on-hover: Fx 154 removed the ac-comment preview JSON and previewed                                   
    values aren't readable, so assert the :autofill preview state and dismiss                                    
    with ESC instead of committing a fill (which suppressed later previews).                                     
  - Promote form_autofill/test_create_profile_autofill to pass (fixed by the                                     
    address moz-select changes above).                                                                           
                                                                                                                 
  Verified: l10n_CM demo/US 28/28; form_autofill regression 11/11.                                               
                                                                                                                 
  Co-Authored-By: Claude Opus 4.8

#### Process Changes Required
- [X] Changes or creates a BOM/POM (name the object model): _
- [X] Changes Autofill L10n harness

#### Workflow Checklist
- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!