### PR TITLE
Akash/ Add test_reload_multiselected_tabs

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1962,6 +1962,11 @@ tabs:
     - functional3
     - nightly
     - no_xvfb
+  test_reload_multiselected_tabs:
+    result: pass
+    splits:
+    - functional3
+    - nightly
   test_reload_overiding_cache_keys:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1966,7 +1966,6 @@ tabs:
     result: pass
     splits:
     - functional3
-    - nightly
   test_reload_overiding_cache_keys:
     result: pass
     splits:

--- a/modules/data/context_menu.components.json
+++ b/modules/data/context_menu.components.json
@@ -151,6 +151,11 @@
     "strategy": "id",
     "groups": []
   },
+  "context-menu_reload-selected-tabs": {
+    "selectorData": "context_reloadSelectedTabs",
+    "strategy": "id",
+    "groups": []
+  },
   "context-menu-move-to-new-window": {
     "selectorData": "context_openTabInWindow",
     "strategy": "id",

--- a/tests/tabs/test_reload_multiselected_tabs.py
+++ b/tests/tabs/test_reload_multiselected_tabs.py
@@ -1,4 +1,3 @@
-from os import listdir
 from shutil import copyfile
 
 import pytest
@@ -29,8 +28,8 @@ def test_case():
 @pytest.fixture()
 def page_urls(tmp_path):
     """Copy the test pages to tmp_path and return their file:// URLs"""
-    for file in listdir("data/pages"):
-        copyfile(f"data/pages/{file}", tmp_path / file)
+    for filename in PAGE_FILENAMES:
+        copyfile(f"data/pages/{filename}", tmp_path / filename)
     return [f"file://{tmp_path / filename}" for filename in PAGE_FILENAMES]
 
 

--- a/tests/tabs/test_reload_multiselected_tabs.py
+++ b/tests/tabs/test_reload_multiselected_tabs.py
@@ -50,7 +50,7 @@ def verify_tabs_reloaded(
     for handle, previous_time_origin in time_origins.items():
         driver.switch_to.window(handle)
         tabs.expect_in_content(
-            lambda _, previous=previous_time_origin: driver.execute_script(
+            lambda d, previous=previous_time_origin: d.execute_script(
                 "return performance.timeOrigin"
             )
             != previous
@@ -99,7 +99,7 @@ def test_reload_multiselected_tabs(
     selected_tabs = tabs.select_multiple_tabs_by_indices(
         SELECTED_TAB_INDICES, sys_platform
     )
-    tab_context_menu.context_click(selected_tabs[1])
+    tab_context_menu.context_click(selected_tabs[0])
     tab_context_menu.click_and_hide_menu(RELOAD_SELECTED_TABS)
 
     verify_tabs_reloaded(driver, tabs, time_origins)

--- a/tests/tabs/test_reload_multiselected_tabs.py
+++ b/tests/tabs/test_reload_multiselected_tabs.py
@@ -1,0 +1,105 @@
+from os import listdir
+from shutil import copyfile
+
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.keys import Keys
+
+from modules.browser_object import ContextMenu, Navigation, TabBar
+
+RELOAD_SELECTED_TABS = "context-menu_reload-selected-tabs"
+
+# One local page per tab
+PAGE_FILENAMES = [
+    "basic_webpage.html",
+    "article_page.html",
+    "mp3_download.html",
+    "web_audio_landing.html",
+]
+
+# Indices of those tabs, 1-based
+SELECTED_TAB_INDICES = [2, 3, 4, 5]
+
+
+@pytest.fixture()
+def test_case():
+    return "4038574"
+
+
+@pytest.fixture()
+def page_urls(tmp_path):
+    """Copy the test pages to tmp_path and return their file:// URLs"""
+    for file in listdir("data/pages"):
+        copyfile(f"data/pages/{file}", tmp_path / file)
+    return [f"file://{tmp_path / filename}" for filename in PAGE_FILENAMES]
+
+
+def get_time_origins(driver: Firefox, handles: list[str]) -> dict[str, float]:
+    """Return the page time origin of every given tab"""
+    time_origins = {}
+    for handle in handles:
+        driver.switch_to.window(handle)
+        time_origins[handle] = driver.execute_script("return performance.timeOrigin")
+    return time_origins
+
+
+def verify_tabs_reloaded(
+    driver: Firefox, tabs: TabBar, time_origins: dict[str, float]
+) -> None:
+    """A new page time origin means the tab reloaded"""
+    for handle, previous_time_origin in time_origins.items():
+        driver.switch_to.window(handle)
+        tabs.expect_in_content(
+            lambda _, previous=previous_time_origin: driver.execute_script(
+                "return performance.timeOrigin"
+            )
+            != previous
+        )
+
+
+def test_reload_multiselected_tabs(
+    driver: Firefox, sys_platform: str, page_urls: list[str]
+):
+    """
+    C4038574 - Verify that multiselected tabs can be reloaded
+    """
+
+    tabs = TabBar(driver)
+    nav = Navigation(driver)
+    tab_context_menu = ContextMenu(driver)
+
+    mod_key = Keys.COMMAND if sys_platform == "Darwin" else Keys.CONTROL
+
+    # Step 1: Open more than 3 tabs with different webpages
+    for url in page_urls:
+        tabs.new_tab_by_button()
+        driver.switch_to.window(driver.window_handles[-1])
+        driver.get(url)
+
+    assert len(driver.window_handles) == len(PAGE_FILENAMES) + 1
+    page_handles = driver.window_handles[1:]
+
+    # Step 2: Multiselect the tabs and reload via the toolbar button
+    time_origins = get_time_origins(driver, page_handles)
+    tabs.select_multiple_tabs_by_indices(SELECTED_TAB_INDICES, sys_platform)
+    nav.refresh_page()
+
+    verify_tabs_reloaded(driver, tabs, time_origins)
+
+    # Step 3: Reload with Ctrl/Cmd + R
+    # Reading the time origins of switched tabs, clearing the multi-selection
+    time_origins = get_time_origins(driver, page_handles)
+    tabs.select_multiple_tabs_by_indices(SELECTED_TAB_INDICES, sys_platform)
+    tabs.reload_tab(nav, mod_key=mod_key, extra_key="r")
+
+    verify_tabs_reloaded(driver, tabs, time_origins)
+
+    # Step 4: Reload via the `Reload Tabs` context menu option
+    time_origins = get_time_origins(driver, page_handles)
+    selected_tabs = tabs.select_multiple_tabs_by_indices(
+        SELECTED_TAB_INDICES, sys_platform
+    )
+    tab_context_menu.context_click(selected_tabs[1])
+    tab_context_menu.click_and_hide_menu(RELOAD_SELECTED_TABS)
+
+    verify_tabs_reloaded(driver, tabs, time_origins)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2036121](https://bugzilla.mozilla.org/show_bug.cgi?id=2050029)
TestRail: [4038574](https://mozilla.testrail.io/index.php?/cases/view/4038574)

### Description of Code / Doc Changes

* Adds `tests/tabs/test_reload_multiselected_tabs.py`, covering C4038574: reloading multiselected tabs via the toolbar button, Ctrl/Cmd + R, and the `Reload Tabs` context menu option.
* Adds a `context-menu_reload-selected-tabs` component (`#context_reloadSelectedTabs`) to `context_menu.components.json`. The existing `context-menu_reload-tab` only covers the single tab case.
* Registers the test in `key.yaml` under `functional3`.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): ContextMenu
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Each step asserts that all four tabs reloaded, by checking that every tab's `performance.timeOrigin` changed. This catches the case where only the active tab reloads instead of the whole selection.

The tabs are filled with local pages from `data/pages` over `file://`, so the test does not depend on the network.

Each step reselects the tabs first. Verification has to switch to each tab to read its time origin, and switching tabs clears the multi-selection.

Verified 3/3 consecutive passes on release Firefox, plus Nightly and headless. Removing a reload step makes it fail on timeout.

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.