### PR TITLE
Akash/ Update test_add_mime_type_doc for C4108461

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -435,11 +435,7 @@ bookmarks_and_history:
     - nightly
 downloads:
   test_add_mime_type_doc:
-    comment: Windows unstable in GHA, https://bugzilla.mozilla.org/show_bug.cgi?id=2043378
-    result:
-      linux: unstable
-      mac: unstable
-      win: unstable
+    result: pass
     splits:
     - functional1
   test_add_zip_type:

--- a/tests/downloads/test_add_mime_type_doc.py
+++ b/tests/downloads/test_add_mime_type_doc.py
@@ -27,9 +27,9 @@ def delete_files_regex_string():
 def close_doc_handler(sys_platform):
     """Quit the app the OS opens the downloaded .doc in."""
     yield
-    # Always wait, since an open handler can block later tests with a dialog
-    sleep(HANDLER_LAUNCH_SEC)
     if sys_platform == "Darwin":
+        # Give the handler time to launch, or it opens onto a deleted file
+        sleep(HANDLER_LAUNCH_SEC)
         for app in ("TextEdit", "Pages", "Microsoft Word"):
             # The `is running` guard stops osascript launching the app
             run(
@@ -42,14 +42,17 @@ def close_doc_handler(sys_platform):
                 check=False,
             )
     elif sys_platform == "Linux":
+        # No wait needed, the CI image has no .doc handler to launch
         run(["pkill", "-f", "soffice"], check=False)
     elif sys_platform == "Windows":
+        sleep(HANDLER_LAUNCH_SEC)
         for proc in ("WINWORD.EXE", "soffice.exe", "soffice.bin"):
             run(["taskkill", "/F", "/T", "/IM", proc], check=False)
         # Windows keeps the file locked briefly after the app dies
         sleep(HANDLER_CLOSE_SEC)
 
 
+@pytest.mark.headed
 @pytest.mark.noxvfb
 def test_mime_type_doc(driver: Firefox, delete_files, close_doc_handler):
     """

--- a/tests/downloads/test_add_mime_type_doc.py
+++ b/tests/downloads/test_add_mime_type_doc.py
@@ -1,3 +1,6 @@
+from subprocess import run
+from time import sleep
+
 import pytest
 from selenium.webdriver import Firefox
 
@@ -7,10 +10,12 @@ from modules.page_object import AboutPrefs, GenericPage
 
 @pytest.fixture()
 def test_case():
-    return "1756748"
+    return "4108461"
 
 
 DOC_LINK = "https://sapphire-hendrika-5.tiiny.site/"
+HANDLER_LAUNCH_SEC = 5
+HANDLER_CLOSE_SEC = 2
 
 
 @pytest.fixture()
@@ -18,26 +23,43 @@ def delete_files_regex_string():
     return r"sample.*\.doc"
 
 
-def expected_app_name(sys_platform: str, opt_ci: bool) -> str:
+@pytest.fixture()
+def close_doc_handler(sys_platform):
+    """Quit the app the OS opens the downloaded .doc in."""
+    yield
+    # Let the handler finish launching, or it opens onto a deleted file
+    sleep(HANDLER_LAUNCH_SEC)
     if sys_platform == "Darwin":
-        return "TextEdit" if opt_ci else "Pages"
-    return "LibreOffice Writer"
+        for app in ("TextEdit", "Pages", "Microsoft Word"):
+            # The `is running` guard stops osascript launching the app
+            run(
+                [
+                    "osascript",
+                    "-e",
+                    f'if application "{app}" is running then '
+                    f'tell application "{app}" to quit saving no',
+                ],
+                check=False,
+            )
+    elif sys_platform == "Linux":
+        run(["pkill", "-f", "soffice"], check=False)
+    elif sys_platform == "Windows":
+        run(["taskkill", "/F", "/T", "/IM", "WINWORD.EXE"], check=False)
+    # Windows keeps the file locked briefly after the app dies.
+    sleep(HANDLER_CLOSE_SEC)
 
 
-# Test is unstable on Windows GHA because the image does not have a .doc handler
-# This test isn't even written to work on Windows due to above method
 @pytest.mark.noxvfb
-def test_mime_type_doc(driver: Firefox, sys_platform: str, opt_ci: bool, delete_files):
+def test_mime_type_doc(driver: Firefox, delete_files, close_doc_handler):
     """
