### PR TITLE
Akash/ Add test_search_again_after_navigation

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -576,6 +576,10 @@ find_toolbar:
     result: pass
     splits:
     - functional1
+  test_search_again_after_navigation:
+    result: pass
+    splits:
+    - functional1
 form_autofill:
   test_address_autofill_attribute:
     result: pass

--- a/tests/find_toolbar/test_search_again_after_navigation.py
+++ b/tests/find_toolbar/test_search_again_after_navigation.py
@@ -1,10 +1,8 @@
 import pytest
 from selenium.webdriver import Firefox
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import WebDriverWait
 
 from modules.browser_object import FindToolbar
+from modules.page_object_generics import GenericPage
 
 
 @pytest.fixture()
@@ -17,14 +15,27 @@ TARGET_PAGE = (
 )
 SEARCH_TERM = "browser"
 MIN_MATCHES = 10  # the page had 25 matches when the test was written
-TOOLBOX_LINK = (
-    By.CSS_SELECTOR,
-    "div[itemprop='articleBody'] a[href$='tools_toolbox/index.html']",
-)
+NEXT_PAGE_URL_PART = "tools_toolbox"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "toolbox-link": {
+            "selectorData": (
+                "div[itemprop='articleBody'] a[href$='tools_toolbox/index.html']"
+            ),
+            "strategy": "css",
+            "groups": [],
+        },
+    }
 
 
 def test_search_again_after_navigation(
-    driver: Firefox, find_toolbar: FindToolbar, current_match: str
+    driver: Firefox,
+    find_toolbar: FindToolbar,
+    current_match: str,
+    temp_selectors: dict,
 ):
     """
     C127264: Verify that searching again after navigating to another page works
@@ -32,27 +43,31 @@ def test_search_again_after_navigation(
     Arguments:
         find_toolbar: instantiation of FindToolbar BOM.
         current_match: script returning info about the currently highlighted match.
+        temp_selectors: the in-content link to the next page.
     """
-    driver.get(TARGET_PAGE)
+    page = GenericPage(driver, url=TARGET_PAGE)
+    page.elements |= temp_selectors
+    page.open()
 
     # Search the term
     find_toolbar.open_with_key_combo()
     find_toolbar.find(SEARCH_TERM)
-    assert find_toolbar.match_dict["total"] >= MIN_MATCHES
+    find_toolbar.expect(lambda _: find_toolbar.get_match_args()["total"] >= MIN_MATCHES)
 
     # Follow a link, the findbar stays open with the term in it
-    driver.find_element(*TOOLBOX_LINK).click()
-    WebDriverWait(driver, 30).until(lambda d: "tools_toolbox" in d.current_url)
+    page.click_on("toolbox-link")
+    page.url_contains(NEXT_PAGE_URL_PART)
 
-    # Navigating drops the highlight, hitting ENTER searches the new page
-    assert driver.execute_script(current_match) is None
-    with driver.context(driver.CONTEXT_CHROME):
-        find_bar = find_toolbar.get_element("find-toolbar-input")
-        find_bar.click()
-        find_bar.send_keys(Keys.ENTER)
+    # Navigating drops the highlight
+    page.expect_not(lambda d: d.execute_script(current_match))
 
-    # The searched word is the only highlight
-    new_match = WebDriverWait(driver, 10).until(
-        lambda d: d.execute_script(current_match)
-    )
-    assert new_match[0].lower() == SEARCH_TERM
+    # Selecting the findbar and hitting ENTER searches the new page for the same term
+    find_toolbar.click_on("find-toolbar-input")
+    find_toolbar.fill("find-toolbar-input", "", clear_first=False)
+
+    # The searched word is highlighted on the new page
+    def search_term_highlighted(d):
+        match = d.execute_script(current_match)
+        return match and match[0].lower() == SEARCH_TERM
+
+    page.expect(search_term_highlighted)

--- a/tests/find_toolbar/test_search_again_after_navigation.py
+++ b/tests/find_toolbar/test_search_again_after_navigation.py
@@ -1,4 +1,5 @@
 import pytest
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver import Firefox
 
 from modules.browser_object import FindToolbar
