### PR TITLE
Akash/ Add test_find_word_with_special_characters

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -568,6 +568,10 @@ find_toolbar:
     splits:
     - functional1
     - nightly
+  test_find_word_with_special_characters:
+    result: pass
+    splits:
+    - functional1
 form_autofill:
   test_address_autofill_attribute:
     result: pass

--- a/tests/find_toolbar/test_find_word_with_special_characters.py
+++ b/tests/find_toolbar/test_find_word_with_special_characters.py
@@ -20,12 +20,20 @@ TARGET_PAGE = "https://de.wikipedia.org/wiki/Mozilla_Firefox"
 SEARCH_TERM = "für"
 MIN_MATCHES = 50  # the page had 113 matches when the test was written
 
-# Text, selected range count and position of the current match, null while there is none
+# Text, selected range count and DOM position of the current match, null while there is none
 CURRENT_MATCH = """
     const selection = window.getSelection();
     if (!selection || !selection.rangeCount) return null;
-    const rect = selection.getRangeAt(0).getBoundingClientRect();
-    return [selection.toString(), selection.rangeCount, Math.round(rect.top + window.scrollY)];
+    const range = selection.getRangeAt(0);
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let node = -1;
+    for (let i = 0; walker.nextNode(); i++) {
+      if (walker.currentNode === range.startContainer) {
+        node = i;
+        break;
+      }
+    }
+    return [selection.toString(), selection.rangeCount, node, range.startOffset];
 """
 
 

--- a/tests/find_toolbar/test_find_word_with_special_characters.py
+++ b/tests/find_toolbar/test_find_word_with_special_characters.py
@@ -18,6 +18,7 @@ def add_to_prefs_list():
 
 TARGET_PAGE = "https://de.wikipedia.org/wiki/Mozilla_Firefox"
 SEARCH_TERM = "für"
+MIN_MATCHES = 50  # the page had 113 matches when the test was written
 
 # Text, selected range count and position of the current match, null while there is none
 CURRENT_MATCH = """
@@ -42,7 +43,7 @@ def test_find_word_with_special_characters(driver: Firefox, find_toolbar: FindTo
     find_toolbar.open_with_key_combo()
     find_toolbar.find(SEARCH_TERM)
     total_matches = find_toolbar.match_dict["total"]
-    assert total_matches > 1
+    assert total_matches >= MIN_MATCHES
 
     # The searched word is the only highlight
     find_toolbar.rewind_to_first_match()

--- a/tests/find_toolbar/test_find_word_with_special_characters.py
+++ b/tests/find_toolbar/test_find_word_with_special_characters.py
@@ -1,0 +1,65 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.support.ui import WebDriverWait
+
+from modules.browser_object import FindToolbar
+
+
+@pytest.fixture()
+def test_case():
+    return "127275"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Make sure the site is served in German"""
+    return [("intl.accept_languages", "de-DE, de")]
+
+
+TARGET_PAGE = "https://de.wikipedia.org/wiki/Mozilla_Firefox"
+SEARCH_TERM = "für"
+
+# Text, selected range count and position of the current match
+CURRENT_MATCH = """
+    const selection = window.getSelection();
+    const rect = selection.getRangeAt(0).getBoundingClientRect();
+    return [selection.toString(), selection.rangeCount, Math.round(rect.top + window.scrollY)];
+"""
+
+
+def test_find_word_with_special_characters(driver: Firefox, find_toolbar: FindToolbar):
+    """
+    C127275: Verify that there are no issues when searching a word that contains
+    special characters
+
+    Arguments:
+        find_toolbar: instantiation of FindToolbar BOM.
+    """
+    driver.get(TARGET_PAGE)
+
+    # Every match of a word with a special character is found
+    find_toolbar.open_with_key_combo()
+    find_toolbar.find(SEARCH_TERM)
+    total_matches = find_toolbar.match_dict["total"]
+    assert total_matches > 1
+
+    # The searched word is the only highlight
+    find_toolbar.rewind_to_first_match()
+    first_match = driver.execute_script(CURRENT_MATCH)
+    assert first_match[:2] == [SEARCH_TERM, 1]
+
+    # F3 moves the highlight forward, SHIFT+F3 moves it back
+    find_toolbar.navigate_matches_by_keys()
+    WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(CURRENT_MATCH) != first_match
+    )
+    find_toolbar.navigate_matches_by_keys(backwards=True)
+    WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(CURRENT_MATCH) == first_match
+    )
+
+    # Scrolling up and down leaves the search session intact
+    driver.execute_script("window.scrollBy(0, 2000)")
+    driver.execute_script("window.scrollTo(0, 0)")
+    assert driver.execute_script(CURRENT_MATCH) == first_match
+    assert find_toolbar.get_match_args()["total"] == total_matches

