### PR TITLE
Hani/ Remove unstable from password manager us test

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1056,11 +1056,7 @@ password_manager:
     - functional2
     - nightly
   test_password_manager_on_google_US:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064167, old mac bug
-    result:
-      linux: pass
-      mac: unstable
-      win: pass
+    result: pass
     splits:
     - functional2
   test_password_manager_on_reddit:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064167](https://bugzilla.mozilla.org/show_bug.cgi?id=2064167)

### Description of Code / Doc Changes

* Remove unstable password_manager/test_password_manager_on_google_US on mac since it passed every time I ran the test locally.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
