### PR TITLE
Akash/ Fix flaky search mode assertions in test_search_mode_change_tab

### DIFF
--- a/tests/address_bar_and_search/test_search_mode_change_tab.py
+++ b/tests/address_bar_and_search/test_search_mode_change_tab.py
@@ -5,6 +5,7 @@ from modules.browser_object_navigation import Navigation
 from modules.browser_object_tabbar import TabBar
 
 TEXT = "Fire"
+SERP_URLS = {"Bing": "bing.com", "DuckDuckGo": "duckduckgo.com"}
 
 
 @pytest.fixture()
@@ -23,6 +24,7 @@ def test_search_mode_change_tab(driver: Firefox, engine1, engine2):
     tabs = TabBar(driver)
 
     # Click on Bing engine
+    first_tab = driver.current_window_handle
     nav.set_search_mode(engine1)
 
     # "Search Mode" is visible in URL bar for Bing
@@ -30,6 +32,7 @@ def test_search_mode_change_tab(driver: Firefox, engine1, engine2):
 
     # Open a new tab and click on the USB
     nav.open_and_switch_to_new_window("tab")
+    second_tab = driver.current_window_handle
 
     # Click on the Duckduckgo engine
     nav.set_search_mode(engine2)
@@ -37,20 +40,20 @@ def test_search_mode_change_tab(driver: Firefox, engine1, engine2):
     # "Search Mode" is visible in URL bar for duckduckgo
     nav.verify_search_mode_is_visible(engine2)
 
-    # Go back to tab from step #2
+    # Go back to tab from step #2, "Search Mode" appears as Bing
     tabs.click_tab_by_index(1)
-
-    # Type any word and hit enter
-    nav.search(TEXT)
-
-    # Check search is done using Bing engine
+    driver.switch_to.window(first_tab)
     nav.verify_search_mode_is_visible(engine1)
 
-    # Go back to the tab from step #4
-    tabs.click_tab_by_index(2)
-
-    # Type any word and hit enter
+    # Type any word and hit enter, search is done using Bing engine
     nav.search(TEXT)
+    nav.url_contains(SERP_URLS[engine1])
 
-    # Check that search is done using the duckduckgo engine
+    # Go back to the tab from step #4, "Search Mode" appears as DuckDuckGo
+    tabs.click_tab_by_index(2)
+    driver.switch_to.window(second_tab)
     nav.verify_search_mode_is_visible(engine2)
+
+    # Type any word and hit enter, search is done using the duckduckgo engine
+    nav.search(TEXT)
+    nav.url_contains(SERP_URLS[engine2])


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2067772](https://bugzilla.mozilla.org/show_bug.cgi?id=2067772)
TestRail: [3028732](https://mozilla.testrail.io/index.php?/cases/view/3028732)

### Description of Code / Doc Changes

- Assert the search mode switcher before each search instead of after, matching TestRail steps 5 and 7.
- Verify the engine used by checking the results page URL, matching TestRail steps 6 and 8.
- Switch the Selenium window handle alongside each `click_tab_by_index()` call, so URL assertions read the tab that is actually selected.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model):
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Firefox resets the search mode switcher to the default engine shortly after the results page
loads, measured at 0.78s to 1.04s over six runs. The old assertion ran after the search, so it
only passed by winning that race. Same behaviour on 154.0.1 and 155.0a1, so not a 156 regression.
Verified: 8/8 headed, 4/4 batches headless under `-n 4`.

### Comments or Future Work

- The DuckDuckGo failure from CI was not reproduced locally; the next scheduled Mac beta runs will confirm.
- Scheduled beta runs upload no artifacts, since the upload step in `main.yml` is gated on `github.event_name == 'pull_request'`. Worth a separate PR.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!