### PR TITLE
Hani/ Fix test mixed content download https

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -508,8 +508,7 @@ downloads:
     splits:
     - functional1
   test_mixed_content_download_via_https:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064075
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_no_download_telemetry_without_panel:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -511,6 +511,7 @@ downloads:
     result: pass
     splits:
     - functional1
+    - nightly
   test_no_download_telemetry_without_panel:
     result: pass
     splits:

--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -693,6 +693,35 @@ class Navigation(BasePage):
         return self
 
     @BasePage.context_chrome
+    def wait_for_download_entry(self, timeout: int = 60) -> BasePage:
+        """
+        Wait for an entry to show up in the Downloads panel.
+        """
+
+        def _entry_visible(_):
+            if any(
+                element.is_displayed()
+                for element in self.get_elements("download-target-element")
+            ):
+                return True
+            if self.get_element("downloads-panel").get_attribute("panelopen") != "true":
+                buttons = self.get_elements("downloads-button")
+                if buttons and buttons[0].is_displayed():
+                    self.js_click_on("downloads-button")
+            return False
+
+        original_timeout = self.driver.timeouts.implicit_wait
+        self.driver.implicitly_wait(0)
+        try:
+            self.custom_wait(timeout=timeout, poll_frequency=0.5).until(
+                _entry_visible,
+                message="No entry appeared in the Downloads panel.",
+            )
+        finally:
+            self.driver.implicitly_wait(original_timeout)
+        return self
+
+    @BasePage.context_chrome
     def verify_download_name(self, expected_pattern: str) -> BasePage:
         """
         Verify download name matches expected pattern.

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -692,6 +692,17 @@
     "strategy": "css",
     "groups": []
   },
+  "downloads-panel": {
+    "selectorData": "downloadsPanel",
+    "strategy": "id",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Downloads panel anchored to the toolbar button",
+      "location": "Toolbar"
+    }
+  },
   "download-target-element": {
     "selectorData": "downloadTarget",
     "strategy": "class",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1662,10 +1662,12 @@ class AboutPrefs(BasePage):
         # Confirm the moz-select actually wrote through to the backing pref —
         # asserting .value alone would be tautological since we just set it.
         self.expect(
-            lambda _: self.driver.execute_script(
-                "return Services.prefs.getStringPref('browser.ai.control.translations', '');"
+            lambda _: (
+                self.driver.execute_script(
+                    "return Services.prefs.getStringPref('browser.ai.control.translations', '');"
+                )
+                == state
             )
-            == state
         )
         return self
 

--- a/tests/ai_controls/test_c3298824_block_all_persists.py
+++ b/tests/ai_controls/test_c3298824_block_all_persists.py
@@ -30,10 +30,12 @@ def test_block_all_ai_features_option_persists(about_prefs: AboutPrefs):
         "Services.prefs.setStringPref('browser.ai.control.translations', 'available');"
     )
     about_prefs.expect(
-        lambda _: about_prefs.driver.execute_script(
-            "return Services.prefs.getStringPref('browser.ai.control.translations', '');"
+        lambda _: (
+            about_prefs.driver.execute_script(
+                "return Services.prefs.getStringPref('browser.ai.control.translations', '');"
+            )
+            == "available"
         )
-        == "available"
     )
 
     # Enabling an individual feature must NOT clear the global Block-all toggle.

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -32,7 +32,7 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     # Wait for the test website to wake up and download the content
     web_page.open()
     nav.click_download_button()
-    web_page.wait.until(lambda _: nav.element_visible("download-target-element"))
+    nav.element_visible("download-target-element")
 
     # Verify download name matches expected pattern
     nav.verify_download_name(r"file-sample_100kB(\(\d+\))?.odt$")

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -21,7 +21,6 @@ MIXED_CONTENT_DOWNLOAD_URL = (
 MAX_CHECKS = 30
 
 
-# This test has been found to be unstable in CI
 def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     """
     C1756722: Verify that the user can download mixed content via HTTPS
@@ -32,6 +31,7 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
 
     # Wait for the test website to wake up and download the content
     web_page.open()
+    nav.click_download_button()
     web_page.wait.until(lambda _: nav.element_visible("download-target-element"))
 
     # Verify download name matches expected pattern

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -18,13 +18,15 @@ def delete_files_regex_string():
 MIXED_CONTENT_DOWNLOAD_URL = (
     "https://file-examples.com/wp-content/storage/2017/10/file-sample_100kB.odt"
 )
