### PR TITLE
Anca/ Make TestRail execution links clickable (follow-up to #1549)

### DIFF
--- a/TESTRAIL_INTEGRATION.md
+++ b/TESTRAIL_INTEGRATION.md
@@ -161,6 +161,8 @@ Dry-run never opens a TestRail session and never modifies any state.
 - a TaskCluster log (for Linux runs that set `TASKCLUSTER_PROXY_URL`), or
 - a GitHub Actions run (Windows / Mac via `GITHUB_REPOSITORY` + `GITHUB_RUN_ID`).
 
+Written as plain text (`Windows execution link: <url>`) because TestRail auto-links bare URLs but does not render markdown in the plan overview.
+
 A plan keeps at most one link per OS. Every existing link for the reporting OS is
 dropped before the current one is re-inserted in its place, so a plan that several
 jobs report to (matrix splits per platform, headless + headed re-runs, one TC task

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -82,9 +82,10 @@ def replace_link_in_description(description: str, os_name: str) -> str:
     if not link:
         return description
 
-    new_line = f"[{os_name} execution link]({link})"
+    # TestRail does not render markdown here, but it does auto-link a bare URL
+    new_line = f"{os_name} execution link: {link}"
     pat = re.compile(
-        rf"\[\s*{re.escape(os_name)}\s+execution\s+link\]\([^)]*\)",
+        rf"{re.escape(os_name)}\s+execution\s+link\s*:\s*\S+",
         re.IGNORECASE,
     )
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: N/A

### Description of Code / Doc Changes

-  Follow-up to #1549, which fixed the duplicate links. The links are written as markdown, `[Mac execution link](https://...)`, and TestRail shows that as raw text in the plan overview instead of a link. It does turn a bare URL into a link, so each line is now written as: 
Mac execution link: https://github.com/mozilla/fx-desktop-qa-automation/actions/runs/31012150312
- Checked in TestRail first: I added both forms to a plan description by hand, and only the bare URL became clickable. The URLs and the one-link-per-OS behaviour from #1549 are unchanged. Older plans keep the markdown lines, they have finished reporting, so nothing rewrites them.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
