### PR TITLE
Akash/ Stabilize test_clear_cookie_data on Windows

### DIFF
--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1066,14 +1066,36 @@ class AboutPrefs(BasePage):
         iframe = self.get_element("browser-popup")
         return iframe
 
-    def clear_cookies_and_get_dialog_iframe(self):
+    def switch_to_clear_data_dialog(self) -> BasePage:
         """
-        Returns the iframe object for the dialog panel in the popup after pressing the clear site
-        data button.
+        Press the clear site data button and switch into the dialog panel's iframe.
+
+        The .dialogFrame element exists before the dialog loads, so switch from the top
+        and retry until the dialog's own content is reachable.
         """
         self.scroll_to_element("clear-site-data-button")
         self.click_on("clear-site-data-button")
-        return self.get_element("browser-popup")
+
+        def _switched_into_loaded_dialog(_) -> bool:
+            self.switch_to_default_frame()
+            for frame in self.get_elements("browser-popup"):
+                try:
+                    self.switch_to_iframe_context(frame)
+                    if self.get_elements("cookies-data-checkbox"):
+                        return True
+                except WebDriverException:
+                    pass
+                self.switch_to_default_frame()
+            return False
+
+        # Don't pay the implicit wait on every miss
+        original = self.driver.timeouts.implicit_wait
+        self.driver.implicitly_wait(0)
+        try:
+            self.wait.until(_switched_into_loaded_dialog)
+        finally:
+            self.driver.implicitly_wait(original)
+        return self
 
     def switch_to_saved_addresses_popup_iframe(self) -> BasePage:
         """
@@ -1185,8 +1207,6 @@ class AboutPrefs(BasePage):
         The <memory used> value for no cookies is '0 bytes', otherwise values are
         '### MB', or '### KB'
         """
-        # Find the dialog option elements containing the checkbox label
-        self.element_exists("clear-data-dialog-options")
         cookies_checkbox = self.get_element("cookies-data-checkbox")
         self.element_has_attribute(cookies_checkbox, "data-l10n-args")
         cookies_object = cookies_checkbox.get_attribute("data-l10n-args")
@@ -1411,14 +1431,12 @@ class AboutPrefs(BasePage):
                 self.element_has_text(locator, text_value)
         return self
 
-    def open_clear_cookie_site_and_get_data(self):
+    def open_clear_cookie_site_and_get_data(self) -> int:
         """
-        Open about:preferences#privacy, show the 'Clear Data' dialog, switch into its iframe,
-        wait for its option container to be present, read the value, then switch back.
+        Open about:preferences#privacy and read the cookies and site data value.
         """
         self.open()
-        iframe = self.clear_cookies_and_get_dialog_iframe()
-        self.switch_to_iframe_context(iframe)
+        self.switch_to_clear_data_dialog()
         val = self.get_cookie_site_data_value()
         self.switch_to_default_frame()
         self.close_dialog_box()
@@ -1428,8 +1446,8 @@ class AboutPrefs(BasePage):
         """
         Open about:preferences#privacy and clear cookies and site data.
         """
-        iframe = self.clear_cookies_and_get_dialog_iframe()
-        self.switch_to_iframe_context(iframe)
+        self.open()
+        self.switch_to_clear_data_dialog()
         self.click_on("clear-data-accept-button")
         self.switch_to_default_frame()
 

--- a/tests/preferences/test_clear_cookie_data.py
+++ b/tests/preferences/test_clear_cookie_data.py
@@ -31,6 +31,6 @@ def test_clear_cookie_data(driver: Firefox, about_prefs: AboutPrefs):
     # Clear cookies and site data: open the dialog again, wait for iframe, click clear
     about_prefs.open_clear_cookie_site_and_clear_data()
 
-    # Wait until the dialog reports 0 (reopen/poll via helper)
+    # Reopen the dialog and confirm it now reports 0
     cookie_value = about_prefs.open_clear_cookie_site_and_get_data()
     assert cookie_value == 0, f"Expected 0 after clearing, got {cookie_value}"


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2064065](https://bugzilla.mozilla.org/show_bug.cgi?id=2064065)
TestRail: [143627](https://mozilla.testrail.io/index.php?/cases/view/143627)

### Description of Code / Doc Changes

- Replaced `clear_cookies_and_get_dialog_iframe` with `switch_to_clear_data_dialog`, which retries the iframe switch from the top of the document until the dialog's content is reachable.
- Removed the `element_exists("clear-data-dialog-options")` wait that was timing out, now redundant.
- `open_clear_cookie_site_and_clear_data` now calls `self.open()` itself instead of assuming the caller is already on the prefs page, matching `open_clear_cookie_site_and_get_data`.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

`about:preferences` creates the `.dialogFrame` element before the dialog document finishes loading. The old code clicked the button and switched into that frame immediately, so under CI load it landed in a blank frame. The subsequent wait then polled inside the wrong document, where the content was never going to appear, which is why the 30 second timeout and the three reruns all failed.

Failure was Windows only and started at 155.0b5. Mac and Linux passed on every build.

### Comments or Future Work

The failure does not reproduce on a local Windows machine with 155.0b5, only on loaded CI workers, so the Windows CI job on this PR is the real verification.

Separately, `conftest.py` reports any driver launch failure as `UnboundLocalError: cannot access local variable 'driver'` because the `finally` block references `driver` before it is assigned. That masks the actual exception and is worth a small follow up PR.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!