### PR TITLE
Hani/ Fix download target element issue

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -464,18 +464,15 @@ downloads:
     - functional1
     - nightly
   test_download_apk_and_check_extension:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064085
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_download_epub_shows_extension_in_downloads_panel:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064085
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_download_exe_and_check_extension:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064085
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_download_malicious_warning:
@@ -484,8 +481,7 @@ downloads:
     splits:
     - functional1
   test_download_mp3_and_check_extension:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064085
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_download_pdf:
@@ -820,13 +816,11 @@ notifications:
     - functional2
     - nightly
   test_downloads_button_is_displayed:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064085
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_downloads_finished_button_is_displayed:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064085
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_geolocation_allow_browserleaks:

--- a/tests/downloads/test_download_apk_and_check_extension.py
+++ b/tests/downloads/test_download_apk_and_check_extension.py
@@ -13,6 +13,13 @@ def test_case():
     return "1836830"
 
 
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("browser.download.alwaysOpenPanel", True),
+    ]
+
+
 @pytest.mark.headed
 def test_download_apk_and_check_extension(driver: Firefox):
     """

--- a/tests/downloads/test_download_epub_shows_extension_in_downloads_panel.py
+++ b/tests/downloads/test_download_epub_shows_extension_in_downloads_panel.py
@@ -13,6 +13,13 @@ def test_case():
     return "1836831"
 
 
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("browser.download.alwaysOpenPanel", True),
+    ]
+
+
 @pytest.mark.headed
 def test_download_epub_and_check_extension(driver: Firefox):
     """

--- a/tests/downloads/test_download_exe_and_check_extension.py
+++ b/tests/downloads/test_download_exe_and_check_extension.py
@@ -13,6 +13,13 @@ def test_case():
     return "1836829"
 
 
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("browser.download.alwaysOpenPanel", True),
+    ]
+
+
 @pytest.mark.headed
 def test_download_exe_and_check_extension(driver: Firefox):
     """

--- a/tests/downloads/test_download_mp3_and_check_extension.py
+++ b/tests/downloads/test_download_mp3_and_check_extension.py
@@ -22,7 +22,10 @@ def test_case():
 
 @pytest.fixture()
 def add_to_prefs_list():
-    return [("media.play-stand-alone", False)]
+    return [
+        ("media.play-stand-alone", False),
+        ("browser.download.alwaysOpenPanel", True),
+    ]
 
 
 @pytest.fixture()

--- a/tests/notifications/test_downloads_button_is_displayed.py
+++ b/tests/notifications/test_downloads_button_is_displayed.py
@@ -9,7 +9,10 @@ TEST_URL = "https://download.samplelib.com/mp3/sample-3s.mp3"
 
 @pytest.fixture()
 def add_to_prefs_list():
-    return [("media.play-stand-alone", False)]
+    return [
+        ("media.play-stand-alone", False),
+        ("browser.download.alwaysOpenPanel", True),
+    ]
 
 
 @pytest.fixture()

--- a/tests/notifications/test_downloads_finished_button_is_displayed.py
+++ b/tests/notifications/test_downloads_finished_button_is_displayed.py
@@ -9,7 +9,10 @@ TEST_URL = "https://download.samplelib.com/mp3/sample-3s.mp3"
 
 @pytest.fixture()
 def add_to_prefs_list():
-    return [("media.play-stand-alone", False)]
+    return [
+        ("media.play-stand-alone", False),
+        ("browser.download.alwaysOpenPanel", True),
+    ]
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064085](https://bugzilla.mozilla.org/show_bug.cgi?id=2064085)

### Description of Code / Doc Changes

* Test fixed: 
tests/downloads/test_download_exe_and_check_extension.py
tests/downloads/test_download_apk_and_check_extension.py
tests/downloads/test_download_epub_shows_extension_in_downloads_panel.py
tests/downloads/test_download_mp3_and_check_extension.py
tests/notifications/test_downloads_finished_button_is_displayed.py
tests/notifications/test_downloads_button_is_displayed.py

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
