### PR TITLE
Anca/ Glean - Add second misc batch

### DIFF
--- a/tests/glean/flows.py
+++ b/tests/glean/flows.py
@@ -9,6 +9,9 @@ SEARCH_TERM = "firefox"
 # Spaces get URL-encoded, so match only the first token when checking the SERP URL.
 RELATED_SEARCH_TERM = "women shoes"
 RELATED_SEARCH_TERM_IN_URL = RELATED_SEARCH_TERM.split()[0]
+# High-intent commercial query, so the SERP serves the text ads that withads and
+# serp.adImpression need. SEARCH_TERM returns no ads.
+AD_SEARCH_TERM = "car insurance quotes"
 PERSISTED_REFINEMENT = " browser"
 IMAGE_PAGE_URL = "https://www.python.org/"
 

--- a/tests/glean/misc_metrics/cases.json
+++ b/tests/glean/misc_metrics/cases.json
@@ -1,14 +1,15 @@
 {
   "cases": [
-    {"id": "3255542", "entry": "searchbar_suggestion", "action": null, "params": {"engine": "DuckDuckGo"}, "prefs": [], "metric": "browserEngagementNavigation.searchbar", "expected": {"search_suggestion": 1}},
     {"id": "3255543", "entry": "searchbar", "action": null, "params": {"engine": "Google"}, "prefs": [], "metric": "browserEngagementNavigation.searchbar", "expected": {"search_enter": 1}},
-
+    {"id": "3255545", "entry": "searchbar", "action": null, "params": {"engine": "Bing"}, "prefs": [], "metric": "browserSearchWithads.searchbar", "expected": {"bing:tagged": 1}},
     {"id": "3255550", "entry": "searchbar", "action": null, "params": {"engine": "Google"}, "prefs": [["browser.search.region", "US"]], "metric": "browserSearchContent.searchbar", "expected": {"google:tagged:firefox-b-1-d": 1}},
     {"id": "3255551", "entry": "searchbar", "action": null, "params": {"engine": "Google"}, "prefs": [["browser.search.region", "DE"]], "metric": "browserSearchContent.searchbar", "expected": {"google:tagged:firefox-b-d": 1}},
     {"id": "3255552", "entry": "searchbar", "action": null, "params": {"engine": "Bing"}, "prefs": [], "metric": "browserSearchContent.searchbar", "expected": {"bing:tagged:MOZI": 1}},
     {"id": "3255553", "entry": "searchbar", "action": null, "params": {"engine": "DuckDuckGo"}, "prefs": [], "metric": "browserSearchContent.searchbar", "expected": {"duckduckgo:tagged:ffab": 1}},
     {"id": "3255554", "entry": "searchbar", "action": null, "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "metric": "browserSearchContent.searchbar", "expected": {"ecosia:tagged:mzl": 1}},
+    {"id": "3255556", "entry": "searchbar", "action": null, "params": {"engine": "Bing"}, "prefs": [], "metric": "serp.adImpression", "expected": {}, "expected_keys": ["ads_hidden", "ads_loaded", "ads_visible", "component", "impression_id"]},
 
+    {"id": "3255542", "entry": "searchbar_suggestion", "action": null, "params": {"engine": "DuckDuckGo"}, "prefs": [], "metric": "browserEngagementNavigation.searchbar", "expected": {"search_suggestion": 1}},
     {"id": "3255555", "entry": "searchbar_search_form", "action": null, "params": {"engine": "Bing"}, "prefs": [], "metric": "sap.searchFormCounts", "expected": {"provider_id": "bing", "source": "searchbar"}}
   ]
 }

--- a/tests/glean/misc_metrics/test_misc_metrics.py
+++ b/tests/glean/misc_metrics/test_misc_metrics.py
@@ -4,6 +4,7 @@ from selenium.webdriver import Firefox
 from modules.browser_object import Glean
 from modules.page_object import AboutPrefs
 from tests.glean.flows import (
+    AD_SEARCH_TERM,
     ENTRY_PREFS,
     SEARCH_TERM,
     block_if_bot_challenge,
@@ -18,6 +19,12 @@ data = load_cases(__file__)
 LABELED_COUNTER_METRICS = {
     "browserEngagementNavigation.searchbar",
     "browserSearchContent.searchbar",
+    "browserSearchWithads.searchbar",
+}
+# Metrics that only record when the SERP serves ads, so they need a commercial query.
+AD_METRICS = {
+    "browserSearchWithads.searchbar",
+    "serp.adImpression",
 }
 # Entries that pick their own engine in-flow, so no default-engine change is needed.
 IN_FLOW_ENGINE_ENTRIES = {"searchbar_search_form"}
@@ -65,15 +72,25 @@ def test_misc_metrics(driver: Firefox, case: dict):
         prefs.open()
         prefs.search_engine_dropdown().select_option(engine)
 
+    search_term = AD_SEARCH_TERM if metric in AD_METRICS else SEARCH_TERM
+
     try:
-        run_entry(driver, case["entry"], SEARCH_TERM, params)
+        run_entry(driver, case["entry"], search_term, params)
         run_action(driver, case.get("action"), params)
 
         if metric in LABELED_COUNTER_METRICS:
             for label, count in expected.items():
                 glean.poll_glean_labeled_counter(metric, label, count)
-        else:
-            glean.poll_glean_metric(metric, expected)
+            return
+        events = glean.poll_glean_metric(metric, expected)
     except Exception:
         block_if_bot_challenge(driver)
         raise
+
+    # Fields whose values are dynamic (ad counts, UUID impression_id) are checked for presence
+    required_keys = case.get("expected_keys", [])
+    if required_keys:
+        assert any(
+            all(key in event.get("extra", {}) for key in required_keys)
+            for event in events
+        ), f"Expected keys {required_keys} in {metric}, got {events!r}"


### PR DESCRIPTION
### Relevant Links

Bugzilla: [6 test cases](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=2032838%2C%202032839%2C%202032840%2C%202032841%2C%202032842%2C%202032849&list_id=18093271)
TestRail: [S70197](https://mozilla.testrail.io/index.php?/suites/view/70197)

### Description of Code / Doc Changes
 - Added C3255545 (`browser.search.withads`, searchbar, Bing) and C3255556 (`serp.adImpression`, searchbar, Bing). 
- Marked 4 cases Unsuitable: C3255544 and C3255546 (withads Google / DuckDuckGo), C3255549 (adclicks DuckDuckGo), C3255548 (adclicks Bing). Google returns a captcha instead of a SERP, DuckDuckGo serves no ads, and adclicks only records on a click on a real sponsored link, which bills an advertiser.
- flows.py`: added `AD_SEARCH_TERM`, a commercial query, since the default `SEARCH_TERM` returns no ads. Kept as a separate constant rather than changing `SEARCH_TERM`, which is shared by every glean suite and an ads-bearing SERP adds moving parts the non-ads cases don't need.
- `test_misc_metrics.py`: `browser.search.withads` reads as a labeled counter; ads metrics use the commercial query; added `expected_keys` for events whose values change per run
- Regrouped `cases.json` by entry surface
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
