### PR TITLE
Akash/ Stabilize test_change_download_folder

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -448,8 +448,7 @@ downloads:
     splits:
     - functional1
   test_change_download_folder:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2063442
-    result: unstable
+    result: pass
     splits:
     - functional1
     - ci

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -695,7 +695,9 @@
   "download-target-element": {
     "selectorData": "downloadTarget",
     "strategy": "class",
-    "groups": [],
+    "groups": [
+      "doNotCache"
+    ],
     "comment": {
       "description": "Downloaded item in the download panel",
       "location": "Download panel"

--- a/tests/downloads/test_change_download_folder.py
+++ b/tests/downloads/test_change_download_folder.py
@@ -19,9 +19,7 @@ DOWNLOADS_PANEL = "downloadsPanel"
 def add_to_prefs_list():
     return [
         ("media.play-stand-alone", False),
-        # The panel no longer auto-opens on every channel, and when it does it
-        # covers the content area and eats the click that starts the next
-        # download. Keep it closed and open it only to assert on it.
+        # Auto-opened panel covers the content area and eats the next download click.
         ("browser.download.alwaysOpenPanel", False),
     ]
 

--- a/tests/downloads/test_change_download_folder.py
+++ b/tests/downloads/test_change_download_folder.py
@@ -11,19 +11,24 @@ from modules.page_object_generics import GenericPage
 FIRST_FILE_REGEX = r"sample-3s(\s\(\d+\))?\.mp3$"
 SECOND_FILE_REGEX = r"sample-6s(\s\(\d+\))?\.mp3$"
 
-# Downloads panel value (chrome) often contains full filename; allow duplicates.
-MP3_PANEL_NAME_REGEX = r".*\.mp3(\s\(\d+\))?$"
 MP3_DOWNLOAD_PAGE = "mp3_download.html"
+DOWNLOADS_PANEL = "downloadsPanel"
 
 
 @pytest.fixture()
 def add_to_prefs_list():
-    return [("media.play-stand-alone", False)]
+    return [
+        ("media.play-stand-alone", False),
+        # The panel no longer auto-opens on every channel, and when it does it
+        # covers the content area and eats the click that starts the next
+        # download. Keep it closed and open it only to assert on it.
+        ("browser.download.alwaysOpenPanel", False),
+    ]
 
 
 @pytest.fixture()
 def test_case():
-    return "1756771"
+    return "1756713"
 
 
 @pytest.fixture()
@@ -88,11 +93,10 @@ def test_change_download_folder(
     page.open()
     page.click_on("link-3s")
 
-    nav.click_file_download_warning_panel()
-
+    nav.open_download_panel()
     nav.element_visible("download-target-element")
-    nav.wait_for_download_completion()
-    nav.verify_download_name(MP3_PANEL_NAME_REGEX)
+    nav.verify_download_name(FIRST_FILE_REGEX)
+    nav.hide_popup(DOWNLOADS_PANEL)
 
     first_pattern = re.compile(FIRST_FILE_REGEX)
 
@@ -110,11 +114,10 @@ def test_change_download_folder(
     # Download another file (should land in new folder)
     page.click_on("link-6s")
 
-    nav.click_file_download_warning_panel()
-
+    nav.open_download_panel()
     nav.element_visible("download-target-element")
-    nav.wait_for_download_completion()
-    nav.verify_download_name(MP3_PANEL_NAME_REGEX)
+    nav.verify_download_name(SECOND_FILE_REGEX)
+    nav.hide_popup(DOWNLOADS_PANEL)
 
     second_pattern = re.compile(SECOND_FILE_REGEX)
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2063442](https://bugzilla.mozilla.org/show_bug.cgi?id=2063442)
TestRail: [1756713](https://mozilla.testrail.io/index.php?/cases/view/1756713)

### Description of Code / Doc Changes

- Set `browser.download.alwaysOpenPanel` to `False` and open/close the downloads panel explicitly (`open_download_panel` / `hide_popup`) instead of relying on it auto-opening.
- Added `doNotCache` to `download-target-element` so the second assertion reads the newest panel row rather than a cached one.
- Tightened both `verify_download_name` calls to the per-file regexes; removed the loose `MP3_PANEL_NAME_REGEX`.
- Removed `click_file_download_warning_panel` (private-browsing-only selector, a guaranteed 3s no-op) and the redundant `wait_for_download_completion`.
- Fixed the `test_case` fixture: `1756771` → `1756713`.
- `key.yaml`: `unstable` → `pass`.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): Navigation
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The test relied on the downloads panel auto-opening. It no longer does on Nightly, so `download-target-element` was never found. Where it does still auto-open, the panel covers the content area and swallows the click that starts the second download.

The caching fix is separate: without `doNotCache`, the second `verify_download_name` re-read the first download's cached row, and the old `.*\.mp3` pattern was loose enough to pass anyway — so the second download was never actually verified.

Verified passing consistently on both Nightly and Firefox release. `doNotCache` is in shared JSON, so the other consumers of `download-target-element` were re-run and all pass.

### Comments or Future Work

- **This test's TestRail coverage is overstated.** It only covers steps 1 and 3 of C1756713. Step 2 (change the folder via **about:preferences → "Save files to"**) is bypassed by setting `browser.download.dir` through `Services.prefs`, because the folder picker is an OS-native dialog Selenium can't drive. Step 4 (**Show in Folder/Finder** for both downloads) isn't covered at all. The case currently reads *Automation Coverage: Full*.
- C1756771 still lists this file under *Automated Test Name(s)* and should be removed, results were landing there because of the wrong fixture ID.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!