@@ -52,7 +53,15 @@ def test_search_again_after_navigation(
     # Search the term
     find_toolbar.open_with_key_combo()
     find_toolbar.find(SEARCH_TERM)
-    find_toolbar.expect(lambda _: find_toolbar.get_match_args()["total"] >= MIN_MATCHES)
+
+    def has_enough_matches(_):
+        """get_match_args raises while the counter is empty, keep polling instead"""
+        try:
+            return find_toolbar.get_match_args()["total"] >= MIN_MATCHES
+        except TimeoutException:
+            return False
+
+    find_toolbar.expect(has_enough_matches)
 
     # Follow a link, the findbar stays open with the term in it
     page.click_on("toolbox-link")

--- a/tests/find_toolbar/test_search_again_after_navigation.py
+++ b/tests/find_toolbar/test_search_again_after_navigation.py
@@ -1,0 +1,68 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+
+from modules.browser_object import FindToolbar
+
+
+@pytest.fixture()
+def test_case():
+    return "127264"
+
+
+TARGET_PAGE = (
+    "https://firefox-source-docs.mozilla.org/devtools-user/browser_toolbox/index.html"
+)
+SEARCH_TERM = "browser"
+TOOLBOX_LINK = (
+    By.CSS_SELECTOR,
+    "div[itemprop='articleBody'] a[href$='tools_toolbox/index.html']",
+)
+# innerText holds the same text the findbar searches, Match Case is off by default
+COUNT_MATCHES = (
+    f'return document.body.innerText.toLowerCase().split("{SEARCH_TERM}").length - 1'
+)
+
+
+def test_search_again_after_navigation(
+    driver: Firefox, find_toolbar: FindToolbar, current_match: str
+):
+    """
+    C127264: Verify that searching again after navigating to another page works
+
+    Arguments:
+        find_toolbar: instantiation of FindToolbar BOM.
+        current_match: script returning info about the currently highlighted match.
+    """
+    driver.get(TARGET_PAGE)
+    matches_on_first_page = driver.execute_script(COUNT_MATCHES)
+    assert matches_on_first_page > 0
+
+    # Search the term
+    find_toolbar.open_with_key_combo()
+    find_toolbar.find(SEARCH_TERM)
+    assert find_toolbar.match_dict["total"] == matches_on_first_page
+
+    # Follow a link, the findbar stays open with the term in it
+    WebDriverWait(driver, 10).until(lambda d: d.find_element(*TOOLBOX_LINK)).click()
+    WebDriverWait(driver, 30).until(lambda d: "tools_toolbox" in d.current_url)
+    matches_on_new_page = driver.execute_script(COUNT_MATCHES)
+    assert matches_on_new_page > 0
+
+    # Hit ENTER again, the counter holds the old value for a moment
+    with driver.context(driver.CONTEXT_CHROME):
+        find_bar = find_toolbar.get_element("find-toolbar-input")
+        find_bar.click()
+        find_bar.send_keys(Keys.ENTER)
+    WebDriverWait(driver, 10).until(
+        lambda _: find_toolbar.get_match_args()["total"] == matches_on_new_page,
+        message=f"Findbar never counted {matches_on_new_page} matches",
+    )
+
+    # The word is the only highlight
+    new_match = driver.execute_script(current_match)
+    assert new_match is not None
+    assert new_match[0].lower() == SEARCH_TERM
+    assert new_match[1] == 1

--- a/tests/find_toolbar/test_search_again_after_navigation.py
+++ b/tests/find_toolbar/test_search_again_after_navigation.py
@@ -16,13 +16,10 @@ TARGET_PAGE = (
     "https://firefox-source-docs.mozilla.org/devtools-user/browser_toolbox/index.html"
 )
 SEARCH_TERM = "browser"
+MIN_MATCHES = 10  # the page had 25 matches when the test was written
 TOOLBOX_LINK = (
     By.CSS_SELECTOR,
     "div[itemprop='articleBody'] a[href$='tools_toolbox/index.html']",
-)
-# innerText holds the same text the findbar searches, Match Case is off by default
-COUNT_MATCHES = (
-    f'return document.body.innerText.toLowerCase().split("{SEARCH_TERM}").length - 1'
 )
 
 
@@ -37,32 +34,25 @@ def test_search_again_after_navigation(
         current_match: script returning info about the currently highlighted match.
     """
     driver.get(TARGET_PAGE)
-    matches_on_first_page = driver.execute_script(COUNT_MATCHES)
-    assert matches_on_first_page > 0
 
     # Search the term
     find_toolbar.open_with_key_combo()
     find_toolbar.find(SEARCH_TERM)
-    assert find_toolbar.match_dict["total"] == matches_on_first_page
+    assert find_toolbar.match_dict["total"] >= MIN_MATCHES
 
     # Follow a link, the findbar stays open with the term in it
-    WebDriverWait(driver, 10).until(lambda d: d.find_element(*TOOLBOX_LINK)).click()
+    driver.find_element(*TOOLBOX_LINK).click()
     WebDriverWait(driver, 30).until(lambda d: "tools_toolbox" in d.current_url)
-    matches_on_new_page = driver.execute_script(COUNT_MATCHES)
-    assert matches_on_new_page > 0
 
-    # Hit ENTER again, the counter holds the old value for a moment
+    # Navigating drops the highlight, hitting ENTER searches the new page
+    assert driver.execute_script(current_match) is None
     with driver.context(driver.CONTEXT_CHROME):
         find_bar = find_toolbar.get_element("find-toolbar-input")
         find_bar.click()
         find_bar.send_keys(Keys.ENTER)
-    WebDriverWait(driver, 10).until(
-        lambda _: find_toolbar.get_match_args()["total"] == matches_on_new_page,
-        message=f"Findbar never counted {matches_on_new_page} matches",
-    )
 
-    # The word is the only highlight
-    new_match = driver.execute_script(current_match)
-    assert new_match is not None
+    # The searched word is the only highlight
+    new_match = WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(current_match)
+    )
     assert new_match[0].lower() == SEARCH_TERM
-    assert new_match[1] == 1


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2013517](https://bugzilla.mozilla.org/show_bug.cgi?id=2013517)
TestRail: [127264](https://mozilla.testrail.io/index.php?/cases/view/127264)

### Description of Code / Doc Changes

- Adds `tests/find_toolbar/test_search_again_after_navigation.py` (C127264), which searches "browser" on the Browser Toolbox docs page, follows the in-content "Toolbox" link, and hits ENTER in the findbar again to confirm the new page is searched and only the matched word is highlighted.
- Registers the test in `manifests/key.yaml` under the `functional1` split.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The expected match counts are read from the page at runtime (`document.body.innerText`) instead of being hardcoded, so doc content edits will not break the test.

The findbar's `found-matches` label keeps the previous page's value for a moment after ENTER, so the test waits for the count to update rather than reading it once.

### Comments or Future Work

None.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.