### PR TITLE
Akash/ Add test for find toolbar search on a page with an iframe

### DIFF
--- a/data/pages/find_in_iframe_frame.html
+++ b/data/pages/find_in_iframe_frame.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Iframe Content</title>
+    <style>
+      body { margin: 0; padding: 16px; font-family: sans-serif; }
+      p { margin: 0 0 24px; }
+    </style>
+  </head>
+  <body>
+    <h3 class="header">Inside the iframe</h3>
+    <p class="para">The first language inside the iframe.</p>
+    <p class="para">A second language and a third language inside the iframe.</p>
+  </body>
+</html>

--- a/data/pages/find_in_iframe_page.html
+++ b/data/pages/find_in_iframe_page.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test Page With An Iframe</title>
+    <style>
+      body { margin: 0; padding: 16px; font-family: sans-serif; }
+      p { margin: 0 0 24px; }
+      .spacer { height: 1200px; }
+      iframe { width: 90%; height: 400px; }
+    </style>
+  </head>
+  <body>
+    <h2 class="header">Find in a page with an iframe</h2>
+    <p class="para">The first language in this paragraph is a top level match.</p>
+    <p class="para">A second language and a third language live in the parent document.</p>
+    <p class="para">Here is a fourth language, and here is a fifth language.</p>
+    <iframe class="frame" src="find_in_iframe_frame.html" title="Iframe with matches"></iframe>
+    <div class="spacer"></div>
+    <p class="footer">Nothing below the iframe matches, this text is only here to make the page scroll.</p>
+  </body>
+</html>

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -562,6 +562,10 @@ find_toolbar:
     result: pass
     splits:
     - functional1
+  test_find_on_page_with_iframe:
+    result: pass
+    splits:
+    - functional1
   test_find_toolbar_nav:
     result: pass
     splits:

