### PR TITLE
vs/Stabilize reopen tabs through keys.

### DIFF
--- a/modules/browser_object_tabbar.py
+++ b/modules/browser_object_tabbar.py
@@ -445,12 +445,10 @@ class TabBar(BasePage):
         return selected_tabs
 
     @BasePage.context_chrome
-    def reopen_tabs_with_shortcut(self, sys_platform: str, count: int) -> None:
+    def reopen_tabs_with_shortcut(self, count: int) -> None:
         """Reopen closed tabs using keyboard shortcut Ctrl/Cmd + Shift + T."""
-        modifier = Keys.COMMAND if sys_platform == "Darwin" else Keys.CONTROL
-
         for _ in range(count):
-            self.perform_key_combo(modifier, Keys.SHIFT, "t")
+            self.perform_key_combo(Keys.CONTROL, Keys.SHIFT, "t")
 
     @BasePage.context_chrome
     def reload_tab(self, nav, mod_key=None, extra_key=None):

--- a/modules/browser_object_tabbar.py
+++ b/modules/browser_object_tabbar.py
@@ -448,10 +448,9 @@ class TabBar(BasePage):
     def reopen_tabs_with_shortcut(self, sys_platform: str, count: int) -> None:
         """Reopen closed tabs using keyboard shortcut Ctrl/Cmd + Shift + T."""
         modifier = Keys.COMMAND if sys_platform == "Darwin" else Keys.CONTROL
+
         for _ in range(count):
-            self.actions.key_down(modifier).key_down(Keys.SHIFT).send_keys(
-                "t"
-            ).key_down(Keys.SHIFT).key_up(modifier).perform()
+            self.perform_key_combo(modifier, Keys.SHIFT, "t")
 
     @BasePage.context_chrome
     def reload_tab(self, nav, mod_key=None, extra_key=None):

--- a/tests/session_restore/test_restore_last_closed_tabs_shortcut.py
+++ b/tests/session_restore/test_restore_last_closed_tabs_shortcut.py
@@ -31,7 +31,7 @@ def test_restore_closed_tabs(driver: Firefox, tabs: TabBar, sys_platform: str):
     tabs.wait_for_num_tabs(2)
     driver.close()
     tabs.wait_for_num_tabs(1)
-    tabs.reopen_tabs_with_shortcut(sys_platform, count=1)
+    tabs.reopen_tabs_with_shortcut(count=1)
     tabs.wait_for_num_tabs(2)
 
     # Clean up for next steps
@@ -52,7 +52,7 @@ def test_restore_closed_tabs(driver: Firefox, tabs: TabBar, sys_platform: str):
     tabs.wait_for_num_tabs(1)
 
     # Use the method to restore the closed tabs with shortcut
-    tabs.reopen_tabs_with_shortcut(sys_platform, count=4)
+    tabs.reopen_tabs_with_shortcut(count=4)
     tabs.wait_for_num_tabs(5)
 
     # Verify the page of each tab was restored

