### PR TITLE
Akash/ Add test_find_in_txt_file

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -558,6 +558,10 @@ find_toolbar:
     splits:
     - functional1
     - nightly
+  test_find_in_txt_file:
+    result: pass
+    splits:
+    - functional1
   test_find_toolbar_nav:
     result: pass
     splits:

--- a/tests/find_toolbar/test_find_in_txt_file.py
+++ b/tests/find_toolbar/test_find_in_txt_file.py
@@ -1,0 +1,68 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.support.ui import WebDriverWait
+
+from modules.browser_object import FindToolbar
+
+
+@pytest.fixture()
+def test_case():
+    return "127273"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Enlarge plain text so the short .txt file is long enough to scroll"""
+    return [("font.size.monospace.x-western", 48)]
+
+
+TARGET_PAGE = "https://example-files.online-convert.com/document/txt/example.txt"
+SEARCH_TERM = "Doe"
+MIN_MATCHES = 15  # the file had 23 matches when the test was written
+
+
+def test_find_in_txt_file(
+    driver: Firefox, find_toolbar: FindToolbar, current_match: str
+):
+    """
+    C127273: Verify that searching on a text file (.txt) works properly
+
+    Arguments:
+        find_toolbar: instantiation of FindToolbar BOM.
+        current_match: script returning info about the currently highlighted match.
+    """
+    driver.get(TARGET_PAGE)
+
+    # Every match in the plain text file is found
+    find_toolbar.open_with_key_combo()
+    find_toolbar.find(SEARCH_TERM)
+    total_matches = find_toolbar.match_dict["total"]
+    assert total_matches >= MIN_MATCHES
+
+    # The first match is the only highlight
+    find_toolbar.rewind_to_first_match()
+    first_match = WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(current_match)
+    )
+    # Match Case is off by default, so the match may differ in case from the search term
+    assert first_match[0].lower() == SEARCH_TERM.lower()
+    assert first_match[1] == 1
+
+    # F3 moves the highlight forward, SHIFT+F3 moves it back
+    find_toolbar.navigate_matches_by_keys()
+    WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(current_match) not in (None, first_match)
+    )
+    find_toolbar.navigate_matches_by_keys(backwards=True)
+    WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(current_match) == first_match
+    )
+
+    # Scrolling up and down leaves the search session intact
+    assert driver.execute_script(
+        "return document.documentElement.scrollHeight > window.innerHeight"
+    )
+    driver.execute_script("window.scrollBy(0, 2000)")
+    driver.execute_script("window.scrollTo(0, 0)")
+    assert driver.execute_script(current_match) == first_match
+    assert find_toolbar.get_match_args()["total"] == total_matches


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2013518](https://bugzilla.mozilla.org/show_bug.cgi?id=2013518)
TestRail: [127273](https://mozilla.testrail.io/index.php?/cases/view/127273)

### Description of Code / Doc Changes

- Adds `tests/find_toolbar/test_find_in_txt_file.py`, covering search on a plain text file
- Registers the test in `manifests/key.yaml` (`functional1`)

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Follows the same shape as the two `test_find_word_with_special_characters` tests: search, confirm the match total, then confirm the current match is the only selection range (one green highlight), navigate with F3 / SHIFT+F3, and scroll without losing the find session.

The `font.size.monospace.x-western` pref is there because the hosted file is only 2.5 KB and renders in a single viewport at default font size, which would make step 5's scroll a silent no-op. The larger font makes it overflow, and the assertion above the scroll guards that it actually does.

Ran 20 times locally, all passing: Firefox 154.0.1 and Nightly 155.0a1, headed and headless, 5 runs each. Match count was 23 in every run.

### Comments or Future Work

None.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.