### PR TITLE
Hani/ Remove unstable from test autofill pp dismissed

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -972,11 +972,7 @@ password_manager:
     - functional2
     - nightly
   test_edit_autofill_after_pp_dismissed:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064165
-    result:
-      linux: unstable
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064165](https://bugzilla.mozilla.org/show_bug.cgi?id=2064165)

### Description of Code / Doc Changes

* Remove unstable from test_edit_autofill_after_pp_dismissed on win and linux since it passed every time I ran the test locally.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [ ] Reviewers have been requested.
- [ ] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