--- a/tests/find_toolbar/test_find_word_with_special_characters.py
+++ b/tests/find_toolbar/test_find_word_with_special_characters.py
@@ -19,9 +19,10 @@ def add_to_prefs_list():
 TARGET_PAGE = "https://de.wikipedia.org/wiki/Mozilla_Firefox"
 SEARCH_TERM = "für"
 
-# Text, selected range count and position of the current match
+# Text, selected range count and position of the current match, null while there is none
 CURRENT_MATCH = """
     const selection = window.getSelection();
+    if (!selection || !selection.rangeCount) return null;
     const rect = selection.getRangeAt(0).getBoundingClientRect();
     return [selection.toString(), selection.rangeCount, Math.round(rect.top + window.scrollY)];
 """
@@ -45,13 +46,17 @@ def test_find_word_with_special_characters(driver: Firefox, find_toolbar: FindTo
 
     # The searched word is the only highlight
     find_toolbar.rewind_to_first_match()
-    first_match = driver.execute_script(CURRENT_MATCH)
-    assert first_match[:2] == [SEARCH_TERM, 1]
+    first_match = WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(CURRENT_MATCH)
+    )
+    # Match Case is off by default, so the match may differ in case from the search term
+    assert first_match[0].lower() == SEARCH_TERM
+    assert first_match[1] == 1
 
     # F3 moves the highlight forward, SHIFT+F3 moves it back
     find_toolbar.navigate_matches_by_keys()
     WebDriverWait(driver, 10).until(
-        lambda d: d.execute_script(CURRENT_MATCH) != first_match
+        lambda d: d.execute_script(CURRENT_MATCH) not in (None, first_match)
     )
     find_toolbar.navigate_matches_by_keys(backwards=True)
     WebDriverWait(driver, 10).until(


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2013519](https://bugzilla.mozilla.org/show_bug.cgi?id=2013519)
TestRail: [127275](https://mozilla.testrail.io/index.php?/cases/view/127275)

### Description of Code / Doc Changes

* Adds `tests/find_toolbar/test_find_word_with_special_characters.py`, covering C127275: searching a word containing special characters ("für") on a German page.
* Registers the test in `manifests/key.yaml` as `result: pass`, split `functional1`.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Two deviations from the manual test case, both deliberate:

* **Page.** The test case points at spiegel.de, where a cookie consent dialog covers the highlight, so the expected result is not observable. Used `de.wikipedia.org/wiki/Mozilla_Firefox` instead: German, stable, no modal, 113 matches for "für".
* **Step 5.** "No checkerboarding, performance is good" cannot be checked through Selenium. The test scrolls down 2000px and back, then asserts the highlighted match and total match count are unchanged.

Highlighting is verified through `window.getSelection()` rather than pixel colors: the current match must be "für" and the only selected range, and F3 / SHIFT+F3 must move the highlight and bring it back.

The last commit identifies a match by its DOM position (start text node index plus range offset) instead of `Math.round(rect.top + window.scrollY)`. The pixel value could come back off by one after SHIFT+F3 and time out the wait, at roughly 2%. Nothing depends on layout now, which also settles the zero-size `DOMRect` case raised in review.

Verified on macOS against release Firefox (windowed and `--run-headless`) and Nightly, all passing at about 3.3s, plus 12 consecutive runs after the DOM change.

### Comments or Future Work

* Step 3 asserts `total >= 50` against a page with 113, not an exact count, so a regression above the floor would not be caught.
* `CURRENT_MATCH` is now identical here and in the C127276 test (#<PR number>). Worth moving into the suite `conftest.py` once both land.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!