### PR TITLE
Tracy/ Fix sidebar tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1492,8 +1492,7 @@ sidebar:
     splits:
     - functional3
   test_hide_sidebar_behaviour:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047908
-    result: unstable
+    result: pass
     splits:
     - functional3
   test_open_ai_chat_via_context_menu:
@@ -1513,8 +1512,7 @@ sidebar:
     splits:
     - functional3
   test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047908
-    result: unstable
+    result: pass
     splits:
     - functional3
   test_sidebar_multiple_vertical_tabs_selection:

--- a/modules/data/sidebar.components.json
+++ b/modules/data/sidebar.components.json
@@ -13,7 +13,7 @@
   },
   "sidebar-main": {
     "selectorData": "sidebar-main",
-    "strategy": "id",
+    "strategy": "css",
     "groups": [
       "doNotCache"
     ],


### PR DESCRIPTION
#### Relevant Links
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2047908

#### Description of Code / Doc Changes
  Fix sidebar locator strategy for sidebar-main custom element                                                   
                                                                                                                 
  sidebar-main is a custom-element tag, not an id, so the manifest's                                             
  strategy: id ([id="sidebar-main"]) never matched — breaking hover,                                             
  context_click, and element_not_visible. Switch to strategy: css                                                
  (tag also fails in the chrome context). Flip both tests to pass.                                               
                                                                                                                 
  - test_hide_sidebar_behaviour                                                                                  
  - test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position                                      
                                                                                                                 
  Co-Authored-By: Claude Opus 4.8

#### Workflow Checklist
- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.

Thank you!