### PR TITLE
Vs/mouse operations stabilziation

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1607,11 +1607,7 @@ tabs:
     splits:
     - functional3
   test_close_pinned_tab_via_mouse:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047903
-    result:
-      linux: unstable
-      mac: pass
-      win: pass
+    result: pass
     splits:
     - smoke
     - ci
@@ -1666,8 +1662,7 @@ tabs:
     splits:
     - smoke
   test_open_new_bg_tab_via_mouse_and_keyboard:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047903
-    result: unstable
+    result: pass
     splits:
     - functional3
   test_open_new_tab:

--- a/tests/tabs/test_close_pinned_tab_via_mouse.py
+++ b/tests/tabs/test_close_pinned_tab_via_mouse.py
@@ -11,30 +11,38 @@ def test_case():
 
 
 @pytest.mark.headed
-def test_close_pinned_tab_via_middle_click(driver: Firefox):
+def test_close_pinned_tab_via_mouse(driver: Firefox):
     """
     C134726 - Verify middle-clicking pinned tab will close it
     """
-
-    # Instantiate objects
     example = ExamplePage(driver)
     tabs = TabBar(driver)
     tab_menu = ContextMenu(driver)
 
-    # Open 2 new tabs
+    # Open 2 new tabs and preserve the handle of the tab to be pinned.
     example.open()
+    pinned_tab_handle = driver.current_window_handle
+
     for _ in range(2):
         tabs.new_tab_by_button()
+
     tabs.wait_for_num_tabs(3)
 
-    # Pin the first tab
-    first_tab = tabs.get_tab(1)
-    tabs.context_click(first_tab)
+    # Pin the first tab and wait for the pinned state.
+    tabs.context_click("tab-by-index", labels=["1"])
     tab_menu.click_and_hide_menu("context-menu-pin-tab")
-    assert tabs.is_pinned(first_tab), "Expected the first tab to be pinned"
+    tabs.element_attribute_is(
+        "tab-by-index",
+        "pinned",
+        "true",
+        labels=["1"],
+    )
 
-    # Middle-click the pinned tab to close it
-    tabs.middle_click(first_tab)
+    # Middle-click the freshly located pinned tab.
+    tabs.close_tab_by_middle_click(1)
 
-    # Verify pinned tab was closed and 2 tabs remain
+    # Verify that the pinned tab specifically was closed.
     tabs.wait_for_num_tabs(2)
+    assert pinned_tab_handle not in driver.window_handles, (
+        "Expected the pinned tab to be closed"
+    )

--- a/tests/tabs/test_open_new_bg_tab_via_mouse_and_keyboard.py
+++ b/tests/tabs/test_open_new_bg_tab_via_mouse_and_keyboard.py
@@ -1,14 +1,68 @@
+from collections.abc import Callable
+
 import pytest
-from selenium.webdriver import Firefox
+from selenium.webdriver import ActionChains, Firefox
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support.ui import WebDriverWait
 
 from modules.page_object import ExamplePage
 
 TEST_URL = "https://www.iana.org/help/example-domains"
+LINK_ELEMENT = "learn-more"
+TAB_OPEN_TIMEOUT = 10
 
 
 @pytest.fixture()
 def test_case():
     return "134455"
+
+
+def _middle_click(driver: Firefox, element: WebElement) -> None:
+    """Middle-click an element using W3C pointer actions."""
+    actions = ActionChains(driver)
+    actions.move_to_element(element).perform()
+    actions.w3c_actions.pointer_action.pointer_down(1)
+    actions.w3c_actions.pointer_action.pointer_up(1)
+    actions.perform()
+
+
+def _verify_link_opens_in_background(
+    driver: Firefox,
+    example: ExamplePage,
+    click_action: Callable[[WebElement], object],
+) -> None:
+    original_handle = driver.current_window_handle
+    handles_before = set(driver.window_handles)
+
+    try:
+        example.element_clickable(LINK_ELEMENT)
+        link = example.get_element(LINK_ELEMENT)
+        click_action(link)
+
+        def _new_tab_handle(current_driver):
+            new_handles = set(current_driver.window_handles) - handles_before
+
+            if len(new_handles) == 1:
+                return next(iter(new_handles))
+
+            return False
+
+        new_handle = WebDriverWait(driver, TAB_OPEN_TIMEOUT).until(_new_tab_handle)
+
+        assert driver.current_window_handle == original_handle, (
+            "Expected the link to open in a background tab"
+        )
+
+        driver.switch_to.window(new_handle)
+        example.url_contains(TEST_URL)
+
+    finally:
+        for handle in set(driver.window_handles) - handles_before:
+            driver.switch_to.window(handle)
+            driver.close()
+
+        if original_handle in driver.window_handles:
+            driver.switch_to.window(original_handle)
 
 
 @pytest.mark.headed
@@ -17,25 +71,19 @@ def test_open_new_bg_tab_via_mouse_and_keyboard(driver: Firefox):
     C134455 - Verify that opening hyperlink with mouse or keyboard
     shortcuts creates new background tabs
     """
-
-    # Instantiate objects
     example = ExamplePage(driver)
     example.open()
 
-    # Middle click link, verify new background tab opens with correct URL
-    example.middle_click("learn-more")
-    example.wait_for_num_tabs(2)
-    example.switch_to_new_tab()
+    # Verify opening the link with a W3C middle click.
+    _verify_link_opens_in_background(
+        driver,
+        example,
+        lambda link: _middle_click(driver, link),
+    )
 
-    example.url_contains(TEST_URL)
-
-    # Close new tab, switch back to original example page
-    driver.close()
-    example.switch_to_new_tab()
-
-    # Control click link, verify new background tab opens with correct URL
-    example.control_click("learn-more")
-    example.wait_for_num_tabs(2)
-    example.switch_to_new_tab()
-
-    example.url_contains(TEST_URL)
+    # Verify opening the link with Control/Command click.
+    _verify_link_opens_in_background(
+        driver,
+        example,
+        example.control_click,
+    )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2042107](https://bugzilla.mozilla.org/show_bug.cgi?id=2042107)
TestRail: N/A

### Description of Code / Doc Changes

Changed name of test to match filename and key.yaml.
Replaced coordinate-based middle clicks with W3C pointer actions for more reliable interaction.
Re-located tab elements after state changes to avoid stale references.
Identified newly opened/closed tabs using window handles instead of tab order.
Added explicit waits and cleanup to restore the original tab even when assertions fail.

Thank you!
