### PR TITLE
add manifest checker to lint step of TC

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -752,7 +752,7 @@ menus:
     - nightly
 meta:
   test_selectors:
-    comment: Not part of feature functional test suites
+    comment: Not part of feature functional test suites (no need for http link)
     result: unstable
     splits: []
   test_version:
@@ -989,9 +989,7 @@ password_manager:
     - functional2
     - nightly
   test_edit_autofill_after_pp_dismissed:
-    comment: uses pyautogui (headed) to answer the native Primary Password prompt;
-      not reliable on linux (Wayland) or win CI, so mac-only like the CSV-export PP
-      tests
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064165
     result:
       linux: unstable
       mac: pass
@@ -1024,6 +1022,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_navigation_to_about_logins_from_autocomplete:
     result: pass
     splits:
@@ -1072,8 +1071,7 @@ password_manager:
     - functional2
     - nightly
   test_password_manager_on_google_US:
-    comment: external site; mac was historically unstable for unknown reasons before
-      bug 2056524, keep in mind if it re-flakes
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064167, old mac bug
     result:
       linux: pass
       mac: unstable
@@ -1123,6 +1121,7 @@ password_manager:
     splits:
     - functional2
     - nightly
+    - no_xvfb
   test_update_login_via_doorhanger:
     result: pass
     splits:
@@ -1367,10 +1366,10 @@ scrolling_panning_zooming:
     splits:
     - smoke
   test_mouse_wheel_zoom:
-    comment: No support for testing this on MAc
+    comment: Mac cannot be supported
     result:
       linux: pass
-      mac: unstable
+      mac: unsupported
       win: pass
     splits:
     - functional2
@@ -1802,7 +1801,7 @@ sidebar:
     - functional3
     - nightly
   test_sidebar_vertical_tabs_mute_unmute:
-    comment: CI limitation - audio playback not supported on Windows CI runners
+    comment: GHA win audio bug, https://bugzilla.mozilla.org/show_bug.cgi?id=2064170
     result:
       linux: pass
       mac: pass

--- a/scripts/manifest_lint.py
+++ b/scripts/manifest_lint.py
@@ -1,0 +1,25 @@
+import yaml
+
+MANIFEST = "manifests/key.yaml"
+
+if __name__ == "__main__":
+    errors = []
+    with open(MANIFEST) as fh:
+        manifest_info = yaml.safe_load(fh)
+    for key in manifest_info:
+        for test in manifest_info[key]:
+            ptr = manifest_info[key][test]
+            trail = [key, test]
+            while "result" not in ptr:
+                next_level = list(ptr.keys())[0]
+                ptr = ptr[next_level]
+                trail.append(next_level)
+            if ptr["result"] == "unstable" or (
+                isinstance(ptr["result"], dict)
+                and any(ptr["result"][k] == "unstable" for k in ptr["result"])
+            ):
+                if "http" not in ptr.get("comment", ""):
+                    errors.append(f"{'/'.join(trail)}: marked unstable without link")
+
+    if errors:
+        raise ValueError("\n".join(errors))

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -5,7 +5,6 @@ transforms:
 task-defaults:
   worker-type: t-linux-wayland
   worker:
-    taskcluster-proxy: true
     max-run-time: 1800
 
 tasks:
@@ -18,7 +17,6 @@ tasks:
         pip3 install 'ruff==0.9.6' --break-system-packages;
         pip3 install 'uv==0.11.18' --break-system-packages;
         python3 -m ruff version;
-        uv run python scripts/switch_config.py ci;
         uv sync;
         uv run python -m scripts.manifest_lint;
         export EXIT_CODE=$?;

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -18,7 +18,7 @@ tasks:
         pip3 install 'uv==0.11.18' --break-system-packages;
         python3 -m ruff version;
         uv sync;
-        python3 -m scripts.manifest_lint;
+        uv run python -m scripts.manifest_lint;
         export EXIT_CODE=$?;
         python3 -m ruff format --check;
         export EXIT_CODE=$(( $EXIT_CODE || $? ));

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -5,6 +5,7 @@ transforms:
 task-defaults:
   worker-type: t-linux-wayland
   worker:
+    taskcluster-proxy: true
     max-run-time: 1800
 
 tasks:
@@ -17,6 +18,7 @@ tasks:
         pip3 install 'ruff==0.9.6' --break-system-packages;
         pip3 install 'uv==0.11.18' --break-system-packages;
         python3 -m ruff version;
+        uv run python scripts/switch_config.py ci;
         uv sync;
         uv run python -m scripts.manifest_lint;
         export EXIT_CODE=$?;

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -15,8 +15,12 @@ tasks:
       command: |-
         export PATH=$HOME/.local/bin:$PWD:$PATH
         pip3 install 'ruff==0.9.6' --break-system-packages;
+        pip3 install 'uv==0.11.18' --break-system-packages;
         python3 -m ruff version;
-        python3 -m ruff format --check;
+        uv sync;
+        python3 -m scripts.manifest_lint;
         export EXIT_CODE=$?;
+        python3 -m ruff format --check;
+        export EXIT_CODE=$(( $EXIT_CODE || $? ));
         python3 -m ruff check --select I;
         exit $(( $EXIT_CODE || $? ));


### PR DESCRIPTION
### Relevant Links

N/A

### Description of Code / Doc Changes

* Create checker that verifies that all "unstable" tests have a link in their comment section in the manifest.
* Run that checker in the lint phase of TC
* Update manifest with links for unstables, no_xvfb for tests failed in recent nightly gate check

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [x] Changes CI flow

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
