### PR TITLE
Anca/ Skip glean SERP cases blocked by engine bot challenges on CI (temporary solution)

### DIFF
--- a/tests/glean/serp_engagement/test_serp_engagement.py
+++ b/tests/glean/serp_engagement/test_serp_engagement.py
@@ -14,6 +14,12 @@ from tests.glean.utils import load_cases
 data = load_cases(__file__)
 METRIC = data["metric"]
 
+# Cases whose result-link click never reaches a real SERP because the engine serves a bot challenge
+# to CI IPs instead. Keyed by platform, since the challenged set differs per platform.
+BOT_CHALLENGE_SKIPS = {
+    "Linux": ("3255530", "3255533"),
+}
+
 
 @pytest.fixture(
     params=data["cases"],
@@ -38,8 +44,11 @@ def add_to_prefs_list(case):
     return prefs
 
 
-def test_serp_engagement(driver: Firefox, case: dict):
+def test_serp_engagement(driver: Firefox, case: dict, sys_platform: str):
     """Verify serp.engagement Glean event payload after a SERP result is clicked."""
+    if case["id"] in BOT_CHALLENGE_SKIPS.get(sys_platform, ()):
+        pytest.skip("Engine serves a bot challenge instead of a SERP on CI")
+
     prefs = AboutPrefs(driver, category="search")
     glean = Glean(driver)
     params = case.get("params", {})

--- a/tests/glean/serp_impression/test_serp_impression.py
+++ b/tests/glean/serp_impression/test_serp_impression.py
@@ -15,6 +15,14 @@ from tests.glean.utils import load_cases
 data = load_cases(__file__)
 METRIC = data["metric"]
 
+# Cases whose on-page SERP interaction never reaches a real SERP because the engine serves a bot
+# challenge to CI IPs instead. Keyed by platform, since the challenged set differs per platform.
+BOT_CHALLENGE_SKIPS = {
+    "Linux": ("3255447", "3255452", "3255477", "3255482"),
+    "Darwin": ("3255477", "3255482"),
+    "Windows": ("3255477", "3255482"),
+}
+
 
 @pytest.fixture(
     params=data["cases"],
@@ -43,14 +51,8 @@ def add_to_prefs_list(case):
 
 def test_serp_impression(driver: Firefox, case: dict, sys_platform: str):
     """Verify serp.impression Glean event payload after a SERP is opened."""
-    # Bing serves a bot-detection captcha on Linux CI for this flow's double-request pattern,
-    # so the refinement never reaches a real SERP.
-    if (
-        sys_platform == "Linux"
-        and case["entry"] == "follow_on_from_refine_on_incontent_search"
-        and case.get("params", {}).get("engine") == "Bing"
-    ):
-        pytest.skip("Bing follow_on hits a bot-detection captcha on Linux CI")
+    if case["id"] in BOT_CHALLENGE_SKIPS.get(sys_platform, ()):
+        pytest.skip("Engine serves a bot challenge instead of a SERP on CI")
 
     prefs = AboutPrefs(driver, category="search")
     glean = Glean(driver)


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: _

### Description of Code / Doc Changes

- Temporary solution to unblock prs and red glean status. search engines serve a bot challenge (Cloudflare "Just a moment…" / Turnstile) to CI datacenter IPs instead of a real SERP.  I ran into the same thing recently with Qwant on FR, and on the next day's run they "self-healed."  I don't know how this detection works (apart for the actually traffic volume), EU region potently have a stricter Cloudflare/GDPR-era bot protection and now I suspect also a region rotation (but I just make assumption here) ..  I think I could set some better skip mechanism (Blocked instead of Untested) on bot detection and see the "trend", then make a decision on reverting to unsuitable or maybe opt for some local pages. 
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