-MAX_CHECKS = 30
 
 
 @pytest.fixture()
 def add_to_prefs_list():
     return [
         ("browser.download.alwaysOpenPanel", True),
+        ("browser.download.folderList", 2),
+        ("browser.helperApps.neverAsk.saveToDisk",
+         "application/vnd.oasis.opendocument.text,application/octet-stream"),
     ]
 
 

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -25,8 +25,10 @@ def add_to_prefs_list():
     return [
         ("browser.download.alwaysOpenPanel", True),
         ("browser.download.folderList", 2),
-        ("browser.helperApps.neverAsk.saveToDisk",
-         "application/vnd.oasis.opendocument.text,application/octet-stream"),
+        (
+            "browser.helperApps.neverAsk.saveToDisk",
+            "application/vnd.oasis.opendocument.text,application/octet-stream",
+        ),
     ]
 
 

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -24,11 +24,6 @@ MIXED_CONTENT_DOWNLOAD_URL = (
 def add_to_prefs_list():
     return [
         ("browser.download.alwaysOpenPanel", True),
-        ("browser.download.folderList", 2),
-        (
-            "browser.helperApps.neverAsk.saveToDisk",
-            "application/vnd.oasis.opendocument.text,application/octet-stream",
-        ),
     ]
 
 

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -31,6 +31,7 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
 
     # Wait for the test website to wake up and download the content
     web_page.open()
+    nav.element_visible("downloads-button")
     nav.click_download_button()
     nav.element_visible("download-target-element")
 

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -38,9 +38,6 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     # Open the page and trigger the mixed content download
     web_page.open()
 
-    # Wait for the downloads button to appear before interacting with it
-    nav.element_visible("download-target-element")
-
     # Verify download name matches expected pattern
     nav.verify_download_name(r"file-sample_100kB(\(\d+\))?.odt$")
 

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -29,11 +29,10 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     web_page = GenericPage(driver, url=MIXED_CONTENT_DOWNLOAD_URL)
     nav = Navigation(driver)
 
-    # Wait for the test website to wake up and download the content
+    # Open the page and trigger the mixed content download
     web_page.open()
 
-    # Wait for download to start and downloads button to appear (longer timeout for CI)
-    nav.element_visible("downloads-button")
+    # Wait for the downloads button to appear before interacting with it
     nav.click_download_button()
     nav.element_visible("download-target-element")
 

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -33,7 +33,7 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     web_page.open()
 
     # Wait for download to start and downloads button to appear (longer timeout for CI)
-    web_page.wait.until(lambda _: nav.element_visible("downloads-button"))
+    nav.element_visible("downloads-button")
     nav.click_download_button()
     nav.element_visible("download-target-element")
 

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -21,6 +21,13 @@ MIXED_CONTENT_DOWNLOAD_URL = (
 MAX_CHECKS = 30
 
 
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("browser.download.alwaysOpenPanel", True),
+    ]
+
+
 def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     """
     C1756722: Verify that the user can download mixed content via HTTPS
@@ -33,7 +40,6 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     web_page.open()
 
     # Wait for the downloads button to appear before interacting with it
-    nav.click_download_button()
     nav.element_visible("download-target-element")
 
     # Verify download name matches expected pattern

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -31,7 +31,9 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
 
     # Wait for the test website to wake up and download the content
     web_page.open()
-    nav.element_visible("downloads-button")
+
+    # Wait for download to start and downloads button to appear (longer timeout for CI)
+    web_page.wait.until(lambda _: nav.element_visible("downloads-button"))
     nav.click_download_button()
     nav.element_visible("download-target-element")
 

--- a/tests/downloads/test_mixed_content_download_via_https.py
+++ b/tests/downloads/test_mixed_content_download_via_https.py
@@ -10,14 +10,18 @@ def test_case():
     return "1756722"
 
 
-@pytest.fixture()
-def delete_files_regex_string():
-    return r"\bdownload\b"
-
-
 MIXED_CONTENT_DOWNLOAD_URL = (
     "https://file-examples.com/wp-content/storage/2017/10/file-sample_100kB.odt"
 )
+
+# Firefox suffixes "(1)", "(2)"... when the file is already in the Downloads folder
+DOWNLOAD_NAME_REGEX = r"file-sample_100kB(\(\d+\))?\.odt"
+
+
+@pytest.fixture()
+def delete_files_regex_string():
+    """Delete the downloaded file, including any copies left by earlier runs."""
+    return rf"{DOWNLOAD_NAME_REGEX}(\.part)?$"
 
 
 @pytest.fixture()
@@ -38,8 +42,11 @@ def test_mixed_content_download_via_https(driver: Firefox, delete_files):
     # Open the page and trigger the mixed content download
     web_page.open()
 
+    # Wait for the download entry to show up in the Downloads panel
+    nav.wait_for_download_entry()
+
     # Verify download name matches expected pattern
-    nav.verify_download_name(r"file-sample_100kB(\(\d+\))?.odt$")
+    nav.verify_download_name(rf"{DOWNLOAD_NAME_REGEX}$")
 
     # Wait for download completion
     nav.wait_for_download_completion()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064075](https://bugzilla.mozilla.org/show_bug.cgi?id=2064075)
TestRail: [1756722](https://mozilla.testrail.io/index.php?/cases/view/1756722)

### Description of Code / Doc Changes

* Fix Fix tests/downloads/test_mixed_content_download_via_https.py

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
