### PR TITLE
Akash/ Stabilize test_download_pdf_with_form_fields

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1128,8 +1128,7 @@ pdf_viewer:
     splits:
     - functional2
   test_download_pdf_with_form_fields:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064142
-    result: unstable
+    result: pass
     splits:
     - functional2
   test_download_triggered_on_content_disposition_attachment:

--- a/tests/pdf_viewer/test_download_pdf_data.py
+++ b/tests/pdf_viewer/test_download_pdf_data.py
@@ -13,7 +13,7 @@ def test_case():
 
 
 PDF_FILE_NAME = "i-9.pdf"
-DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
+DOWNLOADED_PDF_REGEX = r"i-9\.pdf"
 
 
 @pytest.fixture()

--- a/tests/pdf_viewer/test_download_pdf_with_form_fields.py
+++ b/tests/pdf_viewer/test_download_pdf_with_form_fields.py
@@ -1,13 +1,14 @@
 import os
-import time
 
 import pytest
 from selenium.webdriver import Firefox
 
 from modules.page_object_generics import GenericPdf
 
+# The saved copy gets a unique name to avoid colliding with other i-9 downloads.
 PDF_FILE_NAME = "i-9.pdf"
-DOWNLOADED_PDF_REGEX = r"i-9.*\.pdf"
+DOWNLOADED_PDF_NAME = "i-9-form-fields.pdf"
+DOWNLOADED_PDF_REGEX = r"i-9-form-fields\.pdf"
 
 
 @pytest.fixture()
@@ -26,11 +27,16 @@ def file_name():
     return PDF_FILE_NAME
 
 
+@pytest.fixture()
+def add_to_prefs_list():
+    # Unsaved PDF edits otherwise raise a save prompt that blocks navigation.
+    return [("dom.disable_beforeunload", True)]
+
+
 @pytest.mark.headed
 def test_download_pdf_with_form_fields(
     driver: Firefox,
     pdf_viewer: GenericPdf,
-    sys_platform,
     delete_files,
     downloads_folder: str,
     delete_files_regex_string,
@@ -40,23 +46,26 @@ def test_download_pdf_with_form_fields(
     C1020326 Download pdf with form fields
 
     Arguments:
-        sys_platform: Current System Platform Type
         pdf_viewer: Fixture returning instance of GenericPdf with correct path.
         downloads_folder: Fixture returning downloads folder path
         delete_files: Fixture to remove the files after the test finishes
+        wait_for_file_download: Fixture that blocks until the download completes
     """
-    # Fill in the name field and trigger download
-    pdf_viewer.fill_element("first-name-field", "Mark")
-    pdf_viewer.click_download_button()
-
-    # Allow time for the download dialog to appear and handle the prompt
-    time.sleep(2)
-
-    # Handle OS download prompt
-    pdf_viewer.handle_os_download_confirmation()
-
     # Set the expected download path and the expected PDF name
-    saved_pdf_path = os.path.join(downloads_folder, PDF_FILE_NAME)
+    saved_pdf_path = os.path.join(downloads_folder, DOWNLOADED_PDF_NAME)
+
+    # Fill in the name field
+    pdf_viewer.fill_element("first-name-field", "Mark")
+
+    # The native "Save As" panel cannot be driven reliably, so mock the picker.
+    pdf_viewer.install_mock_file_picker(saved_pdf_path)
+
+    # Trigger the download and confirm the save dialog opened
+    try:
+        pdf_viewer.click_download_button()
+        pdf_viewer.wait_for_mock_file_picker()
+    finally:
+        pdf_viewer.cleanup_mock_file_picker()
 
     # Verify if the file exists
     wait_for_file_download(saved_pdf_path)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064142](https://bugzilla.mozilla.org/show_bug.cgi?id=2064142)
TestRail: [1020326](https://mozilla.testrail.io/index.php?/cases/view/1020326)

### Description of Code / Doc Changes

- Mock the file picker instead of the native Save As dialog, matching the other pdf_viewer download tests
- Set `dom.disable_beforeunload` to stop the unsaved-edits prompt
- Save as `i-9-form-fields.pdf` and narrow test_download_pdf_data's cleanup regex, to avoid collisions under `-n auto`
- Drop the unused `sys_platform` fixture
- Flip `key.yaml` from `unstable` to `pass`

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Two bugs here. The prompt blocked `driver.get()` for 300s, which the pref fixes.
Separately, the native Save dialog fails intermittently on macOS (repro'd
locally), which is the `unstable` marking. `wait_for_mock_file_picker()` still
asserts the dialog opened, so step 3 stays covered.

6 consecutive passes on Firefox and Nightly, ~3.9s each (was a 308s timeout).
Verified on macOS only.

### Comments or Future Work

@ben-c-at-moz noted on #1574 that mocking the picker may overlap with main-tree pdf.js
coverage. Same applies here. Happy to retire this test instead if you'd prefer.

`downloads_folder` is an unused fixture arg in `test_pdf_data_can_be_cleared`
and `test_pdf_input_numbers`. Not touching it here.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.