--- a/tests/session_restore/test_restore_multiple_closed_tabs_at_once.py
+++ b/tests/session_restore/test_restore_multiple_closed_tabs_at_once.py
@@ -41,7 +41,7 @@ def test_restore_multiple_closed_tabs(driver: Firefox, tabs: TabBar, sys_platfor
     tabs.wait_for_num_tabs(1)
 
     # Use the method to restore the closed tabs with shortcut
-    tabs.reopen_tabs_with_shortcut(sys_platform, count=1)
+    tabs.reopen_tabs_with_shortcut(count=1)
     tabs.wait_for_num_tabs(5)
 
     # Verify the tabs are restored

--- a/tests/tabs/test_reopen_tabs_through_keys.py
+++ b/tests/tabs/test_reopen_tabs_through_keys.py
@@ -69,7 +69,7 @@ def test_reopen_tabs_through_keys(driver: Firefox, sys_platform: str):
     for expected_tab_count in range(2, len(URLS) + 2):
         handles_before = set(driver.window_handles)
 
-        tabs.reopen_tabs_with_shortcut(sys_platform, count=1)
+        tabs.reopen_tabs_with_shortcut(count=1)
         tabs.wait_for_num_tabs(expected_tab_count)
 
         new_handles = set(driver.window_handles) - handles_before

--- a/tests/tabs/test_reopen_tabs_through_keys.py
+++ b/tests/tabs/test_reopen_tabs_through_keys.py
@@ -3,18 +3,19 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import TabBar
 
-
-@pytest.fixture()
-def test_case():
-    return "134640"
-
-
-URLS = [
+URLS = (
     "about:about",
     "about:addons",
     "about:cache",
     "about:robots",
-]
+)
+
+ORIGINAL_URL = "about:mozilla"
+
+
+@pytest.fixture()
+def test_case():
+    return "134640"
 
 
 def test_reopen_tabs_through_keys(driver: Firefox, sys_platform: str):
@@ -22,32 +23,69 @@ def test_reopen_tabs_through_keys(driver: Firefox, sys_platform: str):
     C134640 - Verify that previously closed tabs can be reopened using
     the keyboard shortcut (Ctrl/Cmd + Shift + T).
     """
-
-    # Instantiate object
     tabs = TabBar(driver)
 
-    # Create 4 new tabs
-    for i in range(4):
+    # Prevent Firefox from restoring the first closed tab into an existing
+    # blank new tab without creating a new window handle.
+    driver.get(ORIGINAL_URL)
+    tabs.url_contains(ORIGINAL_URL)
+
+    original_handle = driver.current_window_handle
+    opened_handles = []
+
+    for expected_tab_count, url in enumerate(URLS, start=2):
+        handles_before = set(driver.window_handles)
+
         tabs.new_tab_by_button()
-        driver.switch_to.window(driver.window_handles[-1])
-        driver.get(URLS[i])
-    tabs.wait_for_num_tabs(5)
+        tabs.wait_for_num_tabs(expected_tab_count)
 
-    # Close 4 tabs
-    for i in range(4):
-        driver.close()
-        driver.switch_to.window(driver.window_handles[-1])
-    tabs.wait_for_num_tabs(1)
+        new_handles = set(driver.window_handles) - handles_before
+        assert len(new_handles) == 1, (
+            f"Expected exactly one new tab, but found: {new_handles}"
+        )
 
-    # Use the refactored method to reopen tabs with shortcut
-    tabs.reopen_tabs_with_shortcut(sys_platform, count=4)
+        new_handle = new_handles.pop()
+        opened_handles.append(new_handle)
 
-    # Verify the correct tabs reopened (order is not considered)
-    open_urls = set()
+        driver.switch_to.window(new_handle)
+        driver.get(url)
+        tabs.url_contains(url)
 
-    for handle in driver.window_handles:
+    # Close only the tabs created by this test, newest first.
+    for expected_tab_count, handle in zip(
+        range(len(URLS), 0, -1),
+        reversed(opened_handles),
+        strict=True,
+    ):
         driver.switch_to.window(handle)
-        open_urls.add(driver.current_url)
+        driver.close()
+        tabs.wait_for_num_tabs(expected_tab_count)
 
-    for url in URLS:
-        assert url in open_urls, f"Expected reopened tab with URL '{url}' not found"
+    driver.switch_to.window(original_handle)
+
+    reopened_handles = []
+
+    # Restore and wait for one tab at a time to avoid racing Firefox.
+    for expected_tab_count in range(2, len(URLS) + 2):
+        handles_before = set(driver.window_handles)
+
+        tabs.reopen_tabs_with_shortcut(sys_platform, count=1)
+        tabs.wait_for_num_tabs(expected_tab_count)
+
+        new_handles = set(driver.window_handles) - handles_before
+        assert len(new_handles) == 1, (
+            f"Expected exactly one tab to reopen, but found: {new_handles}"
+        )
+
+        reopened_handles.append(new_handles.pop())
+
+    reopened_urls = set()
+
+    for handle in reopened_handles:
+        driver.switch_to.window(handle)
+        tabs.expect_in_content(lambda _: driver.current_url in URLS)
+        reopened_urls.add(driver.current_url)
+
+    assert reopened_urls == set(URLS), (
+        f"Expected reopened URLs {set(URLS)}, but found {reopened_urls}"
+    )

--- a/tests/tabs/test_reopen_tabs_through_keys.py
+++ b/tests/tabs/test_reopen_tabs_through_keys.py
@@ -83,7 +83,7 @@ def test_reopen_tabs_through_keys(driver: Firefox, sys_platform: str):
 
     for handle in reopened_handles:
         driver.switch_to.window(handle)
-        tabs.expect_in_content(lambda _: driver.current_url in URLS)
+        tabs.expect_in_content(lambda d: d.current_url in URLS)
         reopened_urls.add(driver.current_url)
 
     assert reopened_urls == set(URLS), (


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: N/A

### Description of Code / Doc Changes

Navigated the original tab to about:mozilla so Firefox does not reuse a blank tab during restoration.
Tracked newly opened and restored tabs using their exact window handles.
Closed and reopened tabs individually, waiting for the expected tab count after each action.
Verified that every shortcut restores exactly one new tab.
Corrected the keyboard shortcut helper to release Shift and the platform modifier properly.
Validated that the four restored tabs contain exactly the expected URLs.

Thank you!