--- a/tests/find_toolbar/test_find_on_page_with_iframe.py
+++ b/tests/find_toolbar/test_find_on_page_with_iframe.py
@@ -100,8 +100,15 @@ def test_find_on_page_with_iframe(
     find_toolbar.navigate_matches_by_keys(backwards=True)
     web_page.expect(lambda d: d.execute_script(current_match) == first_match)
 
-    # Past the last parent match, the highlight enters the iframe
-    find_toolbar.navigate_matches_n_times(PARENT_MATCHES)
+    # The last parent match still highlights in the parent
+    find_toolbar.navigate_matches_n_times(PARENT_MATCHES - 1)
+    find_toolbar.expect(
+        lambda _: find_toolbar.get_match_args()["current"] == PARENT_MATCHES
+    )
+    web_page.expect(lambda d: _single_highlight(d, current_match))
+
+    # One more crosses into the iframe
+    find_toolbar.next_match()
     find_toolbar.expect(
         lambda _: find_toolbar.get_match_args()["current"] == PARENT_MATCHES + 1
     )

--- a/tests/find_toolbar/test_find_on_page_with_iframe.py
+++ b/tests/find_toolbar/test_find_on_page_with_iframe.py
@@ -7,7 +7,6 @@ from selenium.webdriver import Firefox
 
 from modules.browser_object import FindToolbar
 from modules.page_object import GenericPage
-from modules.util import BrowserActions
 
 PARENT_HTML = "find_in_iframe_page.html"
 FRAME_HTML = "find_in_iframe_frame.html"
@@ -72,7 +71,6 @@ def _match_args(find_toolbar: FindToolbar) -> dict:
 def test_find_on_page_with_iframe(
     driver: Firefox,
     find_toolbar: FindToolbar,
-    browser_actions: BrowserActions,
     web_page: GenericPage,
     current_match: str,
 ):
@@ -83,7 +81,6 @@ def test_find_on_page_with_iframe(
 
     Arguments:
         find_toolbar: instantiation of FindToolbar BOM.
-        browser_actions: instantiation of BrowserActions BOM.
         web_page: the local page that contains an iframe.
         current_match: script returning info about the currently highlighted match.
     """
@@ -121,7 +118,7 @@ def test_find_on_page_with_iframe(
     )
     web_page.expect(lambda d: _no_highlight(d, current_match))
 
-    browser_actions.switch_to_iframe_context(web_page.get_element("content-iframe"))
+    web_page.switch_to_iframe_context(web_page.get_element("content-iframe"))
     web_page.expect(lambda d: _single_highlight(d, current_match))
     web_page.switch_to_default_frame()
 

--- a/tests/find_toolbar/test_find_on_page_with_iframe.py
+++ b/tests/find_toolbar/test_find_on_page_with_iframe.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+from shutil import copyfile
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import FindToolbar
+from modules.page_object import GenericPage
+from modules.util import BrowserActions
+
+PARENT_HTML = "find_in_iframe_page.html"
+FRAME_HTML = "find_in_iframe_frame.html"
+SEARCH_TERM = "language"
+PARENT_MATCHES = 5  # in the parent document
+FRAME_MATCHES = 3  # inside the iframe
+TOTAL_MATCHES = PARENT_MATCHES + FRAME_MATCHES
+
+
+@pytest.fixture()
+def test_case():
+    return "127265"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "content-iframe": {
+            "strategy": "css",
+            "selectorData": "iframe.frame",
+            "groups": ["doNotCache"],
+        }
+    }
+
+
+@pytest.fixture()
+def local_doc_path(tmp_path: Path) -> str:
+    """Copy the page and the page it frames into a temp folder"""
+    for filename in (PARENT_HTML, FRAME_HTML):
+        copyfile(f"data/pages/{filename}", tmp_path / filename)
+    return f"file://{tmp_path / PARENT_HTML}"
+
+
+@pytest.fixture()
+def web_page(driver: Firefox, temp_selectors: dict, local_doc_path: str):
+    """Return the opened local page that contains an iframe"""
+    generic_page = GenericPage(driver, url=local_doc_path)
+    generic_page.elements |= temp_selectors
+    generic_page.open()
+    yield generic_page
+
+
+def _single_highlight(driver: Firefox, script: str) -> bool:
+    """The current frame holds one highlight, and it is the search term"""
+    match = driver.execute_script(script)
+    # Match Case is off by default
+    return bool(match) and match[0].lower() == SEARCH_TERM and match[1] == 1
+
+
+def _no_highlight(driver: Firefox, script: str) -> bool:
+    """The current frame holds no highlighted text"""
+    match = driver.execute_script(script)
+    return not match or not match[0].strip()
+
+
+def test_find_on_page_with_iframe(
+    driver: Firefox,
+    find_toolbar: FindToolbar,
+    browser_actions: BrowserActions,
+    web_page: GenericPage,
+    current_match: str,
+):
+    """
+    C127265: Verify that searching on a page with iframe works properly
+
+    The checkerboarding and performance checks stay manual.
+
+    Arguments:
+        find_toolbar: instantiation of FindToolbar BOM.
+        browser_actions: instantiation of BrowserActions BOM.
+        web_page: the local page that contains an iframe.
+        current_match: script returning info about the currently highlighted match.
+    """
+    # All matches are found, parent and iframe
+    find_toolbar.open_with_key_combo()
+    find_toolbar.find(SEARCH_TERM)
+    find_toolbar.expect(
+        lambda _: find_toolbar.get_match_args()["total"] == TOTAL_MATCHES
+    )
+
+    # First match is in the parent, and is the only highlight
+    find_toolbar.rewind_to_first_match()
+    web_page.expect(lambda d: _single_highlight(d, current_match))
+    first_match = driver.execute_script(current_match)
+
+    # F3 moves the highlight forward, SHIFT+F3 moves it back
+    find_toolbar.navigate_matches_by_keys()
+    web_page.expect(
+        lambda d: d.execute_script(current_match) not in (None, first_match)
+    )
+    find_toolbar.navigate_matches_by_keys(backwards=True)
+    web_page.expect(lambda d: d.execute_script(current_match) == first_match)
+
+    # Past the last parent match, the highlight enters the iframe
+    find_toolbar.navigate_matches_n_times(PARENT_MATCHES)
+    find_toolbar.expect(
+        lambda _: find_toolbar.get_match_args()["current"] == PARENT_MATCHES + 1
+    )
+    web_page.expect(lambda d: _no_highlight(d, current_match))
+
+    browser_actions.switch_to_iframe_context(web_page.get_element("content-iframe"))
+    web_page.expect(lambda d: _single_highlight(d, current_match))
+    web_page.switch_to_default_frame()
+
+    # Going back brings it out of the iframe
+    find_toolbar.previous_match()
+    web_page.expect(lambda d: _single_highlight(d, current_match))
+    last_parent_match = driver.execute_script(current_match)
+
+    # Scrolling leaves the search session intact
+    driver.execute_script("window.scrollBy(0, 2000)")
+    driver.execute_script("window.scrollTo(0, 0)")
+    web_page.expect(lambda d: d.execute_script(current_match) == last_parent_match)
+    find_toolbar.expect(
+        lambda _: find_toolbar.get_match_args()["total"] == TOTAL_MATCHES
+    )

--- a/tests/find_toolbar/test_find_on_page_with_iframe.py
+++ b/tests/find_toolbar/test_find_on_page_with_iframe.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from shutil import copyfile
 
@@ -62,6 +63,12 @@ def _no_highlight(driver: Firefox, script: str) -> bool:
     return not match or not match[0].strip()
 
 
+def _match_args(find_toolbar: FindToolbar) -> dict:
+    """The findbar counter, empty while it has not been populated"""
+    args = find_toolbar.get_element("matches-label").get_attribute("data-l10n-args")
+    return json.loads(args) if args else {}
+
+
 def test_find_on_page_with_iframe(
     driver: Firefox,
     find_toolbar: FindToolbar,
@@ -84,7 +91,7 @@ def test_find_on_page_with_iframe(
     find_toolbar.open_with_key_combo()
     find_toolbar.find(SEARCH_TERM)
     find_toolbar.expect(
-        lambda _: find_toolbar.get_match_args()["total"] == TOTAL_MATCHES
+        lambda _: _match_args(find_toolbar).get("total") == TOTAL_MATCHES
     )
 
     # First match is in the parent, and is the only highlight
@@ -103,14 +110,14 @@ def test_find_on_page_with_iframe(
     # The last parent match still highlights in the parent
     find_toolbar.navigate_matches_n_times(PARENT_MATCHES - 1)
     find_toolbar.expect(
-        lambda _: find_toolbar.get_match_args()["current"] == PARENT_MATCHES
+        lambda _: _match_args(find_toolbar).get("current") == PARENT_MATCHES
     )
     web_page.expect(lambda d: _single_highlight(d, current_match))
 
     # One more crosses into the iframe
     find_toolbar.next_match()
     find_toolbar.expect(
-        lambda _: find_toolbar.get_match_args()["current"] == PARENT_MATCHES + 1
+        lambda _: _match_args(find_toolbar).get("current") == PARENT_MATCHES + 1
     )
     web_page.expect(lambda d: _no_highlight(d, current_match))
 
@@ -128,5 +135,5 @@ def test_find_on_page_with_iframe(
     driver.execute_script("window.scrollTo(0, 0)")
     web_page.expect(lambda d: d.execute_script(current_match) == last_parent_match)
     find_toolbar.expect(
-        lambda _: find_toolbar.get_match_args()["total"] == TOTAL_MATCHES
+        lambda _: _match_args(find_toolbar).get("total") == TOTAL_MATCHES
     )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [1991733](https://bugzilla.mozilla.org/show_bug.cgi?id=1991733)
TestRail: [127265](https://mozilla.testrail.io/index.php?/cases/view/127265)

### Description of Code / Doc Changes

- Adds `tests/find_toolbar/test_find_on_page_with_iframe.py` for C127265, verifying Find Toolbar search on a page containing an iframe.
- Adds local pages `data/pages/find_in_iframe_page.html` and `find_in_iframe_frame.html`. The search term appears 5 times in the outer page, 3 times in the iframe.
- Registers the test in `manifests/key.yaml` as `pass` in `functional1`.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Asserts the counter reads 8 matches, confirming Firefox counts matches inside iframes, then walks the highlight past the 5th match to check it moves into the iframe and out again. Covers F3 / Shift+F3 and that scrolling leaves the search session intact.

Local pages keep the match counts fixed.

The checkerboarding and performance checks in steps 5 and 6 need human eyes, so they stay manual. This is noted in the docstring.

Verified on macOS: 4 headed runs, 1 headless, all passing.

### Comments or Future Work

The match counts are hardcoded in the test, so editing the two new HTML pages means updating those constants.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.