### PR TITLE
Anca/ Move glean testrail reporting to a separate plan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,8 @@ jobs:
         run: |
           $split = if ($env:STARFOX_SPLIT) { $env:STARFOX_SPLIT } else { "smoke" }
           if ($split -ne "smoke" -or $env:SKIP_GLEAN -eq "true") {exit 0}
+          # Set after the guard: routes results to the dedicated Glean plan
+          $env:STARFOX_SPLIT = "glean"
           uv run pytest tests/glean --geckodriver=geckodriver.exe
           $env:TEST_EXIT_CODE = $LASTEXITCODE
           mv artifacts artifacts-win || true
@@ -404,7 +406,8 @@ jobs:
           "$FX_EXECUTABLE" --version
           split="${STARFOX_SPLIT:-smoke}"
           if [[ $split != "smoke" || $SKIP_GLEAN = "true" ]]; then exit 0; fi
-          uv run pytest --fx-executable="$FX_EXECUTABLE" tests/glean || TEST_EXIT_CODE=$?
+          # Prefixed, not exported: routes results to the dedicated Glean plan
+          STARFOX_SPLIT=glean uv run pytest --fx-executable="$FX_EXECUTABLE" tests/glean || TEST_EXIT_CODE=$?
           mv artifacts artifacts-mac || true
           exit $TEST_EXIT_CODE
 

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -1086,8 +1086,8 @@ def collect_changes(testrail_session: TestRail, report):
         )
 
     # Find plan to attach runs to, create if doesn't exist
-    # Warn-level: CI runs at log_cli_level=warn, so info would not surface
-    logging.warning(f"Plan title: {plan_title}")
+    # Informational, but logged at warn: CI runs at log_cli_level=warn
+    logging.warning(f"[INFO] Plan title: {plan_title}")
     milestone_id = channel_milestone.get("id")
     expected_plan = testrail_session.matching_plan_in_milestone(
         TESTRAIL_FX_DESK_PRJ, milestone_id, plan_title

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -167,11 +167,13 @@ def get_plan_title(version_str: str, channel: str) -> str:
             .replace("{minor}", minor)
             .replace("{beta}", "rc")
         )
-    if os.environ.get("STARFOX_SPLIT") and os.environ.get("STARFOX_SPLIT").startswith(
-        "functional"
-    ):
-        functional_split = os.environ["STARFOX_SPLIT"].split("functional")[-1]
+    split = os.environ.get("STARFOX_SPLIT") or ""
+    if split.startswith("functional"):
+        functional_split = split.split("functional")[-1]
         plan_title = f"{plan_title} - Functional (Split {functional_split})"
+    elif split == "glean":
+        # Glean reports to its own plan; it is not part of the smoke run
+        plan_title = f"{plan_title} - Glean Telemetry"
     return plan_title
 
 
@@ -1084,7 +1086,8 @@ def collect_changes(testrail_session: TestRail, report):
         )
 
     # Find plan to attach runs to, create if doesn't exist
-    logging.info(f"Plan title: {plan_title}")
+    # Warn-level: CI runs at log_cli_level=warn, so info would not surface
+    logging.warning(f"Plan title: {plan_title}")
     milestone_id = channel_milestone.get("id")
     expected_plan = testrail_session.matching_plan_in_milestone(
         TESTRAIL_FX_DESK_PRJ, milestone_id, plan_title

--- a/taskcluster/kinds/new-beta-qa/kind.yml
+++ b/taskcluster/kinds/new-beta-qa/kind.yml
@@ -51,7 +51,7 @@ tasks:
         uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);
         export FAILURE=${?};
         export REPORTABLE=1;
-        uv run pytest --fx-executable $FX_EXECUTABLE tests/glean;
+        STARFOX_SPLIT=glean uv run pytest --fx-executable $FX_EXECUTABLE tests/glean;
         export FAILURE=$((FAILURE | ${?}));
         uv run python scripts/switch_config.py ci_headed;
         mv ./config/ci_pyproject_headed.toml ./pyproject.toml;

--- a/taskcluster/kinds/new-rc-qa/kind.yml
+++ b/taskcluster/kinds/new-rc-qa/kind.yml
@@ -53,7 +53,7 @@ tasks:
         uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);
         export FAILURE=${?};
         export REPORTABLE=1;
-        uv run pytest --fx-executable $FX_EXECUTABLE tests/glean;
+        STARFOX_SPLIT=glean uv run pytest --fx-executable $FX_EXECUTABLE tests/glean;
         export FAILURE=$((FAILURE | ${?}));
         uv run python scripts/switch_config.py ci_headed;
         uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);

--- a/tests/glean/conftest.py
+++ b/tests/glean/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture()
 def suite_id():
-    return "S70197", "Glean Telemetry"
+    return ("S70197", "Glean Telemetry")
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2059438](https://bugzilla.mozilla.org/show_bug.cgi?id=2059438)
TestRail: N/A

### Description of Code / Doc Changes

- This creates a new Glean TestRail report entry, outside of smoke. Note that the job is still smoke, nothing about execution changes. Same tests, same platforms, same schedule. Only where the results are filed.
- This is the first PR of the Glean separation work; more will follow.
   - We need to decide whether Glean should run in its own job, stay in smoke, or move to the functional set. Each has  pros and cons.
   - Also worth taking into account as more tests are added, the volume of live searches from CI grows and with it the risk of triggering bot detection. L10n already handles this by splitting across betas (`beta_split = (beta_version % 3) + 1`). We could do something similar for Glean, a simple even/odd split across two betas, or moving to three way split direclty.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
