### PR TITLE
Anca/ Fix protection tracker count

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1533,11 +1533,7 @@ security_and_privacy:
     splits:
     - functional3
   test_fingerprinters_displayed_subpanel:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064803
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional3
   test_fingerprinters_subpanel_display_when_not_blocked:
@@ -1626,11 +1622,7 @@ security_and_privacy:
     - functional3
     - nightly
   test_protection_report_displays_blocked_trackers_after_opening_tab:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064805
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional3
     - nightly

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1049,7 +1049,11 @@ password_manager:
     - functional2
     - nightly
   test_password_manager_on_google_US:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064167
+    result:
+      linux: pass
+      mac: unstable
+      win: pass
     splits:
     - functional2
   test_password_manager_on_reddit:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1000,7 +1000,11 @@ password_manager:
     - functional2
     - nightly
   test_multiple_saved_logins:
-    result: pass
+    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2065464
+    result:
+      linux: pass
+      mac: pass
+      win: unstable
     splits:
     - functional2
     - nightly

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -556,6 +556,9 @@ class AboutProtections(BasePage):
 
     URL_TEMPLATE = "about:protections"
 
+    TRACKER_COUNT_TIMEOUT = 30
+    TRACKER_COUNT_POLL = 3
+
     def verify_lockwise_scanned_text(self, expected_count: int):
         """Verify the Lockwise 'N password(s) stored securely.' message matches `expected_count`."""
         expected = (
@@ -566,11 +569,28 @@ class AboutProtections(BasePage):
         self.element_has_text("lockwise-scanned-text", expected)
         return self
 
+    def wait_for_weekly_tracker_count(self, minimum: int) -> int:
+        """Reload about:protections until the weekly count reaches minimum.
+
+        The report queries the tracking database once on DOMContentLoaded, so a
+        count written after the page loaded only shows up on the next load.
+        """
+
+        def _count_reached(_):
+            self.open()
+            return self.get_weekly_tracker_count() >= minimum
+
+        self.custom_wait(
+            timeout=self.TRACKER_COUNT_TIMEOUT, poll_frequency=self.TRACKER_COUNT_POLL
+        ).until(_count_reached, message=f"weekly tracker count stayed below {minimum}")
+        return self.get_weekly_tracker_count()
+
     def get_weekly_tracker_count(self) -> int:
         """Returns the number of trackers blocked over the past week from about:protections"""
         # The graph summary carries no data-l10n-args until the report is populated
         raw = self.wait.until(
-            lambda _: self.get_attribute_value("graph-week-summary", "data-l10n-args")
+            lambda _: self.get_attribute_value("graph-week-summary", "data-l10n-args"),
+            message="about:protections did not populate the weekly tracker summary",
         )
         return json.loads(raw)["count"]
 

--- a/modules/page_object_about_pages.py
+++ b/modules/page_object_about_pages.py
@@ -562,7 +562,10 @@ class AboutProtections(BasePage):
 
     def get_weekly_tracker_count(self) -> int:
         """Returns the number of trackers blocked over the past week from about:protections"""
-        raw = self.get_attribute_value("graph-week-summary", "data-l10n-args")
+        # The graph summary carries no data-l10n-args until the report is populated
+        raw = self.wait.until(
+            lambda _: self.get_attribute_value("graph-week-summary", "data-l10n-args")
+        )
         return json.loads(raw)["count"]
 
 

--- a/tests/security_and_privacy/test_protection_report_displays_blocked_trackers_after_opening_tab.py
+++ b/tests/security_and_privacy/test_protection_report_displays_blocked_trackers_after_opening_tab.py
@@ -35,14 +35,8 @@ def test_protection_report_displays_blocked_trackers_after_opening_tab(driver: F
     # Visit a website that has trackers
     driver.get(TEST_WEBSITE)
 
-    # Reach "about:protections"
-    protection.open()
-
-    # Wait for trackers to be counted
-    protection.wait.until(lambda _: protection.get_weekly_tracker_count() > 0)
-
-    # Get the current tracker count
-    first_count = protection.get_weekly_tracker_count()
+    # Reach "about:protections" and wait for the trackers to be counted
+    first_count = protection.wait_for_weekly_tracker_count(1)
 
     # Open "about:protections" in a new tab
     tabs.open_and_switch_to_new_tab()
@@ -67,7 +61,6 @@ def test_protection_report_displays_blocked_trackers_after_opening_tab(driver: F
 
     # Open "about:protections" in a new tab
     tabs.open_and_switch_to_new_tab()
-    protection.open()
 
     # The number of trackers is increasing with each site visit
-    protection.wait.until(lambda _: protection.get_weekly_tracker_count() > first_count)
+    protection.wait_for_weekly_tracker_count(first_count + 1)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064803, 2064805](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=2064803%2C%202064805&list_id=18086091)
TestRail: N/A

### Description of Code / Doc Changes

- 2064805: the test read the tracker count before about:protections had finished rendering it, so it failed on the empty value instead of waiting for it. get_weekly_tracker_count now waits for the attribute to appear. Added wait_for_weekly_tracker_count, which reloads the page until the count reaches the expected number — the report only reads the tracking database on page load, so a tracker counted afterwards doesn't show up until the next one. The test uses that instead of opening the page and polling by hand. Both have a single caller, so nothing else is affected.
- 2064803 had no code defect, the test page on senglehardt.com timed out on the runner. That host backs around 19 of our tracking-protection tests and the rest passed in the same run, so this looks like a one-off; the test is only re-enabled for the next beta run to confirm.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
