### PR TITLE
Prep STARfox to handle nightly runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -517,7 +517,7 @@ jobs:
           "$FX_EXECUTABLE" --version;
           XVFB_PID=$(ps -e | grep vfb | head -1 | awk '{print $1}')
           if [[ -n "$XVFB_PID" ]]; then kill -9 "$XVFB_PID"; fi;
-          xvfb-run -e /dev/stdout -f "$HOME/.Xauthority" -s "-screen 0 1600x1200x24" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
+          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 1600x1200x24" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 
       - name: Run Smoke Tests in Ubuntu (Headed)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -506,6 +506,8 @@ jobs:
         id: select
         run: |
           uv run python -m scripts.choose_test_split
+        env:
+          STARFOX_EXCLUDE: no_xvfb
 
       - name: Run Smoke Tests in Ubuntu
         if: ${{ steps.select.conclusion == 'success' && inputs.dry_run != true }}
@@ -514,7 +516,7 @@ jobs:
         run: |
           "$FX_EXECUTABLE" --version;
           Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log &
-          DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE"  $(cat selected_tests) || TEST_EXIT_CODE=$?
+          DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 
       - name: Run Smoke Tests in Ubuntu (Headed)
@@ -526,7 +528,7 @@ jobs:
           uv sync;
           uv run python scripts/switch_config.py ci_xvfb_headed;
           uv sync;
-          DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" $(cat selected_tests) || TEST_EXIT_CODE=$?
+          DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 
   Use-Artifacts:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -474,7 +474,7 @@ jobs:
           echo "STARFOX_SPLIT=$TEST_SET" >> "$GITHUB_ENV"
           echo "Running smoke tests on supplied executable"
         env:
-          TEST_SET = ${{ inputs.split }}
+          TEST_SET: ${{ inputs.split }}
 
       - name: Install dependencies
         id: setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,8 @@ on:
         description: 'The link to the Linux tarball (linux-x86_64) for the Fx under test'
         required: false
         type: string
-      split:
-        description: 'The split to run against'
+      test_set:
+        description: 'Test set to run'
         default: "smoke"
         required: false
         type: string
@@ -79,10 +79,10 @@ jobs:
       - name: Set CI Environment (Default)
         shell: pwsh
         run: |
-          "STARFOX_SPLIT=$env:INPUTS_TEST_SET" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "STARFOX_SPLIT=$env:TEST_SET" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "TESTRAIL_REPORT=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         env:
-          INPUTS_TEST_SET: ${{ inputs.test_set }}
+          TEST_SET: ${{ inputs.test_set }}
 
       - name: Set CI Environment (Manual)
         if: ${{ inputs.win_installer_link && inputs.dry_run != true }}
@@ -92,7 +92,7 @@ jobs:
           "STARFOX_SPLIT=$env:TEST_SET" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "Running smoke tests on supplied executable"
         env:
-          TEST_SET: ${{ inputs.split }}
+          TEST_SET: ${{ inputs.test_set }}
 
       - name: Set CI Environment (Scheduled Beta)
         if: ${{ inputs.job_to_run == 'Test-Windows' && inputs.is_pull_request == false && inputs.dry_run != true }}
@@ -296,10 +296,10 @@ jobs:
 
       - name: Set CI Environment (Default)
         run: |
-          echo "STARFOX_SPLIT=${INPUTS_TEST_SET}" >> "$GITHUB_ENV"
+          echo "STARFOX_SPLIT=${TEST_SET}" >> "$GITHUB_ENV"
           echo "TESTRAIL_REPORT=false" >> "$GITHUB_ENV"
         env:
-          INPUTS_TEST_SET: ${{ inputs.test_set }}
+          TEST_SET: ${{ inputs.test_set }}
 
       - name: Check test case numbers
         run: |
@@ -319,7 +319,7 @@ jobs:
           echo "STARFOX_SPLIT=$TEST_SET" >> "$GITHUB_ENV"
           echo "Running smoke tests on supplied executable"
         env:
-          TEST_SET: ${{ inputs.split }}
+          TEST_SET: ${{ inputs.test_set }}
 
       - name: Install dependencies
         id: setup
@@ -457,10 +457,10 @@ jobs:
 
       - name: Set CI Environment (Default)
         run: |
-          echo "STARFOX_SPLIT=${INPUTS_TEST_SET}" >> "$GITHUB_ENV"
+          echo "STARFOX_SPLIT=${TEST_SET}" >> "$GITHUB_ENV"
           echo "TESTRAIL_REPORT=false" >> "$GITHUB_ENV"
         env:
-          INPUTS_TEST_SET: ${{ inputs.test_set }}
+          TEST_SET: ${{ inputs.test_set }}
 
       - name: Check test case numbers
         run: |
@@ -474,7 +474,7 @@ jobs:
           echo "STARFOX_SPLIT=$TEST_SET" >> "$GITHUB_ENV"
           echo "Running smoke tests on supplied executable"
         env:
-          TEST_SET: ${{ inputs.split }}
+          TEST_SET: ${{ inputs.test_set }}
 
       - name: Install dependencies
         id: setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -527,6 +527,8 @@ jobs:
           uv sync;
           uv run python scripts/switch_config.py ci_xvfb_headed;
           uv sync;
+          XVFB_PID=$(ps -e | grep vfb | head -1 | awk '{print $1}')
+          if XVFB_PID; then kill -9 "$XVFB_PID"; fi;
           xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,11 @@ on:
         description: 'The link to the Linux tarball (linux-x86_64) for the Fx under test'
         required: false
         type: string
+      split:
+        description: 'The split to run against'
+        default: "smoke"
+        required: false
+        type: string
 env:
   FX_CHANNEL: ${{ inputs.channel }}
   TESTRAIL_BASE_URL: ${{ secrets.TESTRAIL_BASE_URL }}
@@ -84,8 +89,10 @@ jobs:
         shell: pwsh
         run: |
           "MANUAL=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "STARFOX_SPLIT=smoke" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "STARFOX_SPLIT=$env:TEST_SET" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "Running smoke tests on supplied executable"
+        env:
+          TEST_SET: ${{ inputs.split }}
 
       - name: Set CI Environment (Scheduled Beta)
         if: ${{ inputs.job_to_run == 'Test-Windows' && inputs.is_pull_request == false && inputs.dry_run != true }}
@@ -309,8 +316,10 @@ jobs:
         if: ${{ inputs.mac_installer_link && inputs.dry_run != true }}
         run: |
           echo "MANUAL=true" >> "$GITHUB_ENV"
-          echo "STARFOX_SPLIT=smoke" >> "$GITHUB_ENV"
+          echo "STARFOX_SPLIT=$TEST_SET" >> "$GITHUB_ENV"
           echo "Running smoke tests on supplied executable"
+        env:
+          TEST_SET: ${{ inputs.split }}
 
       - name: Install dependencies
         id: setup
@@ -462,8 +471,10 @@ jobs:
         if: ${{ inputs.linux_tarball_link && inputs.dry_run != true }}
         run: |
           echo "MANUAL=true" >> "$GITHUB_ENV"
-          echo "STARFOX_SPLIT=smoke" >> "$GITHUB_ENV"
+          echo "STARFOX_SPLIT=$TEST_SET" >> "$GITHUB_ENV"
           echo "Running smoke tests on supplied executable"
+        env:
+          TEST_SET = ${{ inputs.split }}
 
       - name: Install dependencies
         id: setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -515,6 +515,8 @@ jobs:
           FX_EXECUTABLE: ./firefox/firefox
         run: |
           "$FX_EXECUTABLE" --version;
+          XVFB_PID=$(ps -e | grep vfb | head -1 | awk '{print $1}')
+          if [[ -n "$XVFB_PID" ]]; then kill -9 "$XVFB_PID"; fi;
           xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 
@@ -528,7 +530,7 @@ jobs:
           uv run python scripts/switch_config.py ci_xvfb_headed;
           uv sync;
           XVFB_PID=$(ps -e | grep vfb | head -1 | awk '{print $1}')
-          if XVFB_PID; then kill -9 "$XVFB_PID"; fi;
+          if [[ -n "$XVFB_PID" ]]; then kill -9 "$XVFB_PID"; fi;
           xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -515,8 +515,7 @@ jobs:
           FX_EXECUTABLE: ./firefox/firefox
         run: |
           "$FX_EXECUTABLE" --version;
-          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" > artifacts/xvfb.log &
-          DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
+          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 
       - name: Run Smoke Tests in Ubuntu (Headed)
@@ -528,8 +527,7 @@ jobs:
           uv sync;
           uv run python scripts/switch_config.py ci_xvfb_headed;
           uv sync;
-          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" > artifacts/xvfb.log &
-          DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
+          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 
   Use-Artifacts:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -515,7 +515,7 @@ jobs:
           FX_EXECUTABLE: ./firefox/firefox
         run: |
           "$FX_EXECUTABLE" --version;
-          xvfb-run -f "$HOME/.Xauthority" -s ":99 -screen 0 '1600x1200x24'" > artifacts/xvfb.log &
+          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" > artifacts/xvfb.log &
           DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 
@@ -528,7 +528,7 @@ jobs:
           uv sync;
           uv run python scripts/switch_config.py ci_xvfb_headed;
           uv sync;
-          xvfb-run -f "$HOME/.Xauthority" -s ":99 -screen 0 '1600x1200x24'" > artifacts/xvfb.log &
+          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" > artifacts/xvfb.log &
           DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -517,7 +517,7 @@ jobs:
           "$FX_EXECUTABLE" --version;
           XVFB_PID=$(ps -e | grep vfb | head -1 | awk '{print $1}')
           if [[ -n "$XVFB_PID" ]]; then kill -9 "$XVFB_PID"; fi;
