### PR TITLE
Add tests to verify clear history

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -34,13 +34,23 @@ address_bar_and_search:
     splits:
     - functional1
   test_clear_last_hour_history:
-    result: pass
-    splits:
-    - functional1
+    test_clear_last_hour_history:
+      result: pass
+      splits:
+      - functional1
+    test_clear_last_hour_history_ui:
+      result: pass
+      splits:
+      - functional1
   test_clear_last_hour_history_when_empty:
-    result: pass
-    splits:
-    - functional1
+    test_clear_last_hour_history_when_empty:
+      result: pass
+      splits:
+      - functional1
+    test_clear_last_hour_history_when_empty_ui:
+      result: pass
+      splits:
+      - functional1
   test_clipboard_pref_flip:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -33,6 +33,14 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+  test_clear_last_hour_history:
+    result: pass
+    splits:
+    - functional1
+  test_clear_last_hour_history_when_empty:
+    result: pass
+    splits:
+    - functional1
   test_clipboard_pref_flip:
     result: pass
     splits:

--- a/modules/browser_object_panel_ui.py
+++ b/modules/browser_object_panel_ui.py
@@ -3,7 +3,11 @@ from time import sleep
 from typing import List, Optional, Tuple
 
 from pypom import Region
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    TimeoutException,
+    StaleElementReferenceException,
+)
 from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
@@ -12,7 +16,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from modules.components.dropdown import Dropdown
 from modules.page_base import BasePage
 from modules.util import BrowserActions, PomUtils
-from selenium.common.exceptions import StaleElementReferenceException
 
 
 class PanelUi(BasePage):

--- a/modules/browser_object_panel_ui.py
+++ b/modules/browser_object_panel_ui.py
@@ -5,8 +5,8 @@ from typing import List, Optional, Tuple
 from pypom import Region
 from selenium.common.exceptions import (
     NoSuchElementException,
-    TimeoutException,
     StaleElementReferenceException,
+    TimeoutException,
 )
 from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By

--- a/modules/browser_object_panel_ui.py
+++ b/modules/browser_object_panel_ui.py
@@ -21,6 +21,15 @@ class PanelUi(BasePage):
     ENABLE_ADD_TAG = (
         """PlacesUtils.tagging.tagURI(makeURI("https://www.github.com"), ["tag1"]);"""
     )
+    # Data category checkboxes in the Clear browsing data and cookies dialog,
+    # in the order Firefox lists them.
+    CLEAR_HISTORY_CATEGORIES = [
+        "browsingHistoryAndDownloads",
+        "cookiesAndStorage",
+        "cache",
+        "formdata",
+        "siteSettings",
+    ]
 
     class Menu(Region):
         """
@@ -207,7 +216,86 @@ class PanelUi(BasePage):
         """
         dropdown_root = self.get_element("clear-history-dropdown")
         dropdown = Dropdown(page=self, root=dropdown_root, require_shadow=False)
-        dropdown.select_option(option)
+        # select_option returns False rather than raising when nothing matched.
+        # Left unchecked that is invisible: the dialog keeps its default range
+        # (Last hour) and the clear still happens, just over the wrong span.
+        if not dropdown.select_option(option):
+            raise NoSuchElementException(
+                f"No '{option}' option in the clear-history time range dropdown"
+            )
+        return self
+
+    @BasePage.context_content
+    def get_clear_history_time_range(self) -> str:
+        """
+        Return the label showing in the dialog's time range menulist (assumes
+        already in iframe context).
+        """
+        return self.driver.execute_script(
+            "return arguments[0].label;",
+            self.get_element("clear-history-duration-choice"),
+        )
+
+    @BasePage.context_content
+    def get_clear_history_categories_checked(self) -> List[str]:
+        """
+        Return the ids of the currently ticked data categories, in dialog order
+        (assumes already in iframe context).
+        """
+        checked = []
+        for category in self.CLEAR_HISTORY_CATEGORIES:
+            boxes = self.get_elements("clear-history-category", labels=[category])
+            if boxes and self.driver.execute_script(
+                "return arguments[0].checked;", boxes[0]
+            ):
+                checked.append(category)
+        return checked
+
+    @BasePage.context_content
+    def set_clear_history_categories(self, checked: List[str]) -> BasePage:
+        """
+        Tick exactly the given data categories in the Clear browsing data and
+        cookies dialog, unticking every other one (assumes already in iframe
+        context).
+
+        Firefox ships this dialog with several categories already ticked, so a
+        test that wants to clear history alone has to untick the rest rather
+        than accept the defaults.
+
+        Argument:
+            checked (List[str]): Category element ids to leave ticked, from
+                CLEAR_HISTORY_CATEGORIES.
+        """
+        unknown = set(checked) - set(self.CLEAR_HISTORY_CATEGORIES)
+        if unknown:
+            raise ValueError(f"Unknown clear-history categories: {sorted(unknown)}")
+
+        for category in self.CLEAR_HISTORY_CATEGORIES:
+            boxes = self.get_elements("clear-history-category", labels=[category])
+            if not boxes:
+                # The category set varies by Firefox version. A missing category
+                # only matters when the caller asked for it to be ticked.
+                if category in checked:
+                    raise NoSuchElementException(
+                        f"Clear-history category '{category}' is not in this dialog"
+                    )
+                logging.info("Clear-history category '%s' not present", category)
+                continue
+
+            box = boxes[0]
+            wanted = category in checked
+            if (
+                self.driver.execute_script("return arguments[0].checked;", box)
+                != wanted
+            ):
+                box.click()
+                self.custom_wait(timeout=10).until(
+                    lambda _, el=box, want=wanted: self.driver.execute_script(
+                        "return arguments[0].checked;", el
+                    )
+                    == want,
+                    message=f"'{category}' did not toggle to checked={wanted}",
+                )
         return self
 
     def get_all_history(self) -> List[WebElement]:

--- a/modules/browser_object_panel_ui.py
+++ b/modules/browser_object_panel_ui.py
@@ -12,6 +12,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from modules.components.dropdown import Dropdown
 from modules.page_base import BasePage
 from modules.util import BrowserActions, PomUtils
