### PR TITLE
Akash/ Add test_find_text_on_buttons

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -566,6 +566,10 @@ find_toolbar:
     result: pass
     splits:
     - functional1
+  test_find_text_on_buttons:
+    result: pass
+    splits:
+    - functional1
   test_find_toolbar_nav:
     result: pass
     splits:

--- a/tests/find_toolbar/test_find_text_on_buttons.py
+++ b/tests/find_toolbar/test_find_text_on_buttons.py
@@ -1,0 +1,72 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+
+from modules.browser_object import FindToolbar
+from modules.util import BrowserActions
+
+
+@pytest.fixture()
+def test_case():
+    return "127250"
+
+
+# Color-count difference that means the highlight changed
+TOLERANCE = 3
+
+TARGET_PAGE = "about:support"
+SEARCH_TERM = "clipboard"
+
+# Two buttons on about:support contain the search term
+first_button = (By.CSS_SELECTOR, "#copy-raw-data-to-clipboard")
+second_button = (By.CSS_SELECTOR, "#copy-to-clipboard")
+
+
+def are_lists_different(a: int, b: int) -> bool:
+    return abs(a - b) > TOLERANCE
+
+
+def test_find_text_on_buttons(
+    driver: Firefox, find_toolbar: FindToolbar, browser_actions: BrowserActions
+):
+    """
+    C127250: Verify that searching for text that appears on buttons works properly
+
+    Arguments:
+        browser_actions: instantiation of BrowserActions BOM.
+        find_toolbar: instantiation of FindToolbar BOM.
+    """
+    driver.get(TARGET_PAGE)
+
+    # Reference colors for both buttons before anything is highlighted
+    first_ref_colors = browser_actions.get_all_colors_in_element(first_button)
+    second_ref_colors = browser_actions.get_all_colors_in_element(second_button)
+
+    # Every instance of the term on the buttons is found
+    find_toolbar.open()
+    find_toolbar.find(SEARCH_TERM)
+    assert find_toolbar.match_dict["total"] == 2
+
+    # Only the first match is highlighted
+    find_toolbar.rewind_to_first_match()
+    first_colors = browser_actions.get_all_colors_in_element(first_button)
+    second_colors = browser_actions.get_all_colors_in_element(second_button)
+
+    assert are_lists_different(len(first_colors), len(first_ref_colors))
+    assert not are_lists_different(len(second_colors), len(second_ref_colors))
+
+    # Going forward moves the highlight to the second match
+    find_toolbar.next_match()
+    first_colors = browser_actions.get_all_colors_in_element(first_button)
+    second_colors = browser_actions.get_all_colors_in_element(second_button)
+
+    assert not are_lists_different(len(first_colors), len(first_ref_colors))
+    assert are_lists_different(len(second_colors), len(second_ref_colors))
+
+    # Going back moves the highlight to the first match again
+    find_toolbar.previous_match()
+    first_colors = browser_actions.get_all_colors_in_element(first_button)
+    second_colors = browser_actions.get_all_colors_in_element(second_button)
+
+    assert are_lists_different(len(first_colors), len(first_ref_colors))
+    assert not are_lists_different(len(second_colors), len(second_ref_colors))


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2013514](https://bugzilla.mozilla.org/show_bug.cgi?id=2013514) 
TestRail: [127250](https://mozilla.testrail.io/index.php?/cases/view/127250)

### Description of Code / Doc Changes

- Adds `tests/find_toolbar/test_find_text_on_buttons.py`, automating C127250.
- The test loads `about:support`, searches "clipboard" in the Find Toolbar, and checks both buttons that contain the term are found.
- It compares button colors before and after the search to confirm only the current match is highlighted, then navigates forward and back to confirm the highlight moves with it.
- Registers the test in `manifests/key.yaml` under the `functional1` split.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

`about:support` is used instead of a live site so the buttonuttons are real `<button>` elements, so they avoid the `input type="submit"` case noted in the test case. Highlight checks reuse the color-count approach already used by `test_find_toolbar_nav` and
`test_find_toolbar_search`.

### Comments or Future Work

None.

### Workflow Checklist

- [ ] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to

Thank you!