-          xvfb-run -e /dev/stdout -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
+          xvfb-run -e /dev/stdout -f "$HOME/.Xauthority" -s "-screen 0 1600x1200x24" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 
       - name: Run Smoke Tests in Ubuntu (Headed)
@@ -531,7 +531,7 @@ jobs:
           uv sync;
           XVFB_PID=$(ps -e | grep vfb | head -1 | awk '{print $1}')
           if [[ -n "$XVFB_PID" ]]; then kill -9 "$XVFB_PID"; fi;
-          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
+          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 1600x1200x24" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 
   Use-Artifacts:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -528,6 +528,7 @@ jobs:
           uv sync;
           uv run python scripts/switch_config.py ci_xvfb_headed;
           uv sync;
+          Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log &
           DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -515,7 +515,7 @@ jobs:
           FX_EXECUTABLE: ./firefox/firefox
         run: |
           "$FX_EXECUTABLE" --version;
-          Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log &
+          xvfb-run -f "$HOME/.Xauthority" -s ":99 -screen 0 '1600x1200x24'" > artifacts/xvfb.log &
           DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 
@@ -528,7 +528,7 @@ jobs:
           uv sync;
           uv run python scripts/switch_config.py ci_xvfb_headed;
           uv sync;
-          Xvfb :99 -screen 0 '1600x1200x24' > artifacts/xvfb.log &
+          xvfb-run -f "$HOME/.Xauthority" -s ":99 -screen 0 '1600x1200x24'" > artifacts/xvfb.log &
           DISPLAY=:99 uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?
           exit $TEST_EXIT_CODE
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -517,7 +517,7 @@ jobs:
           "$FX_EXECUTABLE" --version;
           XVFB_PID=$(ps -e | grep vfb | head -1 | awk '{print $1}')
           if [[ -n "$XVFB_PID" ]]; then kill -9 "$XVFB_PID"; fi;
-          xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
+          xvfb-run -e /dev/stdout -f "$HOME/.Xauthority" -s "-screen 0 '1600x1200x24'" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
 
       - name: Run Smoke Tests in Ubuntu (Headed)

