### PR TITLE
Akash/ Stabilize test_download_pdf_data

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1134,8 +1134,7 @@ pdf_viewer:
     splits:
     - functional2
   test_download_pdf_data:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064111
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_download_pdf_with_form_fields:

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -78,8 +78,3 @@ def test_download_pdf_data(
     tabs.open_and_switch_to_new_tab()
     driver.get("file://" + os.path.realpath(saved_pdf_location))
     pdf_viewer.element_visible("edited-name-field")
-
-    # Verify if the file exists
-    assert os.path.exists(saved_pdf_location), (
-        f"The file was not downloaded to {saved_pdf_location}."
-    )

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -71,7 +71,7 @@ def test_download_pdf_data(
     finally:
         pdf_viewer.cleanup_mock_file_picker()
 
-    # # Set the expected download path and the expected PDF name
+    # Wait for file download to complete
     wait_for_file_download(saved_pdf_location)
 
     # Open the saved pdf and check if the edited field is displayed

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import pytest
 from selenium.webdriver import Firefox
@@ -29,15 +28,12 @@ def delete_files_regex_string():
 
 @pytest.fixture()
 def add_to_prefs_list():
-    # Suppress the Firefox 150+ private-browsing download notification dialog.
-    return [("browser.download.enableDeletePrivate", False)]
-
-
-@pytest.fixture()
-def hard_quit():
-    # Skip the graceful driver.quit(); gracefully closing the private window
-    # with the edited PDF still open re-raises a native save/cancel prompt.
-    return True
+    return [
+        # Suppress the Firefox 150+ private-browsing download notification dialog.
+        ("browser.download.enableDeletePrivate", False),
+        # Unsaved PDF edits otherwise raise a save prompt that blocks driver.quit().
+        ("dom.disable_beforeunload", True),
+    ]
 
 
 @pytest.mark.headed
@@ -45,7 +41,6 @@ def test_download_pdf_data(
     driver: Firefox,
     pdf_file_path,
     downloads_folder: str,
-    sys_platform,
     file_name,
     delete_files,
     delete_files_regex_string,
@@ -65,25 +60,16 @@ def test_download_pdf_data(
     pdf_viewer = GenericPdf(driver, pdf_url=f"file://{pdf_file_path}")
     pdf_viewer.fill_element("first-name-field", "Mark")
 
-    use_mock_picker = sys_platform == "Linux"
-    if use_mock_picker:
-        pdf_viewer.install_mock_file_picker(saved_pdf_location)
+    # The native "Save As" panel cannot be driven reliably by desktop input on any
+    # platform, so mock the picker instead of clicking through it.
+    pdf_viewer.install_mock_file_picker(saved_pdf_location)
 
     # Click the download button
     try:
         pdf_viewer.click_download_button()
-
-        if use_mock_picker:
-            pdf_viewer.wait_for_mock_file_picker()
-        else:
-            # Allow time for the download dialog to appear and pressing enter to download
-            time.sleep(2)
-
-            # Handle OS download prompt
-            pdf_viewer.handle_os_download_confirmation()
+        pdf_viewer.wait_for_mock_file_picker()
     finally:
-        if use_mock_picker:
-            pdf_viewer.cleanup_mock_file_picker()
+        pdf_viewer.cleanup_mock_file_picker()
 
     # # Set the expected download path and the expected PDF name
     wait_for_file_download(saved_pdf_location)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064111](https://bugzilla.mozilla.org/show_bug.cgi?id=2064111)
TestRail: [1020327](https://mozilla.testrail.io/index.php?/cases/view/1020327)

### Description of Code / Doc Changes

* Mock the file picker on all platforms instead of only Linux, so the native "Save As" panel never opens.
* Added `dom.disable_beforeunload` and removed the `hard_quit` fixture, so the browser shuts down cleanly.
* Re-enabled `test_download_pdf_data` in `key.yaml`.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The test drove a native "Save As" panel with pyautogui. The image match against
`data/cv/mac_save_button.png` never succeeded, so every run fell through to a blind `Enter`
that landed on whichever window had focus — hence the flakiness. `install_mock_file_picker`
swaps `nsIFilePicker` in-process, so no OS dialog appears. TestRail step 4 expects that dialog
on screen; it no longer renders, but `wait_for_mock_file_picker` asserts Firefox invoked the
picker, which the old code never checked.

The edited PDF also raised a save prompt on shutdown, blocking `driver.quit()` until
geckodriver's 60s timeout and orphaning a Firefox process each run. `dom.disable_beforeunload`
suppresses it, making `hard_quit` unnecessary. Runtime: 64s → 4s.

Tested headed on macOS and Windows 11, Nightly 156 and Release 154 on both.
PR CI covers Windows, macOS, and Linux.

### Comments or Future Work

* No test now covers the real OS save dialog. One dedicated test driving it via accessibility
  APIs (`AXUIElement` / UIAutomation) would beat image matching — mac and Windows only, since
  Wayland blocks synthetic input. Happy to file if reviewers agree.
* `test_download_pdf_with_form_fields` (bug 2064142) and `test_image_context_menu_actions` still
  call `handle_os_download_confirmation`. Once both move to the mock, that helper and
  `data/cv/*_save_button.png` can go.
* `downloads_folder` (`conftest.py:244`) uses `%USERNAME%` while `home_folder` uses
  `%HOMEDRIVE%%HOMEPATH%`; they disagree when the account name and profile directory
  differ, which broke local Windows runs. CI is unaffected. Filing separately.
* Step 3 of the case also lists checkboxes and dropdowns; this test only fills a text field.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!