### PR TITLE
Akash/ Move CURRENT_MATCH to find_toolbar conftest

### DIFF
--- a/tests/find_toolbar/conftest.py
+++ b/tests/find_toolbar/conftest.py
@@ -33,3 +33,22 @@ def find_toolbar(driver: Firefox):
 def browser_actions(driver: Firefox):
     ba = BrowserActions(driver)
     yield ba
+
+
+@pytest.fixture()
+def current_match():
+    """Script returning info about the current match, null while there is none"""
+    return """
+        const selection = window.getSelection();
+        if (!selection || !selection.rangeCount) return null;
+        const range = selection.getRangeAt(0);
+        const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+        let node = -1;
+        for (let i = 0; walker.nextNode(); i++) {
+          if (walker.currentNode === range.startContainer) {
+            node = i;
+            break;
+          }
+        }
+        return [selection.toString(), selection.rangeCount, node, range.startOffset];
+    """

--- a/tests/find_toolbar/test_find_word_with_special_characters.py
+++ b/tests/find_toolbar/test_find_word_with_special_characters.py
@@ -20,30 +20,17 @@ TARGET_PAGE = "https://de.wikipedia.org/wiki/Mozilla_Firefox"
 SEARCH_TERM = "für"
 MIN_MATCHES = 50  # the page had 113 matches when the test was written
 
-# Text, selected range count and DOM position of the current match, null while there is none
-CURRENT_MATCH = """
-    const selection = window.getSelection();
-    if (!selection || !selection.rangeCount) return null;
-    const range = selection.getRangeAt(0);
-    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-    let node = -1;
-    for (let i = 0; walker.nextNode(); i++) {
-      if (walker.currentNode === range.startContainer) {
-        node = i;
-        break;
-      }
-    }
-    return [selection.toString(), selection.rangeCount, node, range.startOffset];
-"""
 
-
-def test_find_word_with_special_characters(driver: Firefox, find_toolbar: FindToolbar):
+def test_find_word_with_special_characters(
+    driver: Firefox, find_toolbar: FindToolbar, current_match: str
+):
     """
     C127275: Verify that there are no issues when searching a word that contains
     special characters
 
     Arguments:
         find_toolbar: instantiation of FindToolbar BOM.
+        current_match: script returning info about the currently highlighted match.
     """
     driver.get(TARGET_PAGE)
 
@@ -56,7 +43,7 @@ def test_find_word_with_special_characters(driver: Firefox, find_toolbar: FindTo
     # The searched word is the only highlight
     find_toolbar.rewind_to_first_match()
     first_match = WebDriverWait(driver, 10).until(
-        lambda d: d.execute_script(CURRENT_MATCH)
+        lambda d: d.execute_script(current_match)
     )
     # Match Case is off by default, so the match may differ in case from the search term
     assert first_match[0].lower() == SEARCH_TERM
@@ -65,15 +52,15 @@ def test_find_word_with_special_characters(driver: Firefox, find_toolbar: FindTo
     # F3 moves the highlight forward, SHIFT+F3 moves it back
     find_toolbar.navigate_matches_by_keys()
     WebDriverWait(driver, 10).until(
-        lambda d: d.execute_script(CURRENT_MATCH) not in (None, first_match)
+        lambda d: d.execute_script(current_match) not in (None, first_match)
     )
     find_toolbar.navigate_matches_by_keys(backwards=True)
     WebDriverWait(driver, 10).until(
-        lambda d: d.execute_script(CURRENT_MATCH) == first_match
+        lambda d: d.execute_script(current_match) == first_match
     )
 
     # Scrolling up and down leaves the search session intact
     driver.execute_script("window.scrollBy(0, 2000)")
     driver.execute_script("window.scrollTo(0, 0)")
-    assert driver.execute_script(CURRENT_MATCH) == first_match
+    assert driver.execute_script(current_match) == first_match
     assert find_toolbar.get_match_args()["total"] == total_matches

--- a/tests/find_toolbar/test_find_word_with_special_characters_2.py
+++ b/tests/find_toolbar/test_find_word_with_special_characters_2.py
@@ -20,25 +20,9 @@ TARGET_PAGE = "https://ja.wikipedia.org/wiki/辻希美"
 SEARCH_TERM = "辻希美"
 MIN_MATCHES = 30  # the page had 74 matches when the test was written
 
-# Text, selected range count and DOM position of the current match, null while there is none
-CURRENT_MATCH = """
-    const selection = window.getSelection();
-    if (!selection || !selection.rangeCount) return null;
-    const range = selection.getRangeAt(0);
-    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-    let node = -1;
-    for (let i = 0; walker.nextNode(); i++) {
-      if (walker.currentNode === range.startContainer) {
-        node = i;
-        break;
-      }
-    }
-    return [selection.toString(), selection.rangeCount, node, range.startOffset];
-"""
-
 
 def test_find_word_with_special_characters_2(
-    driver: Firefox, find_toolbar: FindToolbar
+    driver: Firefox, find_toolbar: FindToolbar, current_match: str
 ):
     """
     C127276: Verify that there are no issues when searching a word that contains
@@ -46,6 +30,7 @@ def test_find_word_with_special_characters_2(
 
     Arguments:
         find_toolbar: instantiation of FindToolbar BOM.
+        current_match: script returning info about the currently highlighted match.
     """
     driver.get(TARGET_PAGE)
 
@@ -58,7 +43,7 @@ def test_find_word_with_special_characters_2(
     # The searched word is the only highlight
     find_toolbar.rewind_to_first_match()
     first_match = WebDriverWait(driver, 10).until(
-        lambda d: d.execute_script(CURRENT_MATCH)
+        lambda d: d.execute_script(current_match)
     )
     # Match Case is off by default, so the match may differ in case from the search term
     assert first_match[0].lower() == SEARCH_TERM
@@ -67,15 +52,15 @@ def test_find_word_with_special_characters_2(
     # F3 moves the highlight forward, SHIFT+F3 moves it back
     find_toolbar.navigate_matches_by_keys()
     WebDriverWait(driver, 10).until(
-        lambda d: d.execute_script(CURRENT_MATCH) not in (None, first_match)
+        lambda d: d.execute_script(current_match) not in (None, first_match)
     )
     find_toolbar.navigate_matches_by_keys(backwards=True)
     WebDriverWait(driver, 10).until(
-        lambda d: d.execute_script(CURRENT_MATCH) == first_match
+        lambda d: d.execute_script(current_match) == first_match
     )
 
     # Scrolling up and down leaves the search session intact
     driver.execute_script("window.scrollBy(0, 2000)")
     driver.execute_script("window.scrollTo(0, 0)")
-    assert driver.execute_script(CURRENT_MATCH) == first_match
+    assert driver.execute_script(current_match) == first_match
     assert find_toolbar.get_match_args()["total"] == total_matches


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: [127275](https://mozilla.testrail.io/index.php?/cases/view/127275), [127276](https://mozilla.testrail.io/index.php?/cases/view/127276)

### Description of Code / Doc Changes

- Added a `current_match` fixture to `tests/find_toolbar/conftest.py` holding the JS that reports the currently highlighted match.
- Removed the duplicate `CURRENT_MATCH` constant from `test_find_word_with_special_characters.py` and `test_find_word_with_special_characters_2.py`, which now take the fixture instead.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): N/A
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Follow-up to the review comment on #1588 and #1589. Both tests carried an identical copy of the script, so the fixture keeps them from drifting apart. No behaviour change, both tests passed 3 times locally.

### Comments or Future Work

None.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.