### PR TITLE
Hani/ Mark test set default profile as stable

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1315,11 +1315,7 @@ printing_ui:
     - nightly
 profile:
   test_set_default_profile:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2064143
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - smoke
 reader_view:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064143](https://bugzilla.mozilla.org/show_bug.cgi?id=2064143)

### Description of Code / Doc Changes

* Mark tests/profile/test_set_default_profile.py as stable since the test passed locally every time. 

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
