### PR TITLE
vs/Stabilize middle-click tab interaction tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1604,8 +1604,7 @@ tabs:
     - smoke
     - ci
   test_close_tab_through_middle_mouse_click:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2047903
-    result: unstable
+    result: pass
     splits:
     - ci
     - functional3

--- a/tests/tabs/test_close_tab_through_middle_mouse_click.py
+++ b/tests/tabs/test_close_tab_through_middle_mouse_click.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_tabbar import TabBar
+from modules.browser_object import TabBar
 from modules.page_object import ExamplePage
 
 
@@ -15,20 +15,38 @@ def test_close_tab_through_middle_mouse_click(driver: Firefox):
     """
     C134645 - Verify that middle click on a tab will close it
     """
-
-    # Instantiate objects
     example = ExamplePage(driver)
     tabs = TabBar(driver)
 
-    # Open 2 new tabs for a total of 3
+    # Open 2 new tabs for a total of 3.
     example.open()
-    for _ in range(2):
-        tabs.new_tab_by_button()
-    tabs.wait_for_num_tabs(3)
+    original_handle = driver.current_window_handle
+    created_handles = []
 
-    # Ensure each tab exists and middle-click to close it
-    for i in range(3, 1, -1):
-        tab_to_close = tabs.get_tab(i)
-        assert tab_to_close is not None, f"Expected tab index {i} to exist"
-        tabs.middle_click(tab_to_close)
-        tabs.wait_for_num_tabs(i - 1)
+    for expected_tab_count in (2, 3):
+        handles_before = set(driver.window_handles)
+
+        tabs.new_tab_by_button()
+        tabs.wait_for_num_tabs(expected_tab_count)
+
+        new_handles = set(driver.window_handles) - handles_before
+
+        assert len(new_handles) == 1, (
+            f"Expected exactly one new tab, but found: {new_handles}"
+        )
+        created_handles.append(new_handles.pop())
+
+    # Close the third and second tabs using W3C middle-click actions.
+    for tab_index, expected_closed_handle in (
+        (3, created_handles[1]),
+        (2, created_handles[0]),
+    ):
+        tabs.close_tab_by_middle_click(tab_index)
+        tabs.wait_for_num_tabs(tab_index - 1)
+
+        assert expected_closed_handle not in driver.window_handles, (
+            f"Expected tab {tab_index} to be closed"
+        )
+        assert original_handle in driver.window_handles, (
+            "Expected the original tab to remain open"
+        )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2042107](https://bugzilla.mozilla.org/show_bug.cgi?id=2042107) and [2047903](https://bugzilla.mozilla.org/show_bug.cgi?id=2047903)
TestRail: N/A

### Description of Code / Doc Changes

Replaced coordinate-based middle clicks with TabBar.close_tab_by_middle_click().
Tracked the exact handles of the two newly opened tabs.
Verified that the intended tab handle closes after each middle click.
Confirmed that the original tab remains open throughout the test.

Thank you!
