### PR TITLE
Anca/ Fix test_about_logins_username_copy_button

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -913,11 +913,7 @@ password_manager:
     - functional2
     - nightly
   test_about_logins_username_copy_button:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064795
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -187,6 +187,12 @@ class AboutLogins(BasePage):
             logging.info("Element not found or stale, pressing 'Save Changes'")
             self.get_element("save-changes-button").click()
             logging.info("Pressed.")
+            # The item keeps data-editing until the save lands, and the copy
+            # and edit buttons are display:none while it is set.
+            self.wait.until(
+                lambda _: self.get_element("login-item").get_attribute("data-editing")
+                is None
+            )
         return self
 
     def check_logins_present(


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064795](https://bugzilla.mozilla.org/show_bug.cgi?id=2064795)
TestRail: N/A

### Description of Code / Doc Changes

-  After the fallback clicks Save, wait until the login item drops data-editing. about:logins keeps that attribute until the save lands and hides the copy and edit buttons while it's set, so without the wait the test can act on a still-editing item.
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
