### PR TITLE
Akash/ Fix test_download_pdf to use the PDF URL from the test case

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -484,8 +484,7 @@ downloads:
     splits:
     - functional1
   test_download_pdf:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2063587
-    result: unstable
+    result: pass
     splits:
     - smoke
     - ci

--- a/tests/downloads/test_download_pdf.py
+++ b/tests/downloads/test_download_pdf.py
@@ -5,6 +5,10 @@ from selenium.webdriver import Firefox
 
 from modules.page_object import GenericPdf
 
+DUMMY_PDF_URL = (
+    "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+)
+
 
 @pytest.fixture()
 def test_case():
@@ -13,12 +17,11 @@ def test_case():
 
 @pytest.fixture()
 def delete_files_regex_string():
-    return r".*i-9-downloads\.pdf"
+    return r".*dummy-saved\.pdf"
 
 
 def test_download_pdf(
     driver: Firefox,
-    fillable_pdf_url: str,
     downloads_folder: str,
     delete_files,
     wait_for_file_download,
@@ -35,11 +38,11 @@ def test_download_pdf(
     """
 
     # Set the expected download path and the expected PDF name
-    file_name = "i-9-downloads.pdf"
+    file_name = "dummy-saved.pdf"
     saved_pdf_location = os.path.join(downloads_folder, file_name)
 
     # Initialize objects
-    pdf_page = GenericPdf(driver, pdf_url=fillable_pdf_url)
+    pdf_page = GenericPdf(driver, pdf_url=DUMMY_PDF_URL)
 
     # Replace the native save dialog with a mock that returns our target path
     pdf_page.install_mock_file_picker(saved_pdf_location)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2063587](https://bugzilla.mozilla.org/show_bug.cgi?id=2063587)
TestRail: [1756769](https://mozilla.testrail.io/index.php?/cases/view/1756769)

### Description of Code / Doc Changes

- Point `test_download_pdf` at the `dummy.pdf` URL specified in C1756769 step 2, instead of the uscis.gov i-9 form
- Rename the saved file to `dummy-saved.pdf` and update the cleanup regex
- Set `test_download_pdf` back to `pass` in `manifests/key.yaml`

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Failing run: https://github.com/mozilla/fx-desktop-qa-automation/actions/runs/31800114177/job/94765929833

The uscis.gov PDF never rendered on the CI runner, so the test failed while constructing `GenericPdf`, before reaching the download step. It failed all 4 attempts in that job and passes locally, so the host was likely blocking the runner.

### Comments or Future Work

C1756769 step 1 (download a zip first, so step 3's "download panel is not opened" is meaningful) is not automated, and the test never asserts anything about the download panel.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.