### PR TITLE
Akash/ Add test_find_word_with_special_characters_2

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -572,6 +572,10 @@ find_toolbar:
     result: pass
     splits:
     - functional1
+  test_find_word_with_special_characters_2:
+    result: pass
+    splits:
+    - functional1
 form_autofill:
   test_address_autofill_attribute:
     result: pass

--- a/tests/find_toolbar/test_find_word_with_special_characters_2.py
+++ b/tests/find_toolbar/test_find_word_with_special_characters_2.py
@@ -1,0 +1,81 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.support.ui import WebDriverWait
+
+from modules.browser_object import FindToolbar
+
+
+@pytest.fixture()
+def test_case():
+    return "127276"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Make sure the site is served in Japanese"""
+    return [("intl.accept_languages", "ja-JP, ja")]
+
+
+TARGET_PAGE = "https://ja.wikipedia.org/wiki/辻希美"
+SEARCH_TERM = "辻希美"
+MIN_MATCHES = 30  # the page had 74 matches when the test was written
+
+# Text, selected range count and DOM position of the current match, null while there is none
+CURRENT_MATCH = """
+    const selection = window.getSelection();
+    if (!selection || !selection.rangeCount) return null;
+    const range = selection.getRangeAt(0);
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let node = -1;
+    for (let i = 0; walker.nextNode(); i++) {
+      if (walker.currentNode === range.startContainer) {
+        node = i;
+        break;
+      }
+    }
+    return [selection.toString(), selection.rangeCount, node, range.startOffset];
+"""
+
+
+def test_find_word_with_special_characters_2(
+    driver: Firefox, find_toolbar: FindToolbar
+):
+    """
+    C127276: Verify that there are no issues when searching a word that contains
+    special characters (2)
+
+    Arguments:
+        find_toolbar: instantiation of FindToolbar BOM.
+    """
+    driver.get(TARGET_PAGE)
+
+    # Every match of a word with special characters is found
+    find_toolbar.open_with_key_combo()
+    find_toolbar.find(SEARCH_TERM)
+    total_matches = find_toolbar.match_dict["total"]
+    assert total_matches >= MIN_MATCHES
+
+    # The searched word is the only highlight
+    find_toolbar.rewind_to_first_match()
+    first_match = WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(CURRENT_MATCH)
+    )
+    # Match Case is off by default, so the match may differ in case from the search term
+    assert first_match[0].lower() == SEARCH_TERM
+    assert first_match[1] == 1
+
+    # F3 moves the highlight forward, SHIFT+F3 moves it back
+    find_toolbar.navigate_matches_by_keys()
+    WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(CURRENT_MATCH) not in (None, first_match)
+    )
+    find_toolbar.navigate_matches_by_keys(backwards=True)
+    WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(CURRENT_MATCH) == first_match
+    )
+
+    # Scrolling up and down leaves the search session intact
+    driver.execute_script("window.scrollBy(0, 2000)")
+    driver.execute_script("window.scrollTo(0, 0)")
+    assert driver.execute_script(CURRENT_MATCH) == first_match
+    assert find_toolbar.get_match_args()["total"] == total_matches


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2013520](https://bugzilla.mozilla.org/show_bug.cgi?id=2013520)
TestRail: [127276](https://mozilla.testrail.io/index.php?/cases/view/127276)

### Description of Code / Doc Changes

* Adds `tests/find_toolbar/test_find_word_with_special_characters_2.py`, covering C127276: searching a word containing special characters ("辻希美") on a Japanese page.
* Registers the test in `manifests/key.yaml` as `result: pass`, split `functional1`.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Two deviations from the manual test case, both deliberate:

* **Page.** The test case links a site that covers the article with a cookie consent dialog, so the highlight is not observable. Used `ja.wikipedia.org/wiki/辻希美` instead: Japanese, stable, no modal, 74 matches for the search term.
* **Step 5.** "No checkerboarding, performance is good" cannot be checked through Selenium. The test scrolls down 2000px and back, then asserts the highlighted match and total match count are unchanged.

Highlighting is verified through `window.getSelection()` rather than the findbar counter: after F3 the counter label is hidden and its `data-l10n-args` still holds the pre-navigation values, so reading it would assert on stale data. A match is identified by its DOM position (start text node index plus range offset) so the comparison does not depend on layout.

Structurally identical to the C127275 test (#<PR number>); the two differ only in case ID, language pref, URL, search term and match floor.

Verified on macOS against release Firefox, 38 consecutive runs, all passing at about 3.4s.

### Comments or Future Work

* Step 3 asserts `total >= 30` against a page with 74, not an exact count, so a regression above the floor would not be caught.
* `CURRENT_MATCH` is duplicated verbatim from the C127275 test. Worth moving into the suite `conftest.py` once both land.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!