### PR TITLE
Hani/ Mark test edit autofill pp win as stable

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -982,11 +982,7 @@ password_manager:
     - functional2
     - nightly
   test_edit_autofill_after_pp_dismissed:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2067357
-    result:
-      linux: pass
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2067357](https://bugzilla.mozilla.org/show_bug.cgi?id=2067357)

### Description of Code / Doc Changes

* Mark tests/password_manager/test_edit_autofill_after_pp_dismissed.py as stable on Win

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
