### PR TITLE
Anca/ Run Glean before smoke on Linux so an interrupted run cannot drop it (temporary fix)

### DIFF
--- a/taskcluster/kinds/new-beta-qa/kind.yml
+++ b/taskcluster/kinds/new-beta-qa/kind.yml
@@ -48,11 +48,12 @@ tasks:
         $FX_EXECUTABLE --version;
         . ./scripts/keyring-unlock.sh
         uv run python -m scripts.choose_test_split;
-        uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);
-        export FAILURE=${?};
-        export REPORTABLE=1;
+        # Glean first, and unforced: a retry is decided by smoke coverage, so glean must not run last
         STARFOX_SPLIT=glean uv run pytest --fx-executable $FX_EXECUTABLE tests/glean;
+        export FAILURE=${?};
+        uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);
         export FAILURE=$((FAILURE | ${?}));
+        export REPORTABLE=1;
         uv run python scripts/switch_config.py ci_headed;
         mv ./config/ci_pyproject_headed.toml ./pyproject.toml;
         uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);

--- a/taskcluster/kinds/new-rc-qa/kind.yml
+++ b/taskcluster/kinds/new-rc-qa/kind.yml
@@ -50,11 +50,12 @@ tasks:
         $FX_EXECUTABLE --version;
         . ./scripts/keyring-unlock.sh
         uv run python -m scripts.choose_test_split;
-        uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);
-        export FAILURE=${?};
-        export REPORTABLE=1;
+        # Glean first, and unforced: a retry is decided by smoke coverage, so glean must not run last
         STARFOX_SPLIT=glean uv run pytest --fx-executable $FX_EXECUTABLE tests/glean;
+        export FAILURE=${?};
+        uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);
         export FAILURE=$((FAILURE | ${?}));
+        export REPORTABLE=1;
         uv run python scripts/switch_config.py ci_headed;
         uv run pytest --fx-executable $FX_EXECUTABLE $(cat selected_tests);
         exit $((${?} | ${FAILURE}))


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: N/A

### Description of Code / Doc Changes

- Glean runs inside the same Taskcluster task as smoke, right after it. When that run is interrupted the task gets retried, and the retry exits early because the smoke results are already in TestRail, so Glean never runs. It happens intermittently, like a coin flip: Linux Glean coverage was missed on both 154.0b5 and 154.0b6.
- This isn't an ideal solution, but after looking into it, it's the best I have  to justify today's work, but it does have real drawbacks, mainly that Glean and smoke share the same time budget. Glean tests aren't smoke tests and already report to a separate plan, further discussions are underway about where the Glean jobs belong; all three options have pros and cons.
- What this changes
   - Glean moves ahead of the smoke suite, so an interruption later in the task can no longer starve it.
   - export REPORTABLE=1 moves down to just before the headed rerun, which is the phase that needs it.
   -  Because Glean is no longer force-reported, it checks whether its own results already exist and exits in seconds if they do. A retry therefore skips Glean instead of running it twice. That exit returns code 0, so a skip does not fail the task.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

 - b6: XccwVKpkRAStiuWFhRKAnA - run 0 ran 72 smoke tests and posted them, then the log cuts off before the glean command. Run 1 (retry) resolved SUCCEEDED in 56 seconds, having only run the reportability check ("23 Linux test runs, all required suites covered").
 - b5: UhhOiXExTaOrCO5iKjEhmw - same pattern, 54 seconds. 
 - b4: Irk2Y46-QbCk0vFp1KfaSA - one run, no retries, 23 minutes, glean ran normally.

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