+from selenium.common.exceptions import StaleElementReferenceException
 
 
 class PanelUi(BasePage):
@@ -300,7 +301,9 @@ class PanelUi(BasePage):
                 != wanted
             ):
                 box.click()
-                self.custom_wait(timeout=10).until(
+                self.custom_wait(
+                    timeout=10, ignored_exceptions=[StaleElementReferenceException]
+                ).until(
                     lambda _, el=box, want=wanted: self.driver.execute_script(
                         "return arguments[0].checked;", el
                     )

--- a/modules/browser_object_panel_ui.py
+++ b/modules/browser_object_panel_ui.py
@@ -212,14 +212,9 @@ class PanelUi(BasePage):
     @BasePage.context_chrome
     def wait_for_clear_history_dialog_closed(self) -> BasePage:
         """
-        Wait for the Clear browsing data and cookies dialog to dismiss.
-
-        Clicking Clear starts an asynchronous sanitize and the dialog is torn
-        down once it finishes, so the dialog going away is the signal that the
-        clear is complete. Reading history before that races the sanitize.
-
-        Also leaves the dialog's iframe, which stops being a valid frame to sit
-        in the moment the dialog closes.
+        The method does two things:
+            exits the iframe (switch_to_content_context)
+            and then waits for the dialog element to disappear.
         """
         BrowserActions(self.driver).switch_to_content_context()
         self.element_not_visible("iframe")

--- a/modules/browser_object_panel_ui.py
+++ b/modules/browser_object_panel_ui.py
@@ -209,6 +209,22 @@ class PanelUi(BasePage):
         BrowserActions(self.driver).switch_to_iframe_context(iframe)
         return self
 
+    @BasePage.context_chrome
+    def wait_for_clear_history_dialog_closed(self) -> BasePage:
+        """
+        Wait for the Clear browsing data and cookies dialog to dismiss.
+
+        Clicking Clear starts an asynchronous sanitize and the dialog is torn
+        down once it finishes, so the dialog going away is the signal that the
+        clear is complete. Reading history before that races the sanitize.
+
+        Also leaves the dialog's iframe, which stops being a valid frame to sit
+        in the moment the dialog closes.
+        """
+        BrowserActions(self.driver).switch_to_content_context()
+        self.element_not_visible("iframe")
+        return self
+
     @BasePage.context_content
     def select_history_time_range_option(self, option: str) -> BasePage:
         """

--- a/modules/data/panel_ui.components.json
+++ b/modules/data/panel_ui.components.json
@@ -310,7 +310,8 @@
     "groups": [],
     "comment": {
       "description": "A data category checkbox in the Clear browsing data and cookies dialog, keyed by element id: browsingHistoryAndDownloads, cookiesAndStorage, cache, formdata, siteSettings",
-      "location": "On the hamburger menu > History > Clear recent history"
+      "location": "On the hamburger menu > History > Clear recent history",
+      "note": "The checkbox tag is XUL-specific. Firefox has been progressively migrating chrome dialogs to HTML, and if the Clear History dialog is migrated the selector here would need to change to input[type=\"checkbox\"]#{category}."
     }
   },
   "all-history-warning": {

--- a/modules/data/panel_ui.components.json
+++ b/modules/data/panel_ui.components.json
@@ -295,6 +295,24 @@
       "location": "On the hamburger menu > History > Clear recent history"
     }
   },
+  "clear-history-duration-choice": {
+    "selectorData": "sanitizeDurationChoice",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "The time range menulist in the Clear browsing data and cookies dialog. Defaults to Last hour.",
+      "location": "On the hamburger menu > History > Clear recent history"
+    }
+  },
+  "clear-history-category": {
+    "selectorData": "checkbox#{category}",
+    "strategy": "css",
+    "groups": [],
+    "comment": {
+      "description": "A data category checkbox in the Clear browsing data and cookies dialog, keyed by element id: browsingHistoryAndDownloads, cookiesAndStorage, cache, formdata, siteSettings",
+      "location": "On the hamburger menu > History > Clear recent history"
+    }
+  },
   "all-history-warning": {
     "selectorData": "sanitizeEverythingWarningBox",
     "strategy": "id",

--- a/modules/util.py
+++ b/modules/util.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from os import remove
 from random import shuffle
 from time import sleep
-from typing import List, Literal, Union, Any
+from typing import Any, List, Literal, Union
 from urllib.parse import urlparse, urlunparse
 
 from faker import Faker

--- a/modules/util.py
+++ b/modules/util.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from os import remove
 from random import shuffle
 from time import sleep
-from typing import List, Literal, Union
+from typing import List, Literal, Union, Any
 from urllib.parse import urlparse, urlunparse
 
 from faker import Faker
@@ -970,7 +970,7 @@ class PomUtils:
             return matches
 
 
-def run_chrome_async_script(driver: Firefox, body: str, *args) -> any:
+def run_chrome_async_script(driver: Firefox, body: str, *args) -> Any:
     """
     Run an async chrome-context script and unwrap its result envelope.
 
@@ -1052,7 +1052,7 @@ class PlacesHistory:
             raise ValueError("Datetime must be timezone-aware")
         return int(value.timestamp() * 1000)
 
-    def _run(self, body: str, *args) -> any:
+    def _run(self, body: str, *args) -> Any:
         """Run `body` in the chrome context with PlacesUtils already imported."""
         return run_chrome_async_script(
             self.driver, f"{self.PLACES_IMPORT}\n{body}", *args
@@ -1097,6 +1097,11 @@ class PlacesHistory:
         """
         Return `{url: bool}` for whether each URL still has any visit.
 
+        Presence is keyed on visits rather than on the page existing in Places.
+        `fetch` without `includeVisits` resolves a page info object for any
+        known page, so a bookmarked-but-never-visited URL would read as
+        present; asking for the visits and testing their count does not.
+
         Parameters
         ----------
         urls : List[str]
@@ -1107,7 +1112,10 @@ class PlacesHistory:
             const urls = arguments[0];
             const result = {};
             for (const url of urls) {
-                result[url] = Boolean(await PlacesUtils.history.hasVisits(url));
+                const info = await PlacesUtils.history.fetch(url, {
+                    includeVisits: true,
+                });
+                result[url] = Boolean(info?.visits?.length);
             }
             resolve(result);
             """,

--- a/modules/util.py
+++ b/modules/util.py
@@ -993,45 +993,68 @@ def run_chrome_async_script(driver: Firefox, body: str, *args) -> Any:
     """
     script = f"""
         const done = arguments[arguments.length - 1];
+        const scriptArgs = Array.from(arguments).slice(0, -1);
+
         (async () => {{
             let settled = false;
-            const resolve = (value) => {{
+
+            const finish = (result) => {{
+                if (settled) {{
+                    return;
+                }}
+
                 settled = true;
-                done({{ok: true, value}});
+                done(result);
             }};
+
+            const resolve = (value) => {{
+                finish({{
+                    ok: true,
+                    value: value,
+                }});
+            }};
+
             try {{
                 {body}
             }} catch (error) {{
-                settled = true;
-                done({{
+                finish({{
                     ok: false,
                     error: String(error),
                     stack: error?.stack || "",
                 }});
             }} finally {{
                 if (!settled) {{
-                    done({{
+                    finish({{
                         ok: false,
-                        error: "Script body finished without calling resolve(); "
-                            + "every branch must call resolve() exactly once.",
+                        error:
+                            "Script body finished without calling resolve(); "
+                            + "every successful branch must call resolve().",
                         stack: "",
                     }});
                 }}
             }}
         }})();
     """
+
     with driver.context(driver.CONTEXT_CHROME):
         result = driver.execute_async_script(script, *args)
 
     if not isinstance(result, dict):
         raise WebDriverException(
-            f"Chrome-context helper returned an unexpected result: {result!r}"
+            "Chrome-context helper returned an unexpected result: "
+            f"{result!r}"
         )
+
     if not result.get("ok"):
-        raise WebDriverException(
-            f"{result.get('error', 'Unknown chrome-context error')}\n"
-            f"{result.get('stack', '')}"
-        )
+        error = result.get("error", "Unknown chrome-context error")
+        stack = result.get("stack", "")
+
+        message = error
+        if stack:
+            message = f"{error}\n{stack}"
+
+        raise WebDriverException(message)
+
     return result.get("value")
 
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -1109,10 +1109,25 @@ class PlacesHistory:
             """,
             visits,
         )
-        if inserted != len(visits):
-            raise WebDriverException(
-                f"Expected to insert {len(visits)} visits, Firefox reported {inserted}"
-            )
+        inserted = self._run(
+            """
+            const visits = arguments[0];
+            let count = 0;
+            for (const visit of visits) {
+                const added = await PlacesUtils.history.insert({
+                    url: visit.url,
+                    title: visit.title,
+                    visits: [{
+                        date: new Date(visit.timestamp_ms),
+                        transition: PlacesUtils.history.TRANSITIONS.LINK,
+                    }],
+                });
+                if (added) count++;
+            }
+            resolve(count);
+            """,
+            visits,
+        )
 
     def get_visit_presence(self, urls: List[str]) -> dict:
         """

--- a/modules/util.py
+++ b/modules/util.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import re
+from datetime import datetime
 from os import remove
 from random import shuffle
 from time import sleep
@@ -967,3 +968,205 @@ class PomUtils:
             if not matches:
                 logging.info("No matches found.")
             return matches
+
+
+def run_chrome_async_script(driver: Firefox, body: str, *args) -> any:
+    """
+    Run an async chrome-context script and unwrap its result envelope.
+
+    The body is wrapped in a promise with error trapping, so a JS-side failure
+    surfaces as a WebDriverException carrying the JS stack rather than as a
+    bare `None`.
+
+    Parameters
+    ----------
+    driver : selenium.webdriver.Firefox
+        The instance of WebDriver under test.
+    body : str
+        JS statements that call `resolve(value)` exactly once.
+    """
+    script = f"""
+        const done = arguments[arguments.length - 1];
+        (async () => {{
+            try {{
+                const resolve = (value) => done({{ok: true, value}});
+                {body}
+            }} catch (error) {{
+                done({{
+                    ok: false,
+                    error: String(error),
+                    stack: error?.stack || "",
+                }});
+            }}
+        }})();
+    """
+    with driver.context(driver.CONTEXT_CHROME):
+        result = driver.execute_async_script(script, *args)
+
+    if not isinstance(result, dict):
+        raise WebDriverException(
+            f"Chrome-context helper returned an unexpected result: {result!r}"
+        )
+    if not result.get("ok"):
+        raise WebDriverException(
+            f"{result.get('error', 'Unknown chrome-context error')}\n"
+            f"{result.get('stack', '')}"
+        )
+    return result.get("value")
+
+
+class PlacesHistory:
+    """
+    Read and write Firefox browsing history directly, via privileged JS.
+
+    Going through Places rather than the UI lets a test arrange visits at
+    explicit timestamps, which is impossible to do by browsing to pages.
+
+    Attributes
+    ----------
+    driver : selenium.webdriver.Firefox
+        The instance of WebDriver under test.
+    """
+
+    PLACES_IMPORT = """
+        const { PlacesUtils } = ChromeUtils.importESModule(
+            "resource://gre/modules/PlacesUtils.sys.mjs"
+        );
+    """
+
+    def __init__(self, driver: Firefox):
+        self.driver = driver
+
+    @staticmethod
+    def to_epoch_ms(value: datetime) -> int:
+        """
+        Convert a timezone-aware datetime to epoch milliseconds for JS `Date`.
+
+        Parameters
+        ----------
+        value : datetime.datetime
+            Must be timezone-aware, so the timestamp is unambiguous regardless
+            of the timezone the test machine runs in.
+        """
+        if value.tzinfo is None:
+            raise ValueError("Datetime must be timezone-aware")
+        return int(value.timestamp() * 1000)
+
+    def _run(self, body: str, *args) -> any:
+        """Run `body` in the chrome context with PlacesUtils already imported."""
+        return run_chrome_async_script(
+            self.driver, f"{self.PLACES_IMPORT}\n{body}", *args
+        )
+
+    def clear(self):
+        """Remove all browsing history."""
+        self._run("await PlacesUtils.history.clear(); resolve(null);")
+
+    def insert_visits(self, visits: List[dict]):
+        """
+        Insert history visits at explicit timestamps.
+
+        Parameters
+        ----------
+        visits : List[dict]
+            Each entry needs `url`, `title`, and `timestamp_ms` (epoch
+            milliseconds, as produced by `to_epoch_ms`).
+        """
+        inserted = self._run(
+            """
+            const visits = arguments[0];
+            for (const visit of visits) {
+                await PlacesUtils.history.insert({
+                    url: visit.url,
+                    title: visit.title,
+                    visits: [{
+                        date: new Date(visit.timestamp_ms),
+                        transition: PlacesUtils.history.TRANSITIONS.LINK,
+                    }],
+                });
+            }
+            resolve(visits.length);
+            """,
+            visits,
+        )
+        assert inserted == len(visits), (
+            f"Expected to insert {len(visits)} visits, Firefox reported {inserted}"
+        )
+
+    def get_visit_presence(self, urls: List[str]) -> dict:
+        """
+        Return `{url: bool}` for whether each URL still has any visit.
+
+        Parameters
+        ----------
+        urls : List[str]
+            The URLs to look up.
+        """
+        presence = self._run(
+            """
+            const urls = arguments[0];
+            const result = {};
+            for (const url of urls) {
+                result[url] = Boolean(await PlacesUtils.history.hasVisits(url));
+            }
+            resolve(result);
+            """,
+            urls,
+        )
+        if not isinstance(presence, dict):
+            raise WebDriverException(f"Expected a url->bool mapping, got {presence!r}")
+        return presence
+
+
+class Sanitizer:
+    """
+    Drive Firefox's Clear Recent History sanitizer from privileged JS.
+
+    This is the same code path the Clear Recent History dialog runs on accept,
+    entered below the UI so a test can pin the timespan and the exact set of
+    categories being cleared.
+
+    Attributes
+    ----------
+    driver : selenium.webdriver.Firefox
+        The instance of WebDriver under test.
+    """
+
+    def __init__(self, driver: Firefox):
+        self.driver = driver
+
+    def sanitize(self, items: List[str], timespan: str = "TIMESPAN_HOUR") -> dict:
+        """
+        Clear the given categories over the given timespan.
+
+        Parameters
+        ----------
+        items : List[str]
+            Sanitizer category keys, e.g. `["history"]`. Categories not listed
+            are left untouched.
+        timespan : str, optional
+            A `Sanitizer.TIMESPAN_*` constant name (default `TIMESPAN_HOUR`).
+
+        Returns
+        -------
+        dict
+            `{"start": int, "end": int}`, the cleared range in epoch
+            microseconds, so a caller can assert the range was well formed.
+        """
+        return run_chrome_async_script(
+            self.driver,
+            """
+            const [items, timespan] = arguments;
+            const { Sanitizer } = ChromeUtils.importESModule(
+                "resource:///modules/Sanitizer.sys.mjs"
+            );
+            if (!(timespan in Sanitizer)) {
+                throw new Error(`Unknown Sanitizer timespan: ${timespan}`);
+            }
+            const range = Sanitizer.getClearRange(Sanitizer[timespan]);
+            await Sanitizer.sanitize(items, { range });
+            resolve({ start: range[0], end: range[1] });
+            """,
+            items,
+            timespan,
+        )

--- a/modules/util.py
+++ b/modules/util.py
@@ -993,7 +993,6 @@ def run_chrome_async_script(driver: Firefox, body: str, *args) -> Any:
     """
     script = f"""
         const done = arguments[arguments.length - 1];
-        const scriptArgs = Array.from(arguments).slice(0, -1);
 
         (async () => {{
             let settled = false;
@@ -1171,27 +1170,36 @@ class PlacesHistory:
             raise WebDriverException(f"Expected a url->bool mapping, got {presence!r}")
         return presence
 
-    def count_visits(self) -> int:
+    def is_history_empty(self) -> bool:
         """
-        Return the total number of visits recorded in Places.
+        Whether Places holds no visits at all.
 
-        Checking a specific URL is absent cannot show that history is empty,
-        since any URL that was never visited is trivially absent. This counts
-        the visit rows instead, so "empty" is an assertion rather than an
-        assumption.
+        Checking that a specific URL is absent cannot show history is empty,
+        since a URL that was never visited is trivially absent. This asks about
+        the whole store instead, so "empty" is an assertion, not an assumption.
+
+        Uses the nsINavHistoryService query interface rather than counting rows
+        in moz_historyvisits: that table is Places' internal storage and carries
+        no public contract, so a schema change could silently break the check.
+        maxResults stops the query at the first row, since only emptiness is
+        being asked about.
         """
-        count = self._run(
+        empty = self._run(
             """
-            const db = await PlacesUtils.promiseDBConnection();
-            const rows = await db.execute(
-                "SELECT COUNT(*) AS visit_count FROM moz_historyvisits"
-            );
-            resolve(rows[0].getResultByName("visit_count"));
+            const query = PlacesUtils.history.getNewQuery();
+            const options = PlacesUtils.history.getNewQueryOptions();
+            options.resultType = Ci.nsINavHistoryQueryOptions.RESULTS_AS_VISIT;
+            options.maxResults = 1;
+            const root = PlacesUtils.history.executeQuery(query, options).root;
+            root.containerOpen = true;
+            const isEmpty = root.childCount === 0;
+            root.containerOpen = false;
+            resolve(isEmpty);
             """
         )
-        if not isinstance(count, int):
-            raise WebDriverException(f"Expected a visit count, got {count!r}")
-        return count
+        if not isinstance(empty, bool):
+            raise WebDriverException(f"Expected a boolean, got {empty!r}")
+        return empty
 
 
 class Sanitizer:

--- a/modules/util.py
+++ b/modules/util.py
@@ -1041,8 +1041,7 @@ def run_chrome_async_script(driver: Firefox, body: str, *args) -> Any:
 
     if not isinstance(result, dict):
         raise WebDriverException(
-            "Chrome-context helper returned an unexpected result: "
-            f"{result!r}"
+            f"Chrome-context helper returned an unexpected result: {result!r}"
         )
 
     if not result.get("ok"):

--- a/modules/util.py
+++ b/modules/util.py
@@ -1095,23 +1095,6 @@ class PlacesHistory:
         inserted = self._run(
             """
             const visits = arguments[0];
-            for (const visit of visits) {
-                await PlacesUtils.history.insert({
-                    url: visit.url,
-                    title: visit.title,
-                    visits: [{
-                        date: new Date(visit.timestamp_ms),
-                        transition: PlacesUtils.history.TRANSITIONS.LINK,
-                    }],
-                });
-            }
-            resolve(visits.length);
-            """,
-            visits,
-        )
-        inserted = self._run(
-            """
-            const visits = arguments[0];
             let count = 0;
             for (const visit of visits) {
                 const added = await PlacesUtils.history.insert({
@@ -1128,6 +1111,11 @@ class PlacesHistory:
             """,
             visits,
         )
+        if inserted != len(visits):
+            raise WebDriverException(
+                f"Expected {len(visits)} visits to be inserted, "
+                f"Places accepted {inserted}"
+            )
 
     def get_visit_presence(self, urls: List[str]) -> dict:
         """

--- a/modules/util.py
+++ b/modules/util.py
@@ -978,25 +978,45 @@ def run_chrome_async_script(driver: Firefox, body: str, *args) -> Any:
     surfaces as a WebDriverException carrying the JS stack rather than as a
     bare `None`.
 
+    A body that finishes without calling `resolve` is reported as such. Without
+    that guard the script would simply never call back and the test would fail
+    on the WebDriver async script timeout (30 seconds by default) with no
+    indication of which script stalled or why. The guard runs in a `finally`,
+    so it still fires when the body exits through an early `return`.
+
     Parameters
     ----------
     driver : selenium.webdriver.Firefox
         The instance of WebDriver under test.
     body : str
-        JS statements that call `resolve(value)` exactly once.
+        JS statements that call `resolve(value)` exactly once, on every branch.
     """
     script = f"""
         const done = arguments[arguments.length - 1];
         (async () => {{
+            let settled = false;
+            const resolve = (value) => {{
+                settled = true;
+                done({{ok: true, value}});
+            }};
             try {{
-                const resolve = (value) => done({{ok: true, value}});
                 {body}
             }} catch (error) {{
+                settled = true;
                 done({{
                     ok: false,
                     error: String(error),
                     stack: error?.stack || "",
                 }});
+            }} finally {{
+                if (!settled) {{
+                    done({{
+                        ok: false,
+                        error: "Script body finished without calling resolve(); "
+                            + "every branch must call resolve() exactly once.",
+                        stack: "",
+                    }});
+                }}
             }}
         }})();
     """
@@ -1089,9 +1109,10 @@ class PlacesHistory:
             """,
             visits,
         )
-        assert inserted == len(visits), (
-            f"Expected to insert {len(visits)} visits, Firefox reported {inserted}"
-        )
+        if inserted != len(visits):
+            raise WebDriverException(
+                f"Expected to insert {len(visits)} visits, Firefox reported {inserted}"
+            )
 
     def get_visit_presence(self, urls: List[str]) -> dict:
         """
@@ -1124,6 +1145,28 @@ class PlacesHistory:
         if not isinstance(presence, dict):
             raise WebDriverException(f"Expected a url->bool mapping, got {presence!r}")
         return presence
+
+    def count_visits(self) -> int:
+        """
+        Return the total number of visits recorded in Places.
+
+        Checking a specific URL is absent cannot show that history is empty,
+        since any URL that was never visited is trivially absent. This counts
+        the visit rows instead, so "empty" is an assertion rather than an
+        assumption.
+        """
+        count = self._run(
+            """
+            const db = await PlacesUtils.promiseDBConnection();
+            const rows = await db.execute(
+                "SELECT COUNT(*) AS visit_count FROM moz_historyvisits"
+            );
+            resolve(rows[0].getResultByName("visit_count"));
+            """
+        )
+        if not isinstance(count, int):
+            raise WebDriverException(f"Expected a visit count, got {count!r}")
+        return count
 
 
 class Sanitizer:

--- a/tests/address_bar_and_search/test_clear_last_hour_history.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history.py
@@ -3,19 +3,13 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from selenium.webdriver import Firefox
 
+from modules.browser_object import PanelUi
+from modules.page_object import GenericPage
 from modules.util import PlacesHistory, Sanitizer
 
-
-@pytest.fixture()
-def test_case():
-    return "2058317"
-
-
-@pytest.fixture()
-def add_to_prefs_list():
-    return [("places.history.enabled", True)]
-
-
+# Offsets are kept 5 minutes clear of the one-hour boundary on both sides, so
+# the seconds that elapse between arranging the visits and clearing cannot
+# drift a visit across the cutoff.
 RECENT_URLS = {
     "https://example.com/history-test/recent-10-minutes": timedelta(minutes=10),
     "https://example.com/history-test/recent-55-minutes": timedelta(minutes=55),
@@ -26,19 +20,24 @@ OLD_URLS = {
 }
 
 
-def test_clear_last_hour_history(driver: Firefox):
-    """
-    Clearing the last hour of history removes visits from within that
-    hour and preserves older ones.
-    """
-    # Instantiate objects
-    history = PlacesHistory(driver)
-    sanitizer = Sanitizer(driver)
+@pytest.fixture()
+def test_case():
+    return "4245709"
 
-    # Start from a known-empty history so nothing from browser startup counts
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("places.history.enabled", True)]
+
+
+def arrange_visits_across_the_boundary(history: PlacesHistory) -> list:
+    """
+    Reset history and seed visits on both sides of the one-hour boundary.
+
+    Visits are written through Places because no automated route can browse an
+    hour ago. Returns the arranged visit dicts.
+    """
     history.clear()
-
-    # Arrange visits on both sides of the one-hour boundary
     now = datetime.now(timezone.utc)
     visits = [
         {
@@ -55,14 +54,11 @@ def test_clear_last_hour_history(driver: Firefox):
     assert all(presence_before.values()), (
         f"Not all test visits were recorded: {presence_before}"
     )
+    return visits
 
-    # Clear only browsing history, only for the last hour
-    cleared_range = sanitizer.sanitize(["history"], timespan="TIMESPAN_HOUR")
-    assert cleared_range["start"] < cleared_range["end"], (
-        f"Sanitizer reported a malformed clear range: {cleared_range}"
-    )
 
-    # Verify visits inside the last hour are gone and older ones survived
+def assert_only_the_last_hour_was_cleared(history: PlacesHistory, visits: list):
+    """Recent visits must be gone, older ones must remain."""
     presence_after = history.get_visit_presence([visit["url"] for visit in visits])
     for url in RECENT_URLS:
         assert presence_after[url] is False, (
@@ -72,3 +68,60 @@ def test_clear_last_hour_history(driver: Firefox):
         assert presence_after[url] is True, (
             f"Visit from before the last hour was incorrectly removed: {url}"
         )
+
+
+def test_clear_last_hour_history(driver: Firefox):
+    """
+    Clearing the last hour of history removes visits from within that
+    hour and preserves older ones.
+    """
+    # Instantiate objects
+    history = PlacesHistory(driver)
+    sanitizer = Sanitizer(driver)
+
+    visits = arrange_visits_across_the_boundary(history)
+
+    # Clear only browsing history, only for the last hour
+    cleared_range = sanitizer.sanitize(["history"], timespan="TIMESPAN_HOUR")
+    assert cleared_range["start"] < cleared_range["end"], (
+        f"Sanitizer reported a malformed clear range: {cleared_range}"
+    )
+
+    assert_only_the_last_hour_was_cleared(history, visits)
+
+
+def test_clear_last_hour_history_ui(driver: Firefox):
+    """
+    Clearing Last hour from the Clear browsing data and cookies dialog removes
+    visits from within that hour and preserves older ones.
+    """
+    # Instantiate objects
+    history = PlacesHistory(driver)
+    panel = PanelUi(driver)
+    page = GenericPage(driver)
+
+    visits = arrange_visits_across_the_boundary(history)
+
+    # Open Clear browsing data and cookies from the hamburger menu
+    panel.open_history_menu()
+    panel.open_clear_history_dialog()
+
+    # Choose the one-hour range and clear browsing history alone. Last hour is
+    # already the dialog default, so the range is asserted rather than assumed
+    # to have been set by the click.
+    panel.select_history_time_range_option("Last hour")
+    assert panel.get_clear_history_time_range() == "Last hour", (
+        "Time range dropdown does not show Last hour"
+    )
+
+    panel.set_clear_history_categories(["browsingHistoryAndDownloads"])
+    assert panel.get_clear_history_categories_checked() == [
+        "browsingHistoryAndDownloads"
+    ], (
+        "Expected browsing history to be the only ticked category, got "
+        f"{panel.get_clear_history_categories_checked()}"
+    )
+
+    page.click_on("clear-history-button")
+
+    assert_only_the_last_hour_was_cleared(history, visits)

--- a/tests/address_bar_and_search/test_clear_last_hour_history.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history.py
@@ -8,7 +8,7 @@ from modules.util import PlacesHistory, Sanitizer
 
 @pytest.fixture()
 def test_case():
-    return "TODO-TESTRAIL-ID"
+    return "2058317"
 
 
 @pytest.fixture()

--- a/tests/address_bar_and_search/test_clear_last_hour_history.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.util import PlacesHistory, Sanitizer
+
+
+@pytest.fixture()
+def test_case():
+    return "TODO-TESTRAIL-ID"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("places.history.enabled", True)]
+
+
+RECENT_URLS = {
+    "https://example.com/history-test/recent-10-minutes": timedelta(minutes=10),
+    "https://example.com/history-test/recent-55-minutes": timedelta(minutes=55),
+}
+OLD_URLS = {
+    "https://example.com/history-test/old-65-minutes": timedelta(minutes=65),
+    "https://example.com/history-test/old-2-hours": timedelta(hours=2),
+}
+
+
+def test_clear_last_hour_history(driver: Firefox):
+    """
+    Clearing the last hour of history removes visits from within that
+    hour and preserves older ones.
+    """
+    # Instantiate objects
+    history = PlacesHistory(driver)
+    sanitizer = Sanitizer(driver)
+
+    # Start from a known-empty history so nothing from browser startup counts
+    history.clear()
+
+    # Arrange visits on both sides of the one-hour boundary
+    now = datetime.now(timezone.utc)
+    visits = [
+        {
+            "url": url,
+            "title": f"History test visit - {url.rsplit('/', 1)[-1]}",
+            "timestamp_ms": PlacesHistory.to_epoch_ms(now - offset),
+        }
+        for url, offset in {**RECENT_URLS, **OLD_URLS}.items()
+    ]
+    history.insert_visits(visits)
+
+    # Precondition: every arranged visit is present before anything is cleared
+    presence_before = history.get_visit_presence([visit["url"] for visit in visits])
+    assert all(presence_before.values()), (
+        f"Not all test visits were recorded: {presence_before}"
+    )
+
+    # Clear only browsing history, only for the last hour
+    cleared_range = sanitizer.sanitize(["history"], timespan="TIMESPAN_HOUR")
+    assert cleared_range["start"] < cleared_range["end"], (
+        f"Sanitizer reported a malformed clear range: {cleared_range}"
+    )
+
+    # Verify visits inside the last hour are gone and older ones survived
+    presence_after = history.get_visit_presence([visit["url"] for visit in visits])
+    for url in RECENT_URLS:
+        assert presence_after[url] is False, (
+            f"Visit from within the last hour was not removed: {url}"
+        )
+    for url in OLD_URLS:
+        assert presence_after[url] is True, (
+            f"Visit from before the last hour was incorrectly removed: {url}"
+        )

--- a/tests/address_bar_and_search/test_clear_last_hour_history.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history.py
@@ -110,16 +110,17 @@ def test_clear_last_hour_history_ui(driver: Firefox):
     # already the dialog default, so the range is asserted rather than assumed
     # to have been set by the click.
     panel.select_history_time_range_option("Last hour")
-    assert panel.get_clear_history_time_range() == "Last hour", (
-        "Time range dropdown does not show Last hour"
+    # Each of these is read once and held, so the failure message reports the
+    # state that actually failed rather than whatever a second read returns.
+    time_range = panel.get_clear_history_time_range()
+    assert time_range == "Last hour", (
+        f"Expected the time range dropdown to show Last hour, got {time_range!r}"
     )
 
     panel.set_clear_history_categories(["browsingHistoryAndDownloads"])
-    assert panel.get_clear_history_categories_checked() == [
-        "browsingHistoryAndDownloads"
-    ], (
-        "Expected browsing history to be the only ticked category, got "
-        f"{panel.get_clear_history_categories_checked()}"
+    checked = panel.get_clear_history_categories_checked()
+    assert checked == ["browsingHistoryAndDownloads"], (
+        f"Expected browsing history to be the only ticked category, got {checked}"
     )
 
     page.click_on("clear-history-button")

--- a/tests/address_bar_and_search/test_clear_last_hour_history.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history.py
@@ -124,5 +124,6 @@ def test_clear_last_hour_history_ui(driver: Firefox):
     )
 
     page.click_on("clear-history-button")
+    panel.wait_for_clear_history_dialog_closed()
 
     assert_only_the_last_hour_was_cleared(history, visits)

--- a/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
@@ -5,8 +5,6 @@ from modules.browser_object import PanelUi
 from modules.page_object import GenericPage
 from modules.util import PlacesHistory, Sanitizer
 
-PROBE_URL = "https://example.com/history-test/never-visited"
-
 
 @pytest.fixture()
 def test_case():
@@ -29,6 +27,7 @@ def test_clear_last_hour_history_when_empty(driver: Firefox):
 
     # Start from a known-empty history
     history.clear()
+    assert history.count_visits() == 0, "History was not empty to begin with"
 
     # Clearing an empty range should be a no-op rather than an error
     cleared_range = sanitizer.sanitize(["history"], timespan="TIMESPAN_HOUR")
@@ -36,10 +35,10 @@ def test_clear_last_hour_history_when_empty(driver: Firefox):
         f"Sanitizer reported a malformed clear range: {cleared_range}"
     )
 
-    # Verify history is still empty
-    presence = history.get_visit_presence([PROBE_URL])
-    assert presence[PROBE_URL] is False, (
-        f"Unexpected history entry after clearing empty history: {PROBE_URL}"
+    # The point of the test is that the call above did not raise. This confirms
+    # it was a genuine no-op rather than something that left visits behind.
+    assert history.count_visits() == 0, (
+        "History is not empty after clearing an already-empty history"
     )
 
 
@@ -55,6 +54,7 @@ def test_clear_last_hour_history_when_empty_ui(driver: Firefox):
 
     # Start from a known-empty history
     history.clear()
+    assert history.count_visits() == 0, "History was not empty to begin with"
 
     # Open Clear browsing data and cookies from the hamburger menu
     panel.open_history_menu()
@@ -77,8 +77,8 @@ def test_clear_last_hour_history_when_empty_ui(driver: Firefox):
     # Clearing nothing should be a no-op rather than an error
     page.click_on("clear-history-button")
 
-    # Verify history is still empty
-    presence = history.get_visit_presence([PROBE_URL])
-    assert presence[PROBE_URL] is False, (
-        f"Unexpected history entry after clearing empty history: {PROBE_URL}"
+    # The point of the test is that the dialog flow above completed without
+    # raising. This confirms it left history empty rather than adding entries.
+    assert history.count_visits() == 0, (
+        "History is not empty after clearing an already-empty history"
     )

--- a/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
@@ -62,16 +62,17 @@ def test_clear_last_hour_history_when_empty_ui(driver: Firefox):
 
     # Choose the one-hour range and clear browsing history alone
     panel.select_history_time_range_option("Last hour")
-    assert panel.get_clear_history_time_range() == "Last hour", (
-        "Time range dropdown does not show Last hour"
+    # Each of these is read once and held, so the failure message reports the
+    # state that actually failed rather than whatever a second read returns.
+    time_range = panel.get_clear_history_time_range()
+    assert time_range == "Last hour", (
+        f"Expected the time range dropdown to show Last hour, got {time_range!r}"
     )
 
     panel.set_clear_history_categories(["browsingHistoryAndDownloads"])
-    assert panel.get_clear_history_categories_checked() == [
-        "browsingHistoryAndDownloads"
-    ], (
-        "Expected browsing history to be the only ticked category, got "
-        f"{panel.get_clear_history_categories_checked()}"
+    checked = panel.get_clear_history_categories_checked()
+    assert checked == ["browsingHistoryAndDownloads"], (
+        f"Expected browsing history to be the only ticked category, got {checked}"
     )
 
     # Clearing nothing should be a no-op rather than an error

--- a/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
@@ -8,7 +8,7 @@ PROBE_URL = "https://example.com/history-test/never-visited"
 
 @pytest.fixture()
 def test_case():
-    return "TODO-TESTRAIL-ID"
+    return "2058318"
 
 
 @pytest.fixture()

--- a/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
@@ -27,7 +27,7 @@ def test_clear_last_hour_history_when_empty(driver: Firefox):
 
     # Start from a known-empty history
     history.clear()
-    assert history.count_visits() == 0, "History was not empty to begin with"
+    assert history.is_history_empty(), "History was not empty to begin with"
 
     # Clearing an empty range should be a no-op rather than an error
     cleared_range = sanitizer.sanitize(["history"], timespan="TIMESPAN_HOUR")
@@ -37,7 +37,7 @@ def test_clear_last_hour_history_when_empty(driver: Firefox):
 
     # The point of the test is that the call above did not raise. This confirms
     # it was a genuine no-op rather than something that left visits behind.
-    assert history.count_visits() == 0, (
+    assert history.is_history_empty(), (
         "History is not empty after clearing an already-empty history"
     )
 
@@ -54,7 +54,7 @@ def test_clear_last_hour_history_when_empty_ui(driver: Firefox):
 
     # Start from a known-empty history
     history.clear()
-    assert history.count_visits() == 0, "History was not empty to begin with"
+    assert history.is_history_empty(), "History was not empty to begin with"
 
     # Open Clear browsing data and cookies from the hamburger menu
     panel.open_history_menu()
@@ -81,6 +81,6 @@ def test_clear_last_hour_history_when_empty_ui(driver: Firefox):
 
     # The point of the test is that the dialog flow above completed without
     # raising. This confirms it left history empty rather than adding entries.
-    assert history.count_visits() == 0, (
+    assert history.is_history_empty(), (
         "History is not empty after clearing an already-empty history"
     )

--- a/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
@@ -1,6 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
 
+from modules.browser_object import PanelUi
+from modules.page_object import GenericPage
 from modules.util import PlacesHistory, Sanitizer
 
 PROBE_URL = "https://example.com/history-test/never-visited"
@@ -8,7 +10,7 @@ PROBE_URL = "https://example.com/history-test/never-visited"
 
 @pytest.fixture()
 def test_case():
-    return "2058318"
+    return "4245710"
 
 
 @pytest.fixture()
@@ -33,6 +35,47 @@ def test_clear_last_hour_history_when_empty(driver: Firefox):
     assert cleared_range["start"] < cleared_range["end"], (
         f"Sanitizer reported a malformed clear range: {cleared_range}"
     )
+
+    # Verify history is still empty
+    presence = history.get_visit_presence([PROBE_URL])
+    assert presence[PROBE_URL] is False, (
+        f"Unexpected history entry after clearing empty history: {PROBE_URL}"
+    )
+
+
+def test_clear_last_hour_history_when_empty_ui(driver: Firefox):
+    """
+    Clearing Last hour from the Clear browsing data and cookies dialog succeeds
+    when there is no history to clear.
+    """
+    # Instantiate objects
+    history = PlacesHistory(driver)
+    panel = PanelUi(driver)
+    page = GenericPage(driver)
+
+    # Start from a known-empty history
+    history.clear()
+
+    # Open Clear browsing data and cookies from the hamburger menu
+    panel.open_history_menu()
+    panel.open_clear_history_dialog()
+
+    # Choose the one-hour range and clear browsing history alone
+    panel.select_history_time_range_option("Last hour")
+    assert panel.get_clear_history_time_range() == "Last hour", (
+        "Time range dropdown does not show Last hour"
+    )
+
+    panel.set_clear_history_categories(["browsingHistoryAndDownloads"])
+    assert panel.get_clear_history_categories_checked() == [
+        "browsingHistoryAndDownloads"
+    ], (
+        "Expected browsing history to be the only ticked category, got "
+        f"{panel.get_clear_history_categories_checked()}"
+    )
+
+    # Clearing nothing should be a no-op rather than an error
+    page.click_on("clear-history-button")
 
     # Verify history is still empty
     presence = history.get_visit_presence([PROBE_URL])

--- a/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
@@ -1,0 +1,41 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.util import PlacesHistory, Sanitizer
+
+PROBE_URL = "https://example.com/history-test/never-visited"
+
+
+@pytest.fixture()
+def test_case():
+    return "TODO-TESTRAIL-ID"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("places.history.enabled", True)]
+
+
+def test_clear_last_hour_history_when_empty(driver: Firefox):
+    """
+    Clearing the last hour of history succeeds when there is no
+    history to clear.
+    """
+    # Instantiate objects
+    history = PlacesHistory(driver)
+    sanitizer = Sanitizer(driver)
+
+    # Start from a known-empty history
+    history.clear()
+
+    # Clearing an empty range should be a no-op rather than an error
+    cleared_range = sanitizer.sanitize(["history"], timespan="TIMESPAN_HOUR")
+    assert cleared_range["start"] < cleared_range["end"], (
+        f"Sanitizer reported a malformed clear range: {cleared_range}"
+    )
+
+    # Verify history is still empty
+    presence = history.get_visit_presence([PROBE_URL])
+    assert presence[PROBE_URL] is False, (
+        f"Unexpected history entry after clearing empty history: {PROBE_URL}"
+    )

--- a/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
+++ b/tests/address_bar_and_search/test_clear_last_hour_history_when_empty.py
@@ -77,6 +77,7 @@ def test_clear_last_hour_history_when_empty_ui(driver: Firefox):
 
     # Clearing nothing should be a no-op rather than an error
     page.click_on("clear-history-button")
+    panel.wait_for_clear_history_dialog_closed()
 
     # The point of the test is that the dialog flow above completed without
     # raising. This confirms it left history empty rather than adding entries.


### PR DESCRIPTION
### Relevant Links

Bugzilla: [Bug 2058317](https://bugzilla.mozilla.org/show_bug.cgi?id=2058317), [Bug 2058318](https://bugzilla.mozilla.org/show_bug.cgi?id=2058318)
TestRail: [C4245709](https://mozilla.testrail.io/index.php?/cases/view/4245709), [C4245710](https://mozilla.testrail.io/index.php?/cases/view/4245710)


### Description of Code / Doc Changes

- There was a bug reported by end users: https://www.reddit.com/r/firefox/comments/1v3cgch/firefox_153_bug_clearing_last_hour_history/
- Confirmed we do not have test coverage for this scenario (neither manual nor automated)
- Add tests to verify clear last hour history

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
