### PR TITLE
Anca/ Attempt to fix password manager tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -905,20 +905,12 @@ password_manager:
     - functional2
     - nightly
   test_about_logins_search_passwords:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064116
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly
   test_about_logins_search_username:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064114
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly
@@ -965,11 +957,7 @@ password_manager:
     - functional2
     - nightly
   test_changes_made_in_edit_mode_are_saved:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064124
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly
@@ -1034,11 +1022,7 @@ password_manager:
     - functional2
     - nightly
   test_no_generated_password_options_with_pp_and_no_credentials:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064126
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly
@@ -1108,11 +1092,7 @@ password_manager:
     - functional2
     - nightly
   test_saved_hyperlink_redirects_to_corresponding_page:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064104
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly

--- a/modules/data/about_logins.components.json
+++ b/modules/data/about_logins.components.json
@@ -79,23 +79,14 @@
       "location": "The about:login's page's sidebar"
     }
   },
-  "form-actions-row": {
-    "selectorData": "form-actions-row",
-    "strategy": "class",
-    "groups": [],
-    "comment": {
-      "description": "New login page's Cancel and Save button container (is a shadow parent)",
-      "location": "The about:login's new login page"
-    }
-  },
   "save-changes-button": {
     "selectorData": "save-changes-button",
     "strategy": "class",
-    "shadowParent": "form-actions-row",
+    "shadowParent": "login-item",
     "groups": [],
     "comment": {
-      "description": "New login page's Save button",
-      "location": "The about:login's new login page"
+      "description": "Save button for a new or edited login",
+      "location": "The about:login's login form"
     }
   },
   "website-address": {
@@ -259,16 +250,6 @@
     "comment": {
       "description": "About logins edit button",
       "location": "The about:login's main login page after adding a login"
-    }
-  },
-  "save-edited-login": {
-    "selectorData": "save-changes-button",
-    "strategy": "class",
-    "shadowParent": "login-item",
-    "groups": [],
-    "comment": {
-      "description": "Save edited login",
-      "location": "The about:login's main login page after editing a login"
     }
   },
   "copy-username": {

--- a/tests/password_manager/test_about_logins_edit_prompts_primary_password.py
+++ b/tests/password_manager/test_about_logins_edit_prompts_primary_password.py
@@ -43,7 +43,7 @@ def test_about_logins_edit_prompts_primary_password(driver: Firefox):
 
     # The Edit mode is opened, change username and verify the field is changed
     about_logins.get_element("about-logins-page-username-field").send_keys(NEW_USERNAME)
-    about_logins.click_on("save-edited-login")
+    about_logins.click_on("save-changes-button")
     about_logins.element_attribute_contains(
         "about-logins-page-username-field", "value", NEW_USERNAME
     )

--- a/tests/password_manager/test_changes_made_in_edit_mode_are_saved.py
+++ b/tests/password_manager/test_changes_made_in_edit_mode_are_saved.py
@@ -38,7 +38,7 @@ def test_changes_made_in_edit_mode_are_saved(driver: Firefox):
     )
 
     # Click the "Save" button
-    about_logins.click_on("save-edited-login")
+    about_logins.click_on("save-changes-button")
 
     # Verify the username field is changed
     about_logins.element_attribute_contains(


### PR DESCRIPTION
### Relevant Links

Bugzilla: [5 bugs](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=2064104%2C%202064114%2C%202064116%2C%202064124%2C%202064126&list_id=18082185)
TestRail: N/A

### Description of Code / Doc Changes

- `create_new_login` fills the login fields, presses Enter, and falls back to clicking Save if the form didn't submit. That fallback looked for `.form-actions-row` as a top-level element, it isn't one, it lives inside `login-item`'s shadow root, so the lookup could never succeed.
- Mac and Linux submit fine on Enter, so they never ran the fallback. Windows CI loses that race often, ran the fallback every time, and crashed with `NoSuchElementException: .form-actions-row` instead of saving the login.
- Tests fixed
      - test_about_logins_search_passwords
      - test_about_logins_search_username
      - test_no_generated_password_options_with_pp_and_no_credentials
      - test_saved_hyperlink_redirects_to_corresponding_page
      - test_changes_made_in_edit_mode_are_saved
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

-  test_changes_made_in_edit_mode_are_saved still needed one rerun on Windows, so 2064124 may have a second unrelated flake

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
