### PR TITLE
Akash/ Stabilize test_clear_cookie_data

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1267,8 +1267,7 @@ preferences:
     - functional2
     - nightly
   test_clear_cookie_data:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064065
-    result: unstable
+    result: pass
     splits:
     - smoke
   test_firefox_home_new_tabs:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -196,7 +196,7 @@
     }
   },
   "close-dialog": {
-    "selectorData": "button[data-l10n-id='close-button']",
+    "selectorData": ":is(button, moz-button)[data-l10n-id='close-button']",
     "strategy": "css",
     "groups": [],
     "comment": {
@@ -330,7 +330,7 @@
     }
   },
   "panel-popup-button": {
-    "selectorData": "button[data-l10n-id='{name}']",
+    "selectorData": ":is(button, moz-button)[data-l10n-id='{name}']",
     "strategy": "css",
     "groups": [],
     "comment": {

--- a/tests/preferences/test_clear_cookie_data.py
+++ b/tests/preferences/test_clear_cookie_data.py
@@ -21,7 +21,7 @@ def test_clear_cookie_data(driver: Firefox, about_prefs: AboutPrefs):
     """
     C143627: Cookies and site data can be cleared via the "Clear Data" panel
     """
-    # Visit a site to get a cookie added to saved data
+    # Visit a site to get a cookie added to the saved data
     driver.get(WEBSITE_ADDRESS)
 
     # Open dialog and read current value (must be > 0)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064065](https://bugzilla.mozilla.org/show_bug.cgi?id=2064065)
TestRail: [143627](https://mozilla.testrail.io/index.php?/cases/view/143627)

### Description of Code / Doc Changes

* Fixed `close-dialog` and `panel-popup-button` in `about_prefs.components.json`
  to match both `<button>` and `<moz-button>` via `:is(button, moz-button)`.
* Re-enabled `test_clear_cookie_data` in `key.yaml` (set to `unstable` in #1563).

### Process Changes Required

- [x] Changes or creates a BOM/POM (name the object model): _AboutPrefs (element manifest only)_

### Screenshots or Explanations

Fx155 changed the SubDialog close button from `<button class="dialogClose close-icon">`
to `<moz-button class="dialogClose">`. Both selectors hardcoded the `button` tag, so
they matched nothing and `close_dialog_box()` timed out. Not an iframe issue, the
dialog opens and the value reads fine.

`:is()` rather than a comma list because `get_selector` (`page_base.py:530`)
substitutes only the first `{name}`, leaving a literal `{name}` in the second half.

Tested: `test_clear_cookie_data` + `test_manage_cookie_data` pass on Nightly 155 and
Release 153, on macOS and Windows, headed and headless.

### Comments or Future Work

`profile-container-item-button` in `about_profiles.components.json` has the same
`button[data-l10n-id='{name}']` shape, passes today, but latent.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.