### PR TITLE
Anca/ Fix default doh provider

### DIFF
--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -330,8 +330,11 @@ class AboutPrefs(BasePage):
 
     def verify_doh_provider(self, provider_name: str) -> BasePage:
         """Wait until the DoH status box reports the given provider name."""
-        self.element_attribute_contains(
-            "doh-status-box", "data-l10n-args", provider_name
+        self.custom_wait(timeout=30).until(
+            lambda _: provider_name
+            in (
+                self.get_element("doh-status-box").get_attribute("data-l10n-args") or ""
+            )
         )
         return self
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064127](https://bugzilla.mozilla.org/show_bug.cgi?id=2064127)
TestRail: N/A

### Description of Code / Doc Changes
- In Default mode the name only appears once the DoH rollout has turned DoH on, which waits on remote settings and on heuristics that do live DNS lookups, so allow more than the default wait.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