--- a/conftest.py
+++ b/conftest.py
@@ -572,6 +572,14 @@ def driver(
 
 
 @pytest.fixture()
+def browser_name(driver: Firefox) -> str:
+    """
+    Is it 'Firefox' or 'Nightly'?
+    """
+    return "Nightly" if "a" in driver.capabilities.get("browserVersion") else "Firefox"
+
+
+@pytest.fixture()
 def screenshot(driver: Firefox, opt_ci: bool) -> Callable:
     """
     Factory fixture that returns a screenshot function.

--- a/conftest.py
+++ b/conftest.py
@@ -576,7 +576,9 @@ def browser_name(driver: Firefox) -> str:
     """
     Is it 'Firefox' or 'Nightly'?
     """
-    return "Nightly" if "a" in driver.capabilities.get("browserVersion") else "Firefox"
+    return (
+        "Nightly" if "a" in driver.capabilities.get("browserVersion", "") else "Firefox"
+    )
 
 
 @pytest.fixture()

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -331,7 +331,6 @@ bookmarks_and_history:
     result: pass
     splits:
     - functional1
-    - nightly
   test_delete_other_bookmarks:
     result: pass
     splits:
@@ -485,7 +484,6 @@ downloads:
     result: pass
     splits:
     - functional1
-    - nightly
   test_download_pdf:
     result: pass
     splits:
@@ -544,22 +542,24 @@ drag_and_drop:
     result: pass
     splits:
     - functional1
-    - nightly
   test_copy_hyperlink_table:
     result: pass
     splits:
     - functional1
     - nightly
+    - no_xvfb
   test_copy_table_header:
     result: pass
     splits:
     - functional1
     - nightly
+    - no_xvfb
   test_paste_image_text:
     result: pass
     splits:
     - functional1
     - nightly
+    - no_xvfb
 find_toolbar:
   test_find_in_pdf:
     result: pass
@@ -721,6 +721,7 @@ menus:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_hyperlink_context_menu:
     result: pass
     splits:
@@ -998,6 +999,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_insecure_password:
     result: pass
     splits:
@@ -1008,6 +1010,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_navigation_to_about_logins_from_autocomplete:
     result: pass
     splits:
@@ -1065,6 +1068,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_primary_password_allows_csv_export:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -1099,6 +1103,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_update_login_via_doorhanger:
     result: pass
     splits:
@@ -1431,7 +1436,6 @@ security_and_privacy:
       win: unstable
     splits:
     - functional3
-    - nightly
   test_cross_site_tracking_cookies_blocked:
     result: deprecated
     splits:
@@ -1785,6 +1789,7 @@ sidebar:
     splits:
     - functional3
     - nightly
+    - no_xvfb
   test_summarize_page_via_ai_chat_panel:
     result: pass
     splits:
@@ -1862,6 +1867,7 @@ tabs:
     - ci
     - functional3
     - nightly
+    - no_xvfb
   test_display_customize_button:
     result: pass
     splits:
@@ -1905,6 +1911,7 @@ tabs:
     splits:
     - functional3
     - nightly
+    - no_xvfb
   test_navigation_multiple_tabs:
     result: pass
     splits:
@@ -1919,6 +1926,7 @@ tabs:
     splits:
     - functional3
     - nightly
+    - no_xvfb
   test_open_new_tab:
     result: pass
     splits:
@@ -1951,6 +1959,7 @@ tabs:
     splits:
     - functional3
     - nightly
+    - no_xvfb
   test_reload_overiding_cache_keys:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -546,19 +546,16 @@ drag_and_drop:
     splits:
     - functional1
     - nightly
-    - no_xvfb
   test_copy_table_header:
     result: pass
     splits:
     - functional1
     - nightly
-    - no_xvfb
   test_paste_image_text:
     result: pass
     splits:
     - functional1
     - nightly
-    - no_xvfb
 find_toolbar:
   test_find_in_pdf:
     result: pass
@@ -720,7 +717,6 @@ menus:
     splits:
     - functional2
     - nightly
-    - no_xvfb
   test_hyperlink_context_menu:
     result: pass
     splits:
@@ -998,7 +994,6 @@ password_manager:
     splits:
     - functional2
     - nightly
-    - no_xvfb
   test_insecure_password:
     result: pass
     splits:
@@ -1009,7 +1004,6 @@ password_manager:
     splits:
     - functional2
     - nightly
-    - no_xvfb
   test_navigation_to_about_logins_from_autocomplete:
     result: pass
     splits:
@@ -1067,7 +1061,6 @@ password_manager:
     splits:
     - functional2
     - nightly
-    - no_xvfb
   test_primary_password_allows_csv_export:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -1102,7 +1095,6 @@ password_manager:
     splits:
     - functional2
     - nightly
-    - no_xvfb
   test_update_login_via_doorhanger:
     result: pass
     splits:
@@ -1924,7 +1916,6 @@ tabs:
     splits:
     - functional3
     - nightly
-    - no_xvfb
   test_open_new_tab:
     result: pass
     splits:
@@ -2013,6 +2004,7 @@ theme_and_toolbar:
     result: pass
     splits:
     - smoke
+    - no_xvfb
     - ci
   test_installed_theme_enabled:
     result: pass

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -3,10 +3,12 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_adaptive_history_removal:
     result: pass
     splits:
     - functional1
+    - nightly
   test_add_engine_address_bar:
     result: pass
     splits:
@@ -16,6 +18,7 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_addon_suggestion:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2018766
     result: unstable
@@ -25,38 +28,47 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_addressbar_search_engine_keywords:
     result: pass
     splits:
     - functional1
+    - nightly
   test_bing_search_codes:
     result: pass
     splits:
     - functional1
+    - nightly
   test_clipboard_pref_flip:
     result: pass
     splits:
     - functional1
+    - nightly
   test_copied_url_contains_https:
     result: pass
     splits:
     - functional1
+    - nightly
   test_ctrl_enter_completes_link_and_can_refresh:
     result: pass
     splits:
     - functional1
+    - nightly
   test_ctrl_enter_fixes_url:
     result: pass
     splits:
     - functional1
+    - nightly
   test_ddg_search_codes:
     result: pass
     splits:
     - functional1
+    - nightly
   test_default_search_provider_change_awesome_bar:
     result: pass
     splits:
     - functional1
+    - nightly
   test_default_search_provider_change_legacy_search_bar:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033884
     result: unstable
@@ -66,18 +78,22 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_disable_websearch_from_awesome_bar:
     result: pass
     splits:
     - functional1
+    - nightly
   test_dont_show_search_suggestions_in_private_window:
     result: pass
     splits:
     - functional1
+    - nightly
   test_insertion_point_no_search_terms_display:
     result: pass
     splits:
     - functional1
+    - nightly
   test_no_suggestions_for_empty_query:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033884
     result: unstable
@@ -87,26 +103,32 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_open_link_in_new_container_tab:
     result: pass
     splits:
     - functional1
+    - nightly
   test_paste_and_go_opens_correct_url:
     result: pass
     splits:
     - functional1
+    - nightly
   test_refresh_firefox_dialog:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_bar_display_alpenglow_theme:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_bar_results_shown_in_a_new_tab:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_code_google_non_us:
     result: pass
     splits:
@@ -124,6 +146,7 @@ address_bar_and_search:
       win: pass
     splits:
     - functional1
+    - nightly
   test_search_engine_selector:
     result: pass
     splits:
@@ -132,10 +155,12 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_mode_change_tab:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_mode_cleared_on_engine_removal:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043388
     result: unstable
@@ -145,14 +170,17 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_mode_persists_mixed_with_bing:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_mode_update_on_alias_prefix:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_modes_for_sites:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2002277
     result: deprecated
@@ -162,6 +190,7 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_suggestions:
     result: pass
     splits:
@@ -176,26 +205,32 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_works_correctly_with_ddg_telemetry:
     result: pass
     splits:
     - functional1
+    - nightly
   test_server_not_found_error:
     result: pass
     splits:
     - functional1
+    - nightly
   test_server_not_found_error_pb:
     result: pass
     splits:
     - functional1
+    - nightly
   test_suggestion_engine_selection:
     result: pass
     splits:
     - functional1
+    - nightly
   test_switch_to_existing_tab_when_having_the_same_URL:
     result: pass
     splits:
     - functional1
+    - nightly
   test_tile_menu_options:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2021941
     result: unstable
@@ -205,15 +240,18 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_verify_url_after_tab_switch_with_search_mode:
     result: pass
     splits:
     - functional1
+    - nightly
 ai_controls:
   test_c3308998_unblock_restores_state:
     result: pass
     splits:
     - functional1
+    - nightly
 audio_video:
   test_allow_audio_video_functionality:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2034560
@@ -223,10 +261,12 @@ audio_video:
       win: unstable
     splits:
     - functional1
+    - nightly
   test_autoplay_permission_settings_displayed:
     result: pass
     splits:
     - functional1
+    - nightly
   test_autoplay_sound_blocking_background_tab:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2010227
     result: unstable
@@ -245,27 +285,33 @@ audio_video:
     result: pass
     splits:
     - functional1
+    - nightly
 bookmarks_and_history:
   test_add_bookmark_folder_via_toolbar_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_add_bookmark_via_star_only_saved_explicitly:
     result: pass
     splits:
     - functional1
+    - nightly
   test_add_bookmark_via_toolbar_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_add_new_other_bookmark:
     result: pass
     splits:
     - functional1
+    - nightly
   test_bookmark_via_bookmark_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_bookmark_website_via_star_button:
     result: pass
     splits:
@@ -280,42 +326,52 @@ bookmarks_and_history:
     result: pass
     splits:
     - functional1
+    - nightly
   test_delete_bookmarks_from_toolbar:
     result: pass
     splits:
     - functional1
+    - nightly
   test_delete_other_bookmarks:
     result: pass
     splits:
     - functional1
+    - nightly
   test_deleted_page_not_remembered:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_folder_via_toolbar_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_from_bookmark_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_via_star_button:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_via_star_button_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_via_toolbar_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_history_menu_from_different_places:
     result: pass
     splits:
     - functional1
+    - nightly
   test_import_bookmarks_chrome:
     result: pass
     splits:
@@ -331,14 +387,17 @@ bookmarks_and_history:
     result: pass
     splits:
     - functional1
+    - nightly
   test_open_bookmark_in_new_window_via_toolbar_context_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_open_bookmark_in_private_window_via_toolbar_context_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_open_bookmarks_from_toolbar:
     result: pass
     splits:
@@ -351,26 +410,32 @@ bookmarks_and_history:
     result: pass
     splits:
     - functional1
+    - nightly
   test_opened_website_in_new_window_present_in_hamburger_history_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_opened_website_present_in_hamburger_history_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_private_window_website_not_in_history:
     result: pass
     splits:
     - functional1
+    - nightly
   test_toggle_bookmarks_toolbar:
     result: pass
     splits:
     - functional1
+    - nightly
   test_user_can_forget_history:
     result: pass
     splits:
     - functional1
+    - nightly
 downloads:
   test_add_mime_type_doc:
     comment: Windows unstable in GHA, https://bugzilla.mozilla.org/show_bug.cgi?id=2043378
@@ -399,6 +464,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_download_apk_and_check_extension:
     result: pass
     splits:
@@ -419,6 +485,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_download_pdf:
     result: pass
     splits:
@@ -432,6 +499,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_install_unsigned_addons:
     result: pass
     splits:
@@ -448,10 +516,12 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_set_always_ask_file_type:
     result: pass
     splits:
     - functional1
+    - nightly
   test_telemetry_download_and_open:
     result: pass
     splits:
@@ -460,6 +530,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_verify_telemetry_downloads_panel_open:
     result: pass
     splits:
@@ -473,23 +544,28 @@ drag_and_drop:
     result: pass
     splits:
     - functional1
+    - nightly
   test_copy_hyperlink_table:
     result: pass
     splits:
     - functional1
+    - nightly
   test_copy_table_header:
     result: pass
     splits:
     - functional1
+    - nightly
   test_paste_image_text:
     result: pass
     splits:
     - functional1
+    - nightly
 find_toolbar:
   test_find_in_pdf:
     result: pass
     splits:
     - functional1
+    - nightly
   test_find_toolbar_nav:
     result: pass
     splits:
@@ -499,6 +575,7 @@ find_toolbar:
     result: pass
     splits:
     - functional1
+    - nightly
 form_autofill:
   test_address_autofill_attribute:
     result: pass
@@ -508,6 +585,7 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_autofill_credit_card:
     result: pass
     splits:
@@ -516,26 +594,32 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_autofill_credit_card_enable:
     result: pass
     splits:
     - functional1
+    - nightly
   test_autofill_credit_card_four_fields:
     result: pass
     splits:
     - functional1
+    - nightly
   test_cc_clear_form:
     result: pass
     splits:
     - functional1
+    - nightly
   test_clear_form:
     result: pass
     splits:
     - functional1
+    - nightly
   test_create_new_cc_profile:
     result: pass
     splits:
     - functional1
+    - nightly
   test_create_profile_autofill:
     result: pass
     splits:
@@ -544,18 +628,22 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_credit_card:
     result: pass
     splits:
     - functional1
+    - nightly
   test_enable_disable_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_form_autofill_suggestions:
     result: pass
     splits:
     - functional1
+    - nightly
   test_name_autofill_attribute:
     result: pass
     splits:
@@ -564,6 +652,7 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_telephone_autofill_attribute:
     result: pass
     splits:
@@ -573,19 +662,23 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_updating_credit_card:
     result: pass
     splits:
     - functional1
+    - nightly
 geolocation:
   test_geolocation_shared_via_html5:
     result: pass
     splits:
     - functional2
+    - nightly
   test_geolocation_shared_via_w3c_api:
     result: pass
     splits:
     - functional2
+    - nightly
 glean:
   misc_metrics:
     test_misc_metrics:
@@ -627,6 +720,7 @@ menus:
     result: pass
     splits:
     - functional2
+    - nightly
   test_hyperlink_context_menu:
     result: pass
     splits:
@@ -639,18 +733,22 @@ menus:
       win: unstable
     splits:
     - functional2
+    - nightly
   test_new_tab_label:
     result: pass
     splits:
     - functional2
+    - nightly
   test_tab_context_menu_actions:
     result: pass
     splits:
     - functional2
+    - nightly
   test_tab_context_menu_close:
     result: pass
     splits:
     - functional2
+    - nightly
 meta:
   test_selectors:
     comment: Not part of feature functional test suites
@@ -664,10 +762,12 @@ networking:
     result: pass
     splits:
     - functional2
+    - nightly
   test_custom_doh_provider:
     result: pass
     splits:
     - functional2
+    - nightly
   test_default_dns_protection:
     result: pass
     splits:
@@ -676,36 +776,44 @@ networking:
     result: pass
     splits:
     - functional2
+    - nightly
   test_http_site:
     result: pass
     splits:
     - functional2
+    - nightly
   test_nextdns_as_doh_provider:
     result: pass
     splits:
     - functional2
+    - nightly
 notifications:
   test_audio_video_permissions_notification:
     comment: Issue with Mac GHA? trying pass to see what happens.
     result: pass
     splits:
     - functional2
+    - nightly
   test_camera_permissions_notification:
     result: pass
     splits:
     - functional2
+    - nightly
   test_cancel_webextension:
     result: pass
     splits:
     - functional2
+    - nightly
   test_deny_geolocation:
     result: pass
     splits:
     - functional2
+    - nightly
   test_deny_screen_capture:
     result: pass
     splits:
     - functional2
+    - nightly
   test_downloads_button_is_displayed:
     result: pass
     splits:
@@ -718,14 +826,17 @@ notifications:
     result: pass
     splits:
     - functional2
+    - nightly
   test_geolocation_prompt_presence:
     result: pass
     splits:
     - functional2
+    - nightly
   test_microphone_permissions_notification:
     result: pass
     splits:
     - functional2
+    - nightly
   test_notifications_displayed:
     result: pass
     splits:
@@ -739,63 +850,78 @@ notifications:
     result: pass
     splits:
     - functional2
+    - nightly
 password_manager:
   test_about_logins_copy_prompts_primary_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_direct_navigation:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_edit_prompts_primary_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_navigation_from_about_preferences:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_navigation_from_about_protections:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_navigation_from_context_menu:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_navigation_from_hamburger_menu:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_password_copy_button:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_password_show_hide_button:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_search_passwords:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_search_username:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_search_website:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_username_copy_button:
     result: pass
     splits:
     - functional2
+    - nightly
   test_add_password_non_ascii_chars:
     result: pass
     splits:
     - functional2
+    - nightly
   test_add_password_save_valid_data:
     result: pass
     splits:
@@ -808,6 +934,7 @@ password_manager:
     result: pass
     splits:
     - functional2
+    - nightly
   test_auto_saved_generated_password_context_menu:
     result: pass
     splits:
@@ -816,10 +943,12 @@ password_manager:
     result: pass
     splits:
     - functional2
+    - nightly
   test_can_view_password_when_PP_enabled:
     result: pass
     splits:
     - functional2
+    - nightly
   test_changes_made_in_edit_mode_are_saved:
     result:
       linux: pass
@@ -827,18 +956,22 @@ password_manager:
       win: unstable
     splits:
     - functional2
+    - nightly
   test_confirm_or_edit_generated_password_shows_previously_edited_and_generated_password_options:
     result: pass
     splits:
     - functional2
+    - nightly
   test_delete_login:
     result: pass
     splits:
     - functional2
+    - nightly
   test_delete_primary_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_edit_autofill_after_pp_dismissed:
     comment: uses pyautogui (headed) to answer the native Primary Password prompt;
       not reliable on linux (Wayland) or win CI, so mac-only like the CSV-export PP
@@ -849,38 +982,47 @@ password_manager:
       win: unstable
     splits:
     - functional2
+    - nightly
   test_edit_generated_password_triggers_autosave:
     result: pass
     splits:
     - functional2
+    - nightly
   test_edit_primary_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_facebook_login_autofill_dropdown:
     result: pass
     splits:
     - functional2
+    - nightly
   test_insecure_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_multiple_saved_logins:
     result: pass
     splits:
     - functional2
+    - nightly
   test_navigation_to_about_logins_from_autocomplete:
     result: pass
     splits:
     - functional2
+    - nightly
   test_never_save_login_via_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
   test_no_generated_password_options_with_pp_and_no_credentials:
     result: pass
     splits:
     - functional2
+    - nightly
   test_password_csv_correctness:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -889,6 +1031,7 @@ password_manager:
       win: pass
     splits:
     - functional2
+    - nightly
   test_password_csv_export:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -897,14 +1040,17 @@ password_manager:
       win: pass
     splits:
     - functional2
+    - nightly
   test_password_field_only_triggers_dismissed_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
   test_password_manager_key_icon_after_doorhanger_dismiss:
     result: pass
     splits:
     - functional2
+    - nightly
   test_password_manager_on_google_US:
     comment: external site; mac was historically unstable for unknown reasons before
       bug 2056524, keep in mind if it re-flakes
@@ -918,6 +1064,7 @@ password_manager:
     result: pass
     splits:
     - functional2
+    - nightly
   test_primary_password_allows_csv_export:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -926,42 +1073,52 @@ password_manager:
       win: unstable
     splits:
     - functional2
+    - nightly
   test_primary_password_triggered_on_about_logins_access:
     result: pass
     splits:
     - functional2
+    - nightly
   test_private_browsing_dismiss_doorhanger_credentials:
     result: pass
     splits:
     - functional2
+    - nightly
   test_save_login_via_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
   test_saved_hyperlink_redirects_to_corresponding_page:
     result: pass
     splits:
     - functional2
+    - nightly
   test_taobao_password_management:
     result: pass
     splits:
     - functional2
+    - nightly
   test_update_login_via_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
   test_use_saved_password_option_not_in_password_field_context_menu_without_saved_logins:
     result: pass
     splits:
     - functional2
+    - nightly
   test_use_saved_password_option_not_in_username_field_context_menu_without_saved_logins:
     result: pass
     splits:
     - functional2
+    - nightly
   test_username_edit_captured_in_dismissed_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
 pdf_viewer:
   test_add_image_pdf:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1982852
@@ -980,6 +1137,7 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_open_pdf_in_FF:
     result: pass
     splits:
@@ -988,22 +1146,27 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_contextual_menu_actions:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_copy_paste_functionality:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_copy_paste_functionality_numerical:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_data_can_be_cleared:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_download:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2018768
     result:
@@ -1012,14 +1175,17 @@ pdf_viewer:
       win: pass
     splits:
     - functional2
+    - nightly
   test_pdf_drawing_area_actions:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_dropdown_functionality:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_input_numbers:
     result: pass
     splits:
@@ -1028,6 +1194,7 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_navigation:
     result: pass
     splits:
@@ -1037,30 +1204,37 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_text_and_draw_toolbar_buttons:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_zoom_checkboxes:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_zoom_in_text_fields:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_zoom_radio_buttons:
     result: pass
     splits:
     - functional2
+    - nightly
   test_zoom_pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_zoom_works_on_dropdown_menus:
     result: pass
     splits:
     - functional2
+    - nightly
 pocket:
   test_basic_de:
     test_localized_pocket_layout_DE:
@@ -1086,6 +1260,7 @@ preferences:
     result: pass
     splits:
     - functional2
+    - nightly
   test_clear_cookie_data:
     result:
       linux: pass
@@ -1102,6 +1277,7 @@ preferences:
     result: pass
     splits:
     - functional2
+    - nightly
   test_lang_pack_changed_from_about_prefs:
     result: pass
     splits:
@@ -1125,6 +1301,7 @@ printing_ui:
     result: pass
     splits:
     - functional2
+    - nightly
   test_print_preview:
     result: pass
     splits:
@@ -1134,6 +1311,7 @@ printing_ui:
     result: pass
     splits:
     - functional2
+    - nightly
 profile:
   test_set_default_profile:
     result:
@@ -1147,10 +1325,12 @@ reader_view:
     result: pass
     splits:
     - functional2
+    - nightly
   test_reader_view_close_sidebar:
     result: pass
     splits:
     - functional2
+    - nightly
   test_reader_view_location_bar:
     result: pass
     splits:
@@ -1173,10 +1353,12 @@ scrolling_panning_zooming:
     result: pass
     splits:
     - functional2
+    - nightly
   test_zoom_menu_correlation:
     result: pass
     splits:
     - functional2
+    - nightly
   test_zoom_text_only:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2022011
     result: unstable
@@ -1187,6 +1369,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_blocking_cryptominers:
     result: deprecated
     splits:
@@ -1199,38 +1382,47 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_bookmarks_removed_via_private_browsing:
     result: pass
     splits:
     - functional3
+    - nightly
   test_bookmarks_toolbar_present_in_private_browsing:
     result: pass
     splits:
     - functional3
+    - nightly
   test_cache_is_cleared_via_end_private_session_button:
     result: pass
     splits:
     - functional3
+    - nightly
   test_certificate_expired_displayed_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_clear_cookies_site_data_via_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_connection_not_secured_panel_for_http_sites:
     result: pass
     splits:
     - functional3
+    - nightly
   test_connection_secure_second_level_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_cookies_not_saved_private_browsing:
     result: pass
     splits:
     - functional3
+    - nightly
   test_copy_clean_link:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2052850
     result:
@@ -1239,6 +1431,7 @@ security_and_privacy:
       win: unstable
     splits:
     - functional3
+    - nightly
   test_cross_site_tracking_cookies_blocked:
     result: deprecated
     splits:
@@ -1264,14 +1457,17 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_custom_block_suspected_fingerprinters_only_in_private_windows:
     result: pass
     splits:
     - functional3
+    - nightly
   test_data_clearance_from_private_window_can_be_canceled:
     result: pass
     splits:
     - functional3
+    - nightly
   test_detected_blocked_trackers_found:
     result: deprecated
     splits:
@@ -1288,38 +1484,47 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_end_private_session_clears_cookies:
     result: pass
     splits:
     - functional3
+    - nightly
   test_ensure_panel_renders_on_first_run:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_panel_displayed_when_all_protections_disabled_custom:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_panel_displayed_when_no_trackers_detected:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_panel_displayed_when_protection_off:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_toggle_on_off_behavior:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_toggle_on_off_behavior_private_window:
     result: pass
     splits:
     - functional3
+    - nightly
   test_extended_certificate_messaging_displayed_in_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_fingerprinters_blocked_and_shown_in_panel_and_preferences:
     result: pass
     splits:
@@ -1346,14 +1551,17 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_mixed_content_warning_displayed_in_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_never_remember_browsing_history:
     result: pass
     splits:
     - functional3
+    - nightly
   test_no_cached_file_in_private_browsing:
     result: pass
     splits:
@@ -1362,6 +1570,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_link_in_private_window:
     result: pass
     splits:
@@ -1375,6 +1584,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_phishing_and_malware_warnings:
     result: pass
     splits:
@@ -1383,14 +1593,17 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_private_browser_password_doorhanger:
     result: pass
     splits:
     - functional3
+    - nightly
   test_private_session_awesome_bar_exclusion:
     result: pass
     splits:
     - functional3
+    - nightly
   test_private_session_history_exclusion:
     result: pass
     splits:
@@ -1399,14 +1612,17 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_protection_level_redirect_about_preferences:
     result: pass
     splits:
     - functional3
+    - nightly
   test_secure_domain_certificate_messaging_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_see_all_link_redirects_to_blocked_trackers:
     result: pass
     splits:
@@ -1415,6 +1631,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_social_media_trackers_displayed_subpanel:
     result: pass
     splits:
@@ -1448,6 +1665,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_undo_close_tab_private_browsing:
     result: pass
     splits:
@@ -1457,14 +1675,17 @@ session_restore:
     result: pass
     splits:
     - functional3
+    - nightly
   test_closed_tabs_from_multiple_windows_shown_in_history_menu_bar:
     result: pass
     splits:
     - functional3
+    - nightly
   test_closed_tabs_from_multiple_windows_shown_in_library_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_restore_last_closed_tabs_shortcut:
     result: pass
     splits:
@@ -1473,71 +1694,88 @@ session_restore:
     result: pass
     splits:
     - functional3
+    - nightly
   test_restored_closed_tabs_removed_from_all_history_entries:
     result: pass
     splits:
     - functional3
+    - nightly
 sidebar:
   test_ai_chatbot_removed_from_sidebar_not_shown_in_tab_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_choose_ai_chatbot_via_page_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_close_button_present_on_hovering_or_selecting_a_vertical_tab:
     result: pass
     splits:
     - functional3
+    - nightly
   test_hide_sidebar_behaviour:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_ai_chat_via_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_button_always_displayed_on_fresh_profile:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_duplicate_vertical_tab:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_enabled_in_private_window:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_multiple_vertical_tabs_selection:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tab_can_be_reloaded:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_bookmarked:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_closing_options:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_move_options:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_multiselect_close_options:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_mute_unmute:
     comment: CI limitation - audio playback not supported on Windows CI runners
     result:
@@ -1546,38 +1784,47 @@ sidebar:
       win: unstable
     splits:
     - functional3
+    - nightly
   test_summarize_page_via_ai_chat_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_summarize_page_via_sidebar_ai_chat_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_summarize_page_via_tab_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_switch_between_horizontal_vertical_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_switching_to_horizontal_tabs_disables_expand_on_hover:
     result: pass
     splits:
     - functional3
+    - nightly
   test_toggle_sidebar_via_toolbar_button:
     result: pass
     splits:
     - functional3
+    - nightly
   test_user_can_manage_pinned_extensions_on_the_sidebar:
     result: pass
     splits:
     - functional3
+    - nightly
   test_vertical_tab_pinned_unpinned_with_expand_on_hover_enabled:
     result: pass
     splits:
     - functional3
+    - nightly
   test_vertical_tabs_reopen_closed_tab:
     result: pass
     splits:
@@ -1603,6 +1850,7 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_close_pinned_tab_via_mouse:
     result: pass
     splits:
@@ -1613,14 +1861,17 @@ tabs:
     splits:
     - ci
     - functional3
+    - nightly
   test_display_customize_button:
     result: pass
     splits:
     - functional3
+    - nightly
   test_edit_tab_groups:
     result: pass
     splits:
     - functional3
+    - nightly
   test_group_tabs:
     result: pass
     splits:
@@ -1629,18 +1880,22 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_list_all_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_move_multi_selected_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_move_single_tab_via_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_mute_tabs:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2001204
     result:
@@ -1649,10 +1904,12 @@ tabs:
       win: unstable
     splits:
     - functional3
+    - nightly
   test_navigation_multiple_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_bookmark_in_new_tab:
     result: pass
     splits:
@@ -1661,6 +1918,7 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_new_tab:
     result: pass
     splits:
@@ -1669,10 +1927,12 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_new_tab_via_hyperlink:
     result: pass
     splits:
     - functional3
+    - nightly
   test_pin_tab:
     result: pass
     splits:
@@ -1681,6 +1941,7 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_play_mute_unmute_tabs_via_toggle:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2056387
     result:
@@ -1689,46 +1950,57 @@ tabs:
       win: unstable
     splits:
     - functional3
+    - nightly
   test_reload_overiding_cache_keys:
     result: pass
     splits:
     - functional3
+    - nightly
   test_reload_tab_via_keyboard:
     result: pass
     splits:
     - functional3
+    - nightly
   test_remove_tab_from_a_group:
     result: pass
     splits:
     - functional3
+    - nightly
   test_reopen_tab_through_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_reopen_tab_through_history_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_reopen_tabs_through_keys:
     result: pass
     splits:
     - functional3
+    - nightly
   test_restore_closed_tabs_previous_groups:
     result: pass
     splits:
     - functional3
+    - nightly
   test_save_and_close_a_tab_group:
     result: pass
     splits:
     - functional3
+    - nightly
   test_tab_hover_different_content_type:
     result: pass
     splits:
     - functional3
+    - nightly
   test_ungroup_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
 theme_and_toolbar:
   test_customize_themes_and_redirect:
     result: pass

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -329,7 +329,6 @@ bookmarks_and_history:
     result: pass
     splits:
     - functional1
-    - nightly
   test_delete_other_bookmarks:
     result: pass
     splits:
@@ -483,7 +482,6 @@ downloads:
     result: pass
     splits:
     - functional1
-    - nightly
   test_download_pdf:
     result: pass
     splits:
@@ -542,22 +540,24 @@ drag_and_drop:
     result: pass
     splits:
     - functional1
-    - nightly
   test_copy_hyperlink_table:
     result: pass
     splits:
     - functional1
     - nightly
+    - no_xvfb
   test_copy_table_header:
     result: pass
     splits:
     - functional1
     - nightly
+    - no_xvfb
   test_paste_image_text:
     result: pass
     splits:
     - functional1
     - nightly
+    - no_xvfb
 find_toolbar:
   test_find_in_pdf:
     result: pass
@@ -719,6 +719,7 @@ menus:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_hyperlink_context_menu:
     result: pass
     splits:
@@ -996,6 +997,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_insecure_password:
     result: pass
     splits:
@@ -1006,6 +1008,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_navigation_to_about_logins_from_autocomplete:
     result: pass
     splits:
@@ -1063,6 +1066,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_primary_password_allows_csv_export:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -1097,6 +1101,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_update_login_via_doorhanger:
     result: pass
     splits:
@@ -1429,7 +1434,6 @@ security_and_privacy:
       win: unstable
     splits:
     - functional3
-    - nightly
   test_cross_site_tracking_cookies_blocked:
     result: deprecated
     splits:
@@ -1783,6 +1787,7 @@ sidebar:
     splits:
     - functional3
     - nightly
+    - no_xvfb
   test_summarize_page_via_ai_chat_panel:
     result: pass
     splits:
@@ -1860,6 +1865,7 @@ tabs:
     - ci
     - functional3
     - nightly
+    - no_xvfb
   test_display_customize_button:
     result: pass
     splits:
@@ -1903,6 +1909,7 @@ tabs:
     splits:
     - functional3
     - nightly
+    - no_xvfb
   test_navigation_multiple_tabs:
     result: pass
     splits:
@@ -1917,6 +1924,7 @@ tabs:
     splits:
     - functional3
     - nightly
+    - no_xvfb
   test_open_new_tab:
     result: pass
     splits:
@@ -1949,6 +1957,7 @@ tabs:
     splits:
     - functional3
     - nightly
+    - no_xvfb
   test_reload_overiding_cache_keys:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -3,10 +3,12 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_adaptive_history_removal:
     result: pass
     splits:
     - functional1
+    - nightly
   test_add_engine_address_bar:
     result: pass
     splits:
@@ -16,6 +18,7 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_addon_suggestion:
     result: pass
     splits:
@@ -24,38 +27,47 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_addressbar_search_engine_keywords:
     result: pass
     splits:
     - functional1
+    - nightly
   test_bing_search_codes:
     result: pass
     splits:
     - functional1
+    - nightly
   test_clipboard_pref_flip:
     result: pass
     splits:
     - functional1
+    - nightly
   test_copied_url_contains_https:
     result: pass
     splits:
     - functional1
+    - nightly
   test_ctrl_enter_completes_link_and_can_refresh:
     result: pass
     splits:
     - functional1
+    - nightly
   test_ctrl_enter_fixes_url:
     result: pass
     splits:
     - functional1
+    - nightly
   test_ddg_search_codes:
     result: pass
     splits:
     - functional1
+    - nightly
   test_default_search_provider_change_awesome_bar:
     result: pass
     splits:
     - functional1
+    - nightly
   test_default_search_provider_change_legacy_search_bar:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033884
     result: unstable
@@ -65,18 +77,22 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_disable_websearch_from_awesome_bar:
     result: pass
     splits:
     - functional1
+    - nightly
   test_dont_show_search_suggestions_in_private_window:
     result: pass
     splits:
     - functional1
+    - nightly
   test_insertion_point_no_search_terms_display:
     result: pass
     splits:
     - functional1
+    - nightly
   test_no_suggestions_for_empty_query:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2033884
     result: unstable
@@ -86,26 +102,32 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_open_link_in_new_container_tab:
     result: pass
     splits:
     - functional1
+    - nightly
   test_paste_and_go_opens_correct_url:
     result: pass
     splits:
     - functional1
+    - nightly
   test_refresh_firefox_dialog:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_bar_display_alpenglow_theme:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_bar_results_shown_in_a_new_tab:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_code_google_non_us:
     result: pass
     splits:
@@ -123,6 +145,7 @@ address_bar_and_search:
       win: pass
     splits:
     - functional1
+    - nightly
   test_search_engine_selector:
     result: pass
     splits:
@@ -131,10 +154,12 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_mode_change_tab:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_mode_cleared_on_engine_removal:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043388
     result: unstable
@@ -144,14 +169,17 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_mode_persists_mixed_with_bing:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_mode_update_on_alias_prefix:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_modes_for_sites:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2002277
     result: deprecated
@@ -161,6 +189,7 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_suggestions:
     result: pass
     splits:
@@ -174,26 +203,32 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_search_works_correctly_with_ddg_telemetry:
     result: pass
     splits:
     - functional1
+    - nightly
   test_server_not_found_error:
     result: pass
     splits:
     - functional1
+    - nightly
   test_server_not_found_error_pb:
     result: pass
     splits:
     - functional1
+    - nightly
   test_suggestion_engine_selection:
     result: pass
     splits:
     - functional1
+    - nightly
   test_switch_to_existing_tab_when_having_the_same_URL:
     result: pass
     splits:
     - functional1
+    - nightly
   test_tile_menu_options:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2021941
     result: unstable
@@ -203,15 +238,18 @@ address_bar_and_search:
     result: pass
     splits:
     - functional1
+    - nightly
   test_verify_url_after_tab_switch_with_search_mode:
     result: pass
     splits:
     - functional1
+    - nightly
 ai_controls:
   test_c3308998_unblock_restores_state:
     result: pass
     splits:
     - functional1
+    - nightly
 audio_video:
   test_allow_audio_video_functionality:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2034560
@@ -221,10 +259,12 @@ audio_video:
       win: unstable
     splits:
     - functional1
+    - nightly
   test_autoplay_permission_settings_displayed:
     result: pass
     splits:
     - functional1
+    - nightly
   test_autoplay_sound_blocking_background_tab:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2010227
     result: unstable
@@ -243,27 +283,33 @@ audio_video:
     result: pass
     splits:
     - functional1
+    - nightly
 bookmarks_and_history:
   test_add_bookmark_folder_via_toolbar_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_add_bookmark_via_star_only_saved_explicitly:
     result: pass
     splits:
     - functional1
+    - nightly
   test_add_bookmark_via_toolbar_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_add_new_other_bookmark:
     result: pass
     splits:
     - functional1
+    - nightly
   test_bookmark_via_bookmark_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_bookmark_website_via_star_button:
     result: pass
     splits:
@@ -278,42 +324,52 @@ bookmarks_and_history:
     result: pass
     splits:
     - functional1
+    - nightly
   test_delete_bookmarks_from_toolbar:
     result: pass
     splits:
     - functional1
+    - nightly
   test_delete_other_bookmarks:
     result: pass
     splits:
     - functional1
+    - nightly
   test_deleted_page_not_remembered:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_folder_via_toolbar_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_from_bookmark_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_via_star_button:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_via_star_button_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_bookmark_via_toolbar_not_saving_realtime:
     result: pass
     splits:
     - functional1
+    - nightly
   test_history_menu_from_different_places:
     result: pass
     splits:
     - functional1
+    - nightly
   test_import_bookmarks_chrome:
     result: pass
     splits:
@@ -329,14 +385,17 @@ bookmarks_and_history:
     result: pass
     splits:
     - functional1
+    - nightly
   test_open_bookmark_in_new_window_via_toolbar_context_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_open_bookmark_in_private_window_via_toolbar_context_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_open_bookmarks_from_toolbar:
     result: pass
     splits:
@@ -349,26 +408,32 @@ bookmarks_and_history:
     result: pass
     splits:
     - functional1
+    - nightly
   test_opened_website_in_new_window_present_in_hamburger_history_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_opened_website_present_in_hamburger_history_menu:
     result: pass
     splits:
     - functional1
+    - nightly
   test_private_window_website_not_in_history:
     result: pass
     splits:
     - functional1
+    - nightly
   test_toggle_bookmarks_toolbar:
     result: pass
     splits:
     - functional1
+    - nightly
   test_user_can_forget_history:
     result: pass
     splits:
     - functional1
+    - nightly
 downloads:
   test_add_mime_type_doc:
     comment: Windows unstable in GHA, https://bugzilla.mozilla.org/show_bug.cgi?id=2043378
@@ -397,6 +462,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_download_apk_and_check_extension:
     result: pass
     splits:
@@ -417,6 +483,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_download_pdf:
     result: pass
     splits:
@@ -430,6 +497,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_install_unsigned_addons:
     result: pass
     splits:
@@ -446,10 +514,12 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_set_always_ask_file_type:
     result: pass
     splits:
     - functional1
+    - nightly
   test_telemetry_download_and_open:
     result: pass
     splits:
@@ -458,6 +528,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_verify_telemetry_downloads_panel_open:
     result: pass
     splits:
@@ -471,23 +542,28 @@ drag_and_drop:
     result: pass
     splits:
     - functional1
+    - nightly
   test_copy_hyperlink_table:
     result: pass
     splits:
     - functional1
+    - nightly
   test_copy_table_header:
     result: pass
     splits:
     - functional1
+    - nightly
   test_paste_image_text:
     result: pass
     splits:
     - functional1
+    - nightly
 find_toolbar:
   test_find_in_pdf:
     result: pass
     splits:
     - functional1
+    - nightly
   test_find_toolbar_nav:
     result: pass
     splits:
@@ -497,6 +573,7 @@ find_toolbar:
     result: pass
     splits:
     - functional1
+    - nightly
 form_autofill:
   test_address_autofill_attribute:
     result: pass
@@ -506,6 +583,7 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_autofill_credit_card:
     result: pass
     splits:
@@ -514,26 +592,32 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_autofill_credit_card_enable:
     result: pass
     splits:
     - functional1
+    - nightly
   test_autofill_credit_card_four_fields:
     result: pass
     splits:
     - functional1
+    - nightly
   test_cc_clear_form:
     result: pass
     splits:
     - functional1
+    - nightly
   test_clear_form:
     result: pass
     splits:
     - functional1
+    - nightly
   test_create_new_cc_profile:
     result: pass
     splits:
     - functional1
+    - nightly
   test_create_profile_autofill:
     result: pass
     splits:
@@ -542,18 +626,22 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_edit_credit_card:
     result: pass
     splits:
     - functional1
+    - nightly
   test_enable_disable_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_form_autofill_suggestions:
     result: pass
     splits:
     - functional1
+    - nightly
   test_name_autofill_attribute:
     result: pass
     splits:
@@ -562,6 +650,7 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_telephone_autofill_attribute:
     result: pass
     splits:
@@ -571,19 +660,23 @@ form_autofill:
     result: pass
     splits:
     - functional1
+    - nightly
   test_updating_credit_card:
     result: pass
     splits:
     - functional1
+    - nightly
 geolocation:
   test_geolocation_shared_via_html5:
     result: pass
     splits:
     - functional2
+    - nightly
   test_geolocation_shared_via_w3c_api:
     result: pass
     splits:
     - functional2
+    - nightly
 glean:
   misc_metrics:
     test_misc_metrics:
@@ -625,6 +718,7 @@ menus:
     result: pass
     splits:
     - functional2
+    - nightly
   test_hyperlink_context_menu:
     result: pass
     splits:
@@ -637,18 +731,22 @@ menus:
       win: unstable
     splits:
     - functional2
+    - nightly
   test_new_tab_label:
     result: pass
     splits:
     - functional2
+    - nightly
   test_tab_context_menu_actions:
     result: pass
     splits:
     - functional2
+    - nightly
   test_tab_context_menu_close:
     result: pass
     splits:
     - functional2
+    - nightly
 meta:
   test_selectors:
     comment: Not part of feature functional test suites
@@ -662,10 +760,12 @@ networking:
     result: pass
     splits:
     - functional2
+    - nightly
   test_custom_doh_provider:
     result: pass
     splits:
     - functional2
+    - nightly
   test_default_dns_protection:
     result: pass
     splits:
@@ -674,36 +774,44 @@ networking:
     result: pass
     splits:
     - functional2
+    - nightly
   test_http_site:
     result: pass
     splits:
     - functional2
+    - nightly
   test_nextdns_as_doh_provider:
     result: pass
     splits:
     - functional2
+    - nightly
 notifications:
   test_audio_video_permissions_notification:
     comment: Issue with Mac GHA? trying pass to see what happens.
     result: pass
     splits:
     - functional2
+    - nightly
   test_camera_permissions_notification:
     result: pass
     splits:
     - functional2
+    - nightly
   test_cancel_webextension:
     result: pass
     splits:
     - functional2
+    - nightly
   test_deny_geolocation:
     result: pass
     splits:
     - functional2
+    - nightly
   test_deny_screen_capture:
     result: pass
     splits:
     - functional2
+    - nightly
   test_downloads_button_is_displayed:
     result: pass
     splits:
@@ -716,14 +824,17 @@ notifications:
     result: pass
     splits:
     - functional2
+    - nightly
   test_geolocation_prompt_presence:
     result: pass
     splits:
     - functional2
+    - nightly
   test_microphone_permissions_notification:
     result: pass
     splits:
     - functional2
+    - nightly
   test_notifications_displayed:
     result: pass
     splits:
@@ -737,63 +848,78 @@ notifications:
     result: pass
     splits:
     - functional2
+    - nightly
 password_manager:
   test_about_logins_copy_prompts_primary_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_direct_navigation:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_edit_prompts_primary_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_navigation_from_about_preferences:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_navigation_from_about_protections:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_navigation_from_context_menu:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_navigation_from_hamburger_menu:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_password_copy_button:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_password_show_hide_button:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_search_passwords:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_search_username:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_search_website:
     result: pass
     splits:
     - functional2
+    - nightly
   test_about_logins_username_copy_button:
     result: pass
     splits:
     - functional2
+    - nightly
   test_add_password_non_ascii_chars:
     result: pass
     splits:
     - functional2
+    - nightly
   test_add_password_save_valid_data:
     result: pass
     splits:
@@ -806,6 +932,7 @@ password_manager:
     result: pass
     splits:
     - functional2
+    - nightly
   test_auto_saved_generated_password_context_menu:
     result: pass
     splits:
@@ -814,10 +941,12 @@ password_manager:
     result: pass
     splits:
     - functional2
+    - nightly
   test_can_view_password_when_PP_enabled:
     result: pass
     splits:
     - functional2
+    - nightly
   test_changes_made_in_edit_mode_are_saved:
     result:
       linux: pass
@@ -825,18 +954,22 @@ password_manager:
       win: unstable
     splits:
     - functional2
+    - nightly
   test_confirm_or_edit_generated_password_shows_previously_edited_and_generated_password_options:
     result: pass
     splits:
     - functional2
+    - nightly
   test_delete_login:
     result: pass
     splits:
     - functional2
+    - nightly
   test_delete_primary_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_edit_autofill_after_pp_dismissed:
     comment: uses pyautogui (headed) to answer the native Primary Password prompt;
       not reliable on linux (Wayland) or win CI, so mac-only like the CSV-export PP
@@ -847,38 +980,47 @@ password_manager:
       win: unstable
     splits:
     - functional2
+    - nightly
   test_edit_generated_password_triggers_autosave:
     result: pass
     splits:
     - functional2
+    - nightly
   test_edit_primary_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_facebook_login_autofill_dropdown:
     result: pass
     splits:
     - functional2
+    - nightly
   test_insecure_password:
     result: pass
     splits:
     - functional2
+    - nightly
   test_multiple_saved_logins:
     result: pass
     splits:
     - functional2
+    - nightly
   test_navigation_to_about_logins_from_autocomplete:
     result: pass
     splits:
     - functional2
+    - nightly
   test_never_save_login_via_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
   test_no_generated_password_options_with_pp_and_no_credentials:
     result: pass
     splits:
     - functional2
+    - nightly
   test_password_csv_correctness:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -887,6 +1029,7 @@ password_manager:
       win: pass
     splits:
     - functional2
+    - nightly
   test_password_csv_export:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -895,14 +1038,17 @@ password_manager:
       win: pass
     splits:
     - functional2
+    - nightly
   test_password_field_only_triggers_dismissed_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
   test_password_manager_key_icon_after_doorhanger_dismiss:
     result: pass
     splits:
     - functional2
+    - nightly
   test_password_manager_on_google_US:
     comment: external site; mac was historically unstable for unknown reasons before
       bug 2056524, keep in mind if it re-flakes
@@ -916,6 +1062,7 @@ password_manager:
     result: pass
     splits:
     - functional2
+    - nightly
   test_primary_password_allows_csv_export:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1983843
     result:
@@ -924,42 +1071,52 @@ password_manager:
       win: unstable
     splits:
     - functional2
+    - nightly
   test_primary_password_triggered_on_about_logins_access:
     result: pass
     splits:
     - functional2
+    - nightly
   test_private_browsing_dismiss_doorhanger_credentials:
     result: pass
     splits:
     - functional2
+    - nightly
   test_save_login_via_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
   test_saved_hyperlink_redirects_to_corresponding_page:
     result: pass
     splits:
     - functional2
+    - nightly
   test_taobao_password_management:
     result: pass
     splits:
     - functional2
+    - nightly
   test_update_login_via_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
   test_use_saved_password_option_not_in_password_field_context_menu_without_saved_logins:
     result: pass
     splits:
     - functional2
+    - nightly
   test_use_saved_password_option_not_in_username_field_context_menu_without_saved_logins:
     result: pass
     splits:
     - functional2
+    - nightly
   test_username_edit_captured_in_dismissed_doorhanger:
     result: pass
     splits:
     - functional2
+    - nightly
 pdf_viewer:
   test_add_image_pdf:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1982852
@@ -978,6 +1135,7 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_open_pdf_in_FF:
     result: pass
     splits:
@@ -986,22 +1144,27 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_contextual_menu_actions:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_copy_paste_functionality:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_copy_paste_functionality_numerical:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_data_can_be_cleared:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_download:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2018768
     result:
@@ -1010,14 +1173,17 @@ pdf_viewer:
       win: pass
     splits:
     - functional2
+    - nightly
   test_pdf_drawing_area_actions:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_dropdown_functionality:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_input_numbers:
     result: pass
     splits:
@@ -1026,6 +1192,7 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_navigation:
     result: pass
     splits:
@@ -1035,30 +1202,37 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_text_and_draw_toolbar_buttons:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_zoom_checkboxes:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_zoom_in_text_fields:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_zoom_radio_buttons:
     result: pass
     splits:
     - functional2
+    - nightly
   test_zoom_pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_zoom_works_on_dropdown_menus:
     result: pass
     splits:
     - functional2
+    - nightly
 pocket:
   test_basic_de:
     test_localized_pocket_layout_DE:
@@ -1084,6 +1258,7 @@ preferences:
     result: pass
     splits:
     - functional2
+    - nightly
   test_clear_cookie_data:
     result:
       linux: pass
@@ -1100,6 +1275,7 @@ preferences:
     result: pass
     splits:
     - functional2
+    - nightly
   test_lang_pack_changed_from_about_prefs:
     result: pass
     splits:
@@ -1123,6 +1299,7 @@ printing_ui:
     result: pass
     splits:
     - functional2
+    - nightly
   test_print_preview:
     result: pass
     splits:
@@ -1132,6 +1309,7 @@ printing_ui:
     result: pass
     splits:
     - functional2
+    - nightly
 profile:
   test_set_default_profile:
     result:
@@ -1145,10 +1323,12 @@ reader_view:
     result: pass
     splits:
     - functional2
+    - nightly
   test_reader_view_close_sidebar:
     result: pass
     splits:
     - functional2
+    - nightly
   test_reader_view_location_bar:
     result: pass
     splits:
@@ -1171,10 +1351,12 @@ scrolling_panning_zooming:
     result: pass
     splits:
     - functional2
+    - nightly
   test_zoom_menu_correlation:
     result: pass
     splits:
     - functional2
+    - nightly
   test_zoom_text_only:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2022011
     result: unstable
@@ -1185,6 +1367,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_blocking_cryptominers:
     result: deprecated
     splits:
@@ -1197,38 +1380,47 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_bookmarks_removed_via_private_browsing:
     result: pass
     splits:
     - functional3
+    - nightly
   test_bookmarks_toolbar_present_in_private_browsing:
     result: pass
     splits:
     - functional3
+    - nightly
   test_cache_is_cleared_via_end_private_session_button:
     result: pass
     splits:
     - functional3
+    - nightly
   test_certificate_expired_displayed_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_clear_cookies_site_data_via_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_connection_not_secured_panel_for_http_sites:
     result: pass
     splits:
     - functional3
+    - nightly
   test_connection_secure_second_level_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_cookies_not_saved_private_browsing:
     result: pass
     splits:
     - functional3
+    - nightly
   test_copy_clean_link:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2052850
     result:
@@ -1237,6 +1429,7 @@ security_and_privacy:
       win: unstable
     splits:
     - functional3
+    - nightly
   test_cross_site_tracking_cookies_blocked:
     result: deprecated
     splits:
@@ -1262,14 +1455,17 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_custom_block_suspected_fingerprinters_only_in_private_windows:
     result: pass
     splits:
     - functional3
+    - nightly
   test_data_clearance_from_private_window_can_be_canceled:
     result: pass
     splits:
     - functional3
+    - nightly
   test_detected_blocked_trackers_found:
     result: deprecated
     splits:
@@ -1286,38 +1482,47 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_end_private_session_clears_cookies:
     result: pass
     splits:
     - functional3
+    - nightly
   test_ensure_panel_renders_on_first_run:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_panel_displayed_when_all_protections_disabled_custom:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_panel_displayed_when_no_trackers_detected:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_panel_displayed_when_protection_off:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_toggle_on_off_behavior:
     result: pass
     splits:
     - functional3
+    - nightly
   test_etp_toggle_on_off_behavior_private_window:
     result: pass
     splits:
     - functional3
+    - nightly
   test_extended_certificate_messaging_displayed_in_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_fingerprinters_blocked_and_shown_in_panel_and_preferences:
     result: pass
     splits:
@@ -1344,14 +1549,17 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_mixed_content_warning_displayed_in_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_never_remember_browsing_history:
     result: pass
     splits:
     - functional3
+    - nightly
   test_no_cached_file_in_private_browsing:
     result: pass
     splits:
@@ -1360,6 +1568,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_link_in_private_window:
     result: pass
     splits:
@@ -1373,6 +1582,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_phishing_and_malware_warnings:
     result: pass
     splits:
@@ -1381,14 +1591,17 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_private_browser_password_doorhanger:
     result: pass
     splits:
     - functional3
+    - nightly
   test_private_session_awesome_bar_exclusion:
     result: pass
     splits:
     - functional3
+    - nightly
   test_private_session_history_exclusion:
     result: pass
     splits:
@@ -1397,14 +1610,17 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_protection_level_redirect_about_preferences:
     result: pass
     splits:
     - functional3
+    - nightly
   test_secure_domain_certificate_messaging_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_see_all_link_redirects_to_blocked_trackers:
     result: pass
     splits:
@@ -1413,6 +1629,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_social_media_trackers_displayed_subpanel:
     result: pass
     splits:
@@ -1446,6 +1663,7 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+    - nightly
   test_undo_close_tab_private_browsing:
     result: pass
     splits:
@@ -1455,14 +1673,17 @@ session_restore:
     result: pass
     splits:
     - functional3
+    - nightly
   test_closed_tabs_from_multiple_windows_shown_in_history_menu_bar:
     result: pass
     splits:
     - functional3
+    - nightly
   test_closed_tabs_from_multiple_windows_shown_in_library_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_restore_last_closed_tabs_shortcut:
     result: pass
     splits:
@@ -1471,71 +1692,88 @@ session_restore:
     result: pass
     splits:
     - functional3
+    - nightly
   test_restored_closed_tabs_removed_from_all_history_entries:
     result: pass
     splits:
     - functional3
+    - nightly
 sidebar:
   test_ai_chatbot_removed_from_sidebar_not_shown_in_tab_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_choose_ai_chatbot_via_page_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_close_button_present_on_hovering_or_selecting_a_vertical_tab:
     result: pass
     splits:
     - functional3
+    - nightly
   test_hide_sidebar_behaviour:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_ai_chat_via_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_button_always_displayed_on_fresh_profile:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_duplicate_vertical_tab:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_enabled_in_private_window:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_expand_collapse_on_hover_unaffected_by_right_side_position:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_multiple_vertical_tabs_selection:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tab_can_be_reloaded:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_bookmarked:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_closing_options:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_move_options:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_multiselect_close_options:
     result: pass
     splits:
     - functional3
+    - nightly
   test_sidebar_vertical_tabs_mute_unmute:
     comment: CI limitation - audio playback not supported on Windows CI runners
     result:
@@ -1544,38 +1782,47 @@ sidebar:
       win: unstable
     splits:
     - functional3
+    - nightly
   test_summarize_page_via_ai_chat_panel:
     result: pass
     splits:
     - functional3
+    - nightly
   test_summarize_page_via_sidebar_ai_chat_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_summarize_page_via_tab_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_switch_between_horizontal_vertical_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_switching_to_horizontal_tabs_disables_expand_on_hover:
     result: pass
     splits:
     - functional3
+    - nightly
   test_toggle_sidebar_via_toolbar_button:
     result: pass
     splits:
     - functional3
+    - nightly
   test_user_can_manage_pinned_extensions_on_the_sidebar:
     result: pass
     splits:
     - functional3
+    - nightly
   test_vertical_tab_pinned_unpinned_with_expand_on_hover_enabled:
     result: pass
     splits:
     - functional3
+    - nightly
   test_vertical_tabs_reopen_closed_tab:
     result: pass
     splits:
@@ -1601,6 +1848,7 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_close_pinned_tab_via_mouse:
     result: pass
     splits:
@@ -1611,14 +1859,17 @@ tabs:
     splits:
     - ci
     - functional3
+    - nightly
   test_display_customize_button:
     result: pass
     splits:
     - functional3
+    - nightly
   test_edit_tab_groups:
     result: pass
     splits:
     - functional3
+    - nightly
   test_group_tabs:
     result: pass
     splits:
@@ -1627,18 +1878,22 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_list_all_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_move_multi_selected_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_move_single_tab_via_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_mute_tabs:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2001204
     result:
@@ -1647,10 +1902,12 @@ tabs:
       win: unstable
     splits:
     - functional3
+    - nightly
   test_navigation_multiple_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_bookmark_in_new_tab:
     result: pass
     splits:
@@ -1659,6 +1916,7 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_new_tab:
     result: pass
     splits:
@@ -1667,10 +1925,12 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_open_new_tab_via_hyperlink:
     result: pass
     splits:
     - functional3
+    - nightly
   test_pin_tab:
     result: pass
     splits:
@@ -1679,6 +1939,7 @@ tabs:
     result: pass
     splits:
     - functional3
+    - nightly
   test_play_mute_unmute_tabs_via_toggle:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2056387
     result:
@@ -1687,46 +1948,57 @@ tabs:
       win: unstable
     splits:
     - functional3
+    - nightly
   test_reload_overiding_cache_keys:
     result: pass
     splits:
     - functional3
+    - nightly
   test_reload_tab_via_keyboard:
     result: pass
     splits:
     - functional3
+    - nightly
   test_remove_tab_from_a_group:
     result: pass
     splits:
     - functional3
+    - nightly
   test_reopen_tab_through_context_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_reopen_tab_through_history_menu:
     result: pass
     splits:
     - functional3
+    - nightly
   test_reopen_tabs_through_keys:
     result: pass
     splits:
     - functional3
+    - nightly
   test_restore_closed_tabs_previous_groups:
     result: pass
     splits:
     - functional3
+    - nightly
   test_save_and_close_a_tab_group:
     result: pass
     splits:
     - functional3
+    - nightly
   test_tab_hover_different_content_type:
     result: pass
     splits:
     - functional3
+    - nightly
   test_ungroup_tabs:
     result: pass
     splits:
     - functional3
+    - nightly
 theme_and_toolbar:
   test_customize_themes_and_redirect:
     result: pass

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1493,7 +1493,6 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
-    - nightly
   test_ensure_panel_renders_on_first_run:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1491,7 +1491,6 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
-    - nightly
   test_ensure_panel_renders_on_first_run:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -448,7 +448,8 @@ downloads:
     splits:
     - functional1
   test_change_download_folder:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2063442
+    result: unstable
     splits:
     - functional1
     - ci

--- a/modules/page_base.py
+++ b/modules/page_base.py
@@ -47,6 +47,7 @@ _gui_auto = None
 def _make_gui_auto(sysname):
     if (
         sysname == "Linux"
+        and not os.environ.get("MANUAL")
         and not os.environ.get("DISPLAY")
         and not os.environ.get("WAYLAND_DISPLAY")
     ):

--- a/scripts/choose_test_split.py
+++ b/scripts/choose_test_split.py
@@ -164,11 +164,11 @@ if __name__ == "__main__":
         run_list = dedupe(run_list)
         run_list = manifest.filter_filenames_by_pass(run_list)
 
+        # Assign a split name to STARFOX_EXCLUDE to remove tests in that split from run
         if os.environ.get("STARFOX_EXCLUDE"):
             print(f"Excluding tests from split: {os.environ['STARFOX_EXCLUDE']}...")
             for exclude in dedupe(manifest.gather_split(os.environ["STARFOX_EXCLUDE"])):
-                if exclude in run_list:
-                    del run_list[run_list.index(exclude)]
+                run_list.remove(exclude)
 
         with open(OUTPUT_FILE, "w") as fh:
             fh.write("\n".join(run_list))

--- a/scripts/choose_test_split.py
+++ b/scripts/choose_test_split.py
@@ -168,7 +168,8 @@ if __name__ == "__main__":
         if os.environ.get("STARFOX_EXCLUDE"):
             print(f"Excluding tests from split: {os.environ['STARFOX_EXCLUDE']}...")
             for exclude in dedupe(manifest.gather_split(os.environ["STARFOX_EXCLUDE"])):
-                run_list.remove(exclude)
+                if exclude in run_list:
+                    run_list.remove(exclude)
 
         with open(OUTPUT_FILE, "w") as fh:
             fh.write("\n".join(run_list))

--- a/scripts/choose_test_split.py
+++ b/scripts/choose_test_split.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
 
         if os.environ.get("STARFOX_EXCLUDE"):
             print(f"Excluding tests from split: {os.environ['STARFOX_EXCLUDE']}...")
-            for exclude in manifest.gather_split(os.environ["STARFOX_EXCLUDE"]):
+            for exclude in dedupe(manifest.gather_split(os.environ["STARFOX_EXCLUDE"])):
                 if exclude in run_list:
                     del run_list[run_list.index(exclude)]
 

--- a/scripts/choose_test_split.py
+++ b/scripts/choose_test_split.py
@@ -164,6 +164,12 @@ if __name__ == "__main__":
         run_list = dedupe(run_list)
         run_list = manifest.filter_filenames_by_pass(run_list)
 
+        if os.environ.get("STARFOX_EXCLUDE"):
+            print(f"Excluding tests from split: {os.environ['STARFOX_EXCLUDE']}...")
+            for exclude in manifest.gather_split(os.environ["STARFOX_EXCLUDE"]):
+                if exclude in run_list:
+                    del run_list[run_list.index(exclude)]
+
         with open(OUTPUT_FILE, "w") as fh:
             fh.write("\n".join(run_list))
         sys.exit(0)

--- a/tests/security_and_privacy/test_never_remember_browsing_history.py
+++ b/tests/security_and_privacy/test_never_remember_browsing_history.py
@@ -20,9 +20,7 @@ links = [
     "about:blank",
 ]
 
-COOKIE_LABEL_TEXT = (
-    "Firefox clears cookies and site data from your session when you close the browser."
-)
+COOKIE_LABEL_TEMPLATE = "%BROWSER% clears cookies and site data from your session when you close the browser."
 HISTORY_LABEL_TEXT = (
     "Every window acts like a private window. When on, extensions need to be allowed."
 )
@@ -34,7 +32,7 @@ def add_to_prefs_list():
 
 
 def test_never_remember_browsing_history_settings(
-    driver: Firefox, about_prefs_privacy: AboutPrefs
+    driver: Firefox, about_prefs_privacy: AboutPrefs, browser_name: str
 ):
     """
     C102381.1: Ensure that setting the browser to never remember history has the correct
@@ -43,10 +41,11 @@ def test_never_remember_browsing_history_settings(
 
     # instantiate objs
     about_prefs_privacy.open()
+    cookie_label_text = COOKIE_LABEL_TEMPLATE.replace("%BROWSER%", browser_name)
 
     # perform all about:preferences#privacy assertions according to testrail
     cookies_label = about_prefs_privacy.get_element("cookies-privacy-label")
-    assert cookies_label.get_attribute("message") == COOKIE_LABEL_TEXT
+    assert cookies_label.get_attribute("message") == cookie_label_text
 
     delete_cookies_checkbox = about_prefs_privacy.get_element("cookies-delete-on-close")
     assert delete_cookies_checkbox.get_attribute("checked") == "true"

--- a/tests/tabs/test_display_customize_button.py
+++ b/tests/tabs/test_display_customize_button.py
@@ -12,7 +12,7 @@ def test_case():
     return "134463"
 
 
-def test_customize_button_displayed_in_tab_bar(driver: Firefox):
+def test_customize_button_displayed_in_tab_bar(driver: Firefox, browser_name: str):
     """
     C134463 - Verify that the Customize button is displayed in the tab bar
     and the Customize tab persists when switching tabs.
@@ -35,7 +35,7 @@ def test_customize_button_displayed_in_tab_bar(driver: Firefox):
     with driver.context(driver.CONTEXT_CHROME):
         customize_tab = tabs.get_tab(2)
         assert customize_tab is not None, "Customize tab should still exist."
-        assert tabs.get_tab_title(customize_tab) == "Customize Firefox"
+        assert tabs.get_tab_title(customize_tab) == f"Customize {browser_name}"
         assert customize_tab.get_attribute("visuallyselected") != "true", (
             "Customize tab should be unfocused."
         )


### PR DESCRIPTION
### Relevant Links

JIRA: [ticket](https://mozilla-hub.atlassian.net/browse/DTE-4367)

### Description of Code / Doc Changes

In preparation to handle Nightly as the system under test, we need to make a few changes to the codebase:
* Create a pytest fixture that returns "Firefox" or "Nightly" based on the name of the application
* Create a `nightly` split for functional testing
* Temporary workflow changes while prepping for the full Nightly workflow:
  * allow split name to be passed into main.yml workflow dispatch
  * Attempt to allow test exclusion based on overlapping splits
* Update tests that failed because of reliance on "Firefox" app name

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes CI flow

### Comments or Future Work

Headed testing in GHA linux doesn't work, even with the test exclusions. I'm going ahead and calling that "out of scope" for this change, but we're going to have to revisit it.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted..

Thank you!
