### PR TITLE
Anca/ Fix duplicate links in TestRail plans

### DIFF
--- a/TESTRAIL_INTEGRATION.md
+++ b/TESTRAIL_INTEGRATION.md
@@ -161,7 +161,10 @@ Dry-run never opens a TestRail session and never modifies any state.
 - a TaskCluster log (for Linux runs that set `TASKCLUSTER_PROXY_URL`), or
 - a GitHub Actions run (Windows / Mac via `GITHUB_REPOSITORY` + `GITHUB_RUN_ID`).
 
-If a line for the same OS already exists, it's replaced rather than duplicated.
+A plan keeps at most one link per OS. Every existing link for the reporting OS is
+dropped before the current one is re-inserted in its place, so a plan that several
+jobs report to (matrix splits per platform, headless + headed re-runs, one TC task
+per suite) collapses back to one link per OS instead of accumulating one per job.
 
 ## Helper scripts
 

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -69,31 +69,45 @@ def get_execution_link(os_name: str = None) -> str:
     return ""
 
 
-def replace_link_in_description(description, os_name) -> str:
-    """Add or replace a test execution link in the test run description"""
+def replace_link_in_description(description: str, os_name: str) -> str:
+    """
+    Leave exactly one execution link for os_name in the description.
+
+    Every link for this OS is dropped, however many copies there are and
+    wherever they sit, then the current one is re-inserted where the first copy
+    was, so platform order stays stable and unrelated text is kept.
+    """
 
     link = get_execution_link(os_name)
     if not link:
         return description
 
     new_line = f"[{os_name} execution link]({link})"
-    lines = description.splitlines()
     pat = re.compile(
-        rf"^\s*\[{re.escape(os_name)}\s+execution\s+link\]\(.*?\)\s*$",
+        rf"\[\s*{re.escape(os_name)}\s+execution\s+link\]\([^)]*\)",
         re.IGNORECASE,
     )
 
-    # Look for existing line to replace
-    for i, line in enumerate(lines):
-        if pat.match(line):
-            if line.strip() == new_line:
-                return description
-            lines[i] = new_line
-            return "\n".join(lines)
+    lines = []
+    insert_at = None
+    for line in description.splitlines():
+        if not pat.search(line):
+            lines.append(line)
+            continue
+        # Keep anything that shares the line with the link(s), but not leftover
+        # punctuation (a list marker, a stray bracket) from an older format
+        remainder = pat.sub("", line).strip()
+        if re.search(r"\w", remainder):
+            lines.append(remainder)
+        if insert_at is None:
+            insert_at = len(lines)
 
-    # No existing line found, append new one
-    lines.append(new_line)
-    return "\n".join(lines)
+    if insert_at is None:
+        insert_at = len(lines)
+    lines.insert(insert_at, new_line)
+
+    updated = "\n".join(lines)
+    return description if updated == description else updated
 
 
 def determine_current_os() -> str:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2059740](https://bugzilla.mozilla.org/show_bug.cgi?id=2059740)
TestRail: N/A

### Description of Code / Doc Changes

- Plan descriptions In TestRail  were accumulating duplicate execution links, up to one per reporting session instead of one per OS. Fix it by keeping one execution link per OS. Also, I've checked #1547, that is currently in review, shouldn't be  no conflict or dependency. 

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