-    C1756748 - Verify that downloading a .doc file adds a new MIME type entry
-    and the correct default application is assigned.
+    C4108461 - Verify that downloading a .doc file adds the .doc MIME type
+    entry to the Files and Applications list.
     """
 
     # Instantiate objects
     page = GenericPage(driver, url=DOC_LINK)
     nav = Navigation(driver)
-    # Settings redesign (bug 2043378) moved the Applications file-handlers list
-    # from the General pane to about:preferences#downloads.
+    # The settings redesign (bug 2043378) moved file handlers to this pane
     about_prefs = AboutPrefs(driver, category="downloads")
 
     # Open the test page with the .doc download link
@@ -47,7 +69,6 @@ def test_mime_type_doc(driver: Firefox, sys_platform: str, opt_ci: bool, delete_
     # Download the file and set 'Always Open Similar Files'
     nav.perform_download_context_action("context-menu-always-open-similar-files")
 
-    # Verify the MIME type entry exists and default app matches expectation
+    # Check the doc mime type is listed. Its label and app come from the OS
     about_prefs.open()
-    app_name = about_prefs.get_app_name_for_mime_type("application/msword")
-    assert app_name == expected_app_name(sys_platform, opt_ci)
+    about_prefs.element_exists("mime-type-item", labels=["application/msword"])

--- a/tests/downloads/test_add_mime_type_doc.py
+++ b/tests/downloads/test_add_mime_type_doc.py
@@ -27,7 +27,7 @@ def delete_files_regex_string():
 def close_doc_handler(sys_platform):
     """Quit the app the OS opens the downloaded .doc in."""
     yield
-    # Let the handler finish launching, or it opens onto a deleted file
+    # Always wait, since an open handler can block later tests with a dialog
     sleep(HANDLER_LAUNCH_SEC)
     if sys_platform == "Darwin":
         for app in ("TextEdit", "Pages", "Microsoft Word"):
@@ -44,7 +44,8 @@ def close_doc_handler(sys_platform):
     elif sys_platform == "Linux":
         run(["pkill", "-f", "soffice"], check=False)
     elif sys_platform == "Windows":
-        run(["taskkill", "/F", "/T", "/IM", "WINWORD.EXE"], check=False)
+        for proc in ("WINWORD.EXE", "soffice.exe", "soffice.bin"):
+            run(["taskkill", "/F", "/T", "/IM", proc], check=False)
     # Windows keeps the file locked briefly after the app dies.
     sleep(HANDLER_CLOSE_SEC)
 

--- a/tests/downloads/test_add_mime_type_doc.py
+++ b/tests/downloads/test_add_mime_type_doc.py
@@ -46,8 +46,8 @@ def close_doc_handler(sys_platform):
     elif sys_platform == "Windows":
         for proc in ("WINWORD.EXE", "soffice.exe", "soffice.bin"):
             run(["taskkill", "/F", "/T", "/IM", proc], check=False)
-    # Windows keeps the file locked briefly after the app dies.
-    sleep(HANDLER_CLOSE_SEC)
+        # Windows keeps the file locked briefly after the app dies
+        sleep(HANDLER_CLOSE_SEC)
 
 
 @pytest.mark.noxvfb


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047092](https://bugzilla.mozilla.org/show_bug.cgi?id=2047092)
TestRail: [4108461](https://mozilla.testrail.io/index.php?/cases/view/4108461)

### Description of Code / Doc Changes

- Point `test_add_mime_type_doc` at C4108461, the 152+ case that replaced the retired C1756748 (`[<152]`).
- Replace the hardcoded default app assertion with a check that the `application/msword` row is present in the Files and Applications list, which is what step 4 asks for.
- Add a `close_doc_handler` teardown that quits the OS handler for the download and waits for the file lock to release before `delete_files` runs.
- Set the test to `pass` in `key.yaml` and drop the comment pointing at bug 2043378, which is closed.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

**Why it was still failing**

- The test was marked unstable citing bug 2043378, which is closed.
- That bug's PR (#1483) fixed the selectors and pane, but never flipped the manifest flag.
- It also left one problem behind: `expected_app_name()` hardcoded the OS default `.doc` handler per platform.
- That is a property of the machine, not of Firefox, so it cannot hold across runners. The Linux CI image installs no office suite at all.
- Locally it failed 5 out of 5 runs on `assert 'TextEdit' == 'Pages'`, reaching the final line every time, so the assertion was the only broken part.
- C4108461 expects "doc mime type is present in the application list", so that is what is checked now.

**Why the teardown was added**

- The test sets "Always Open Similar Files", so Firefox hands each download to the system handler.
- That left a document window open after every run.
- On Windows, Word started too slowly and `delete_files` removed the file first, causing a blocking dialog and a `[WinError 32]` teardown error.
- `close_doc_handler` quits the handler and waits for the lock to release.

Verified passing on mac and Windows.

### Comments or Future Work

`test_add_zip_type` is still marked unstable citing the same closed bug 2043378. It already asserts row existence rather than an app name, so it may just need the flag flipped, but it is a separate case and out of scope here.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!