### PR TITLE
Anca/ Glean - sap count first batch

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -689,6 +689,11 @@ glean:
       result: pass
       splits:
       - glean
+  sap_counts:
+    test_sap_counts:
+      result: pass
+      splits:
+      - glean
   serp_abandonment:
     test_serp_abandonment:
       result: pass

--- a/tests/glean/sap_counts/cases.json
+++ b/tests/glean/sap_counts/cases.json
@@ -13,7 +13,6 @@
     {"id": "3255577", "entry": "urlbar_handoff", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_handoff"}},
     {"id": "3255589", "entry": "urlbar_handoff", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_handoff"}},
 
-    {"id": "3255566", "entry": "urlbar_persisted", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_persisted"}},
     {"id": "3255578", "entry": "urlbar_persisted", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_persisted"}},
     {"id": "3255590", "entry": "urlbar_persisted", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_persisted"}},
 

--- a/tests/glean/sap_counts/cases.json
+++ b/tests/glean/sap_counts/cases.json
@@ -1,0 +1,30 @@
+{
+  "metric": "sap.counts",
+  "cases": [
+    {"id": "3255564", "entry": "urlbar", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar"}},
+    {"id": "3255576", "entry": "urlbar", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar"}},
+    {"id": "3255588", "entry": "urlbar", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar"}},
+
+    {"id": "3255562", "entry": "searchbar", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "searchbar"}},
+    {"id": "3255574", "entry": "searchbar", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "searchbar"}},
+    {"id": "3255586", "entry": "searchbar", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "searchbar"}},
+
+    {"id": "3255565", "entry": "urlbar_handoff", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_handoff"}},
+    {"id": "3255577", "entry": "urlbar_handoff", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_handoff"}},
+    {"id": "3255589", "entry": "urlbar_handoff", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_handoff"}},
+
+    {"id": "3255566", "entry": "urlbar_persisted", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_persisted"}},
+    {"id": "3255578", "entry": "urlbar_persisted", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_persisted"}},
+    {"id": "3255590", "entry": "urlbar_persisted", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_persisted"}},
+
+    {"id": "3255567", "entry": "urlbar_searchmode", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_searchmode"}},
+    {"id": "3255579", "entry": "urlbar_searchmode", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_searchmode"}},
+    {"id": "3255591", "entry": "urlbar_searchmode", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_searchmode"}},
+
+    {"id": "3255561", "entry": "contextmenu", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "contextmenu"}},
+    {"id": "3255573", "entry": "contextmenu", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "contextmenu"}},
+    {"id": "3255585", "entry": "contextmenu", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "contextmenu"}},
+
+    {"id": "3255560", "entry": "contextmenu_visual", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "contextmenu_visual"}}
+  ]
+}

--- a/tests/glean/sap_counts/test_sap_counts.py
+++ b/tests/glean/sap_counts/test_sap_counts.py
@@ -1,0 +1,56 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Glean
+from modules.page_object import AboutPrefs
+from tests.glean.flows import (
+    ENTRY_PREFS,
+    SEARCH_TERM,
+    block_if_bot_challenge,
+    run_entry,
+)
+from tests.glean.utils import load_cases
+
+data = load_cases(__file__)
+METRIC = data["metric"]
+
+
+@pytest.fixture(
+    params=data["cases"],
+    ids=lambda c: f"{c['id']}-{c['params']['engine']}-{c['entry']}",
+)
+def case(request):
+    """Parametrized fixture yielding one test case dict from cases.json."""
+    return request.param
+
+
+@pytest.fixture()
+def test_case(case):
+    """TestRail case ID for the current parametrized case."""
+    return case["id"]
+
+
+@pytest.fixture()
+def add_to_prefs_list(case):
+    """Per-case Firefox prefs to set before driver launch."""
+    prefs = [tuple(p) for p in case.get("prefs", [])]
+    prefs += ENTRY_PREFS.get(case["entry"], [])
+    return prefs
+
+
+def test_sap_counts(driver: Firefox, case: dict):
+    """Verify sap.counts records the access point a search was issued from."""
+    prefs = AboutPrefs(driver, category="search")
+    glean = Glean(driver)
+    params = case["params"]
+
+    prefs.open()
+    prefs.search_engine_dropdown().select_option(params["engine"])
+
+    try:
+        run_entry(driver, case["entry"], SEARCH_TERM, params)
+
+        glean.poll_glean_metric(METRIC, case["expected"])
+    except Exception:
+        block_if_bot_challenge(driver)
+        raise


### PR DESCRIPTION
### Relevant Links

Bugzilla: [19 test cases](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=2032853%2C2032854%2C2032855%2C2032856%2C2032857%2C2032858%2C2032859%2C2032864%2C2032865%2C2032866%2C2032867%2C2032868%2C2032869%2C2032874%2C2032875%2C2032876%2C2032877%2C2032878%2C2032879)
TestRail: [S70197](https://mozilla.testrail.io/index.php?/suites/view/70197)

### Description of Code / Doc Changes
- sap.counts records one event per search issued, tagged with the access point it came from (source) and the engine that served it. It fires when the search is issued, not when the results page loads.
- Adds sap.counts coverage to the glean suite, 18 cases across Google, Bing and DuckDuckGo on the search access points
- Google is excluded from urlbar_persisted (1test case): the flow needs Firefox to recognise the SERP before refining, and CI runners get Google's "unusual traffic" captcha served in place at the search URL

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
