### PR TITLE
Anca/ Write TestRail execution links as HTML anchors (supersedes #1555)

### DIFF
--- a/TESTRAIL_INTEGRATION.md
+++ b/TESTRAIL_INTEGRATION.md
@@ -161,27 +161,13 @@ Dry-run never opens a TestRail session and never modifies any state.
 - a TaskCluster log (for Linux runs that set `TASKCLUSTER_PROXY_URL`), or
 - a GitHub Actions run (Windows / Mac via `GITHUB_REPOSITORY` + `GITHUB_RUN_ID`).
 
-Written as a line break plus an anchor tag
-(`<br><a href="<url>" target="_blank" ...>Windows execution link</a>`), matching how the
-hand-authored plans in this project store their links. The `<br>` is load-bearing: TestRail
-folds the whole description into a single paragraph and drops any `</p>` sent to it, so an
-anchor without one is pulled onto the end of the preceding text, and an anchor wrapped in
-its own `<p>` produces invalid nesting.
+Written as `<br><a href="<url>" target="_blank" ...><OS> execution link</a>`. The field
+is HTML, so markdown and bare URLs are shown literally. The `<br>` puts the link on its own
+line: TestRail folds the description into one paragraph and drops any `</p>` sent to it.
 
-Markdown (`[Windows execution link](<url>)`) worked here for a year, until TestRail moved
-this field to its Froala rich-text editor between 2026-07-27 and 2026-07-29. Plans up to
-154.0b3 are stored as plain text; 154.0b4 onward are HTML-wrapped by TestRail itself, which
-is how the change is datable — this repo has never written a `<p>` tag.
-
-`update_plan` has no editor in the path: it stores the literal string it is sent, wrapping
-it in `<p>` and turning newlines into paragraph breaks. So the API never linkified anything.
-What changed is that the renderer stopped parsing markdown, which left a year of `[...](...)`
-showing literally. Only the UI editor linkifies a URL as you type it — so editing a
-description by hand is not a valid test of what CI produces, and it silently converts that
-plan's stored description to HTML.
-
-All three formats this repo has written (anchor, markdown, bare URL) are recognized when
-replacing, so plans from before the switch upgrade in place as each platform reports.
+TestRail's UI editor creates the anchor itself, so hand-editing a description does not
+test what CI produces. Markdown and bare-URL entries are still recognized when replacing,
+so older plans upgrade in place.
 
 A plan keeps at most one link per OS. Every existing link for the reporting OS is
 dropped before the current one is re-inserted in its place, so a plan that several

--- a/TESTRAIL_INTEGRATION.md
+++ b/TESTRAIL_INTEGRATION.md
@@ -161,7 +161,27 @@ Dry-run never opens a TestRail session and never modifies any state.
 - a TaskCluster log (for Linux runs that set `TASKCLUSTER_PROXY_URL`), or
 - a GitHub Actions run (Windows / Mac via `GITHUB_REPOSITORY` + `GITHUB_RUN_ID`).
 
-Written as plain text (`Windows execution link: <url>`) because TestRail auto-links bare URLs but does not render markdown in the plan overview.
+Written as a line break plus an anchor tag
+(`<br><a href="<url>" target="_blank" ...>Windows execution link</a>`), matching how the
+hand-authored plans in this project store their links. The `<br>` is load-bearing: TestRail
+folds the whole description into a single paragraph and drops any `</p>` sent to it, so an
+anchor without one is pulled onto the end of the preceding text, and an anchor wrapped in
+its own `<p>` produces invalid nesting.
+
+Markdown (`[Windows execution link](<url>)`) worked here for a year, until TestRail moved
+this field to its Froala rich-text editor between 2026-07-27 and 2026-07-29. Plans up to
+154.0b3 are stored as plain text; 154.0b4 onward are HTML-wrapped by TestRail itself, which
+is how the change is datable — this repo has never written a `<p>` tag.
+
+`update_plan` has no editor in the path: it stores the literal string it is sent, wrapping
+it in `<p>` and turning newlines into paragraph breaks. So the API never linkified anything.
+What changed is that the renderer stopped parsing markdown, which left a year of `[...](...)`
+showing literally. Only the UI editor linkifies a URL as you type it — so editing a
+description by hand is not a valid test of what CI produces, and it silently converts that
+plan's stored description to HTML.
+
+All three formats this repo has written (anchor, markdown, bare URL) are recognized when
+replacing, so plans from before the switch upgrade in place as each platform reports.
 
 A plan keeps at most one link per OS. Every existing link for the reporting OS is
 dropped before the current one is re-inserted in its place, so a plan that several

--- a/modules/testrail_integration.py
+++ b/modules/testrail_integration.py
@@ -69,45 +69,54 @@ def get_execution_link(os_name: str = None) -> str:
     return ""
 
 
+def _execution_link_pattern(os_name: str) -> re.Pattern:
+    """Match an execution link in any format this repo has written: anchor,
+    markdown, or bare URL, with the <br>/<p> tags around it."""
+
+    label = rf"{re.escape(os_name)}\s+execution\s+link"
+    body = "|".join(
+        [
+            rf"<a\b[^>]*>\s*{label}\s*</a>",
+            rf"\[\s*{label}\s*\]\([^)]*\)",
+            # stops at "<" because the description is stored as a single line
+            rf"{label}\s*:\s*[^\s<]+",
+        ]
+    )
+    edge = r"(?:<br\s*/?>|<p>)\s*"
+    return re.compile(rf"(?:{edge})?(?:{body})(?:\s*</p>)?", re.IGNORECASE)
+
+
 def replace_link_in_description(description: str, os_name: str) -> str:
     """
     Leave exactly one execution link for os_name in the description.
 
-    Every link for this OS is dropped, however many copies there are and
-    wherever they sit, then the current one is re-inserted where the first copy
-    was, so platform order stays stable and unrelated text is kept.
+    Every copy for this OS is dropped and the current one re-inserted where the
+    first sat, so platform order stays stable and unrelated text is kept.
     """
 
     link = get_execution_link(os_name)
     if not link:
         return description
 
-    # TestRail does not render markdown here, but it does auto-link a bare URL
-    new_line = f"{os_name} execution link: {link}"
-    pat = re.compile(
-        rf"{re.escape(os_name)}\s+execution\s+link\s*:\s*\S+",
-        re.IGNORECASE,
+    # The field is HTML and TestRail only linkifies in its UI editor; the <br>
+    # is what puts the link on its own line
+    new_entry = (
+        f'<br><a href="{link}" target="_blank" rel="noopener noreferrer">'
+        f"{os_name} execution link</a>"
     )
 
-    lines = []
-    insert_at = None
-    for line in description.splitlines():
-        if not pat.search(line):
-            lines.append(line)
-            continue
-        # Keep anything that shares the line with the link(s), but not leftover
-        # punctuation (a list marker, a stray bracket) from an older format
-        remainder = pat.sub("", line).strip()
-        if re.search(r"\w", remainder):
-            lines.append(remainder)
-        if insert_at is None:
-            insert_at = len(lines)
+    # Whole string, not lines: TestRail collapses the description onto one line
+    matches = list(_execution_link_pattern(os_name).finditer(description))
+    if matches:
+        insert_at = matches[0].start()
+        updated = description
+        # Back to front so the earlier offsets stay valid
+        for match in reversed(matches):
+            updated = updated[: match.start()] + updated[match.end() :]
+        updated = updated[:insert_at] + new_entry + updated[insert_at:]
+    else:
+        updated = description + new_entry
 
-    if insert_at is None:
-        insert_at = len(lines)
-    lines.insert(insert_at, new_line)
-
-    updated = "\n".join(lines)
     return description if updated == description else updated
 
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2062575](https://bugzilla.mozilla.org/show_bug.cgi?id=2062575)
TestRail: N/A

### Description of Code / Doc Changes

- Follow-up to Anca/ Fix clickable links #1555, which did not work. Both attempts so far treated this as a formatting choice: #1549 wrote the links as markdown, #1555 switched to a bare URL on the assumption that TestRail auto-links one. Neither renders as a link.
- The cause is on TestRail's side. The plan description used to be a markdown field, which is why [<OS> execution link](url) had worked since 2025. Between 154.0b3 and 154.0b4 TestRail moved that field to a rich-text HTML editor, so markdown is now printed literally and a bare URL is left as plain text. 
- Each line is now written as HTML
- Checked through the API this time, not by hand. Editing a description in the TestRail UI is not a valid test of this path, because the editor linkifies a URL as you type it, that is what made the bare URL look correct last time while the code path stayed broken. I created a scratch plan in the [TEMP] project, drove it through the same calls CI makes, and confirmed that the anchor survives the API, that three platforms produce three clickable links on separate lines, and that a re-run leaves the description byte-identical. The scratch plan has been deleted.
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
