### PR TITLE
Anca/Glean - sap_count second batch and add a flag unstable mechanism 

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -689,6 +689,11 @@ glean:
       result: pass
       splits:
       - glean
+  sap_counts:
+    test_sap_counts:
+      result: pass
+      splits:
+      - glean
   serp_abandonment:
     test_serp_abandonment:
       result: pass

--- a/tests/glean/misc_metrics/test_misc_metrics.py
+++ b/tests/glean/misc_metrics/test_misc_metrics.py
@@ -11,7 +11,7 @@ from tests.glean.flows import (
     run_action,
     run_entry,
 )
-from tests.glean.utils import load_cases
+from tests.glean.utils import load_cases, skip_if_unstable
 
 data = load_cases(__file__)
 
@@ -38,6 +38,7 @@ DEFAULT_ENGINE = "Google"
 )
 def case(request):
     """Parametrized fixture yielding one test case dict from cases.json."""
+    skip_if_unstable(request.param)
     return request.param
 
 

--- a/tests/glean/sap_counts/cases.json
+++ b/tests/glean/sap_counts/cases.json
@@ -13,7 +13,6 @@
     {"id": "3255577", "entry": "urlbar_handoff", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_handoff"}},
     {"id": "3255589", "entry": "urlbar_handoff", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_handoff"}},
 
-    {"id": "3255566", "entry": "urlbar_persisted", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_persisted"}},
     {"id": "3255578", "entry": "urlbar_persisted", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_persisted"}},
     {"id": "3255590", "entry": "urlbar_persisted", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_persisted"}},
 

--- a/tests/glean/sap_counts/cases.json
+++ b/tests/glean/sap_counts/cases.json
@@ -4,25 +4,42 @@
     {"id": "3255564", "entry": "urlbar", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar"}},
     {"id": "3255576", "entry": "urlbar", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar"}},
     {"id": "3255588", "entry": "urlbar", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar"}},
+    {"id": "3255600", "entry": "urlbar", "params": {"engine": "Perplexity"}, "prefs": [], "expected": {"provider_id": "perplexity", "source": "urlbar"}},
+    {"id": "3255609", "entry": "urlbar", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"provider_id": "qwant", "source": "urlbar"}},
+    {"id": "3255629", "entry": "urlbar", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"provider_id": "ecosia", "source": "urlbar"}},
 
     {"id": "3255562", "entry": "searchbar", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "searchbar"}},
     {"id": "3255574", "entry": "searchbar", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "searchbar"}},
     {"id": "3255586", "entry": "searchbar", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "searchbar"}},
+    {"id": "3255598", "entry": "searchbar", "params": {"engine": "Perplexity"}, "prefs": [], "expected": {"provider_id": "perplexity", "source": "searchbar"}},
+    {"id": "3255607", "entry": "searchbar", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"provider_id": "qwant", "source": "searchbar"}},
+    {"id": "3255627", "entry": "searchbar", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"provider_id": "ecosia", "source": "searchbar"}},
 
     {"id": "3255565", "entry": "urlbar_handoff", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_handoff"}},
     {"id": "3255577", "entry": "urlbar_handoff", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_handoff"}},
     {"id": "3255589", "entry": "urlbar_handoff", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_handoff"}},
+    {"id": "3255601", "entry": "urlbar_handoff", "params": {"engine": "Perplexity"}, "prefs": [], "expected": {"provider_id": "perplexity", "source": "urlbar_handoff"}},
+    {"id": "3255610", "entry": "urlbar_handoff", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"provider_id": "qwant", "source": "urlbar_handoff"}},
+    {"id": "3255630", "entry": "urlbar_handoff", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"provider_id": "ecosia", "source": "urlbar_handoff"}},
 
     {"id": "3255578", "entry": "urlbar_persisted", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_persisted"}},
     {"id": "3255590", "entry": "urlbar_persisted", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_persisted"}},
+    {"id": "3255611", "entry": "urlbar_persisted", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"provider_id": "qwant", "source": "urlbar_persisted"}},
+    {"id": "3255631", "entry": "urlbar_persisted", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"provider_id": "ecosia", "source": "urlbar_persisted"}},
 
     {"id": "3255567", "entry": "urlbar_searchmode", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_searchmode"}},
     {"id": "3255579", "entry": "urlbar_searchmode", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_searchmode"}},
     {"id": "3255591", "entry": "urlbar_searchmode", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_searchmode"}},
+    {"id": "3255602", "entry": "urlbar_searchmode", "params": {"engine": "Perplexity"}, "prefs": [], "expected": {"provider_id": "perplexity", "source": "urlbar_searchmode"}},
+    {"id": "3255612", "entry": "urlbar_searchmode", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"provider_id": "qwant", "source": "urlbar_searchmode"}},
+    {"id": "3255632", "entry": "urlbar_searchmode", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"provider_id": "ecosia", "source": "urlbar_searchmode"}},
 
     {"id": "3255561", "entry": "contextmenu", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "contextmenu"}},
     {"id": "3255573", "entry": "contextmenu", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "contextmenu"}},
     {"id": "3255585", "entry": "contextmenu", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "contextmenu"}},
+    {"id": "3255597", "entry": "contextmenu", "params": {"engine": "Perplexity"}, "prefs": [], "expected": {"provider_id": "perplexity", "source": "contextmenu"}},
+    {"id": "3255606", "entry": "contextmenu", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"provider_id": "qwant", "source": "contextmenu"}},
+    {"id": "3255626", "entry": "contextmenu", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"provider_id": "ecosia", "source": "contextmenu"}},
 
     {"id": "3255560", "entry": "contextmenu_visual", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "contextmenu_visual"}}
   ]

--- a/tests/glean/sap_counts/cases.json
+++ b/tests/glean/sap_counts/cases.json
@@ -1,0 +1,30 @@
+{
+  "metric": "sap.counts",
+  "cases": [
+    {"id": "3255564", "entry": "urlbar", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar"}},
+    {"id": "3255576", "entry": "urlbar", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar"}},
+    {"id": "3255588", "entry": "urlbar", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar"}},
+
+    {"id": "3255562", "entry": "searchbar", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "searchbar"}},
+    {"id": "3255574", "entry": "searchbar", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "searchbar"}},
+    {"id": "3255586", "entry": "searchbar", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "searchbar"}},
+
+    {"id": "3255565", "entry": "urlbar_handoff", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_handoff"}},
+    {"id": "3255577", "entry": "urlbar_handoff", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_handoff"}},
+    {"id": "3255589", "entry": "urlbar_handoff", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_handoff"}},
+
+    {"id": "3255566", "entry": "urlbar_persisted", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_persisted"}},
+    {"id": "3255578", "entry": "urlbar_persisted", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_persisted"}},
+    {"id": "3255590", "entry": "urlbar_persisted", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_persisted"}},
+
+    {"id": "3255567", "entry": "urlbar_searchmode", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "urlbar_searchmode"}},
+    {"id": "3255579", "entry": "urlbar_searchmode", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "urlbar_searchmode"}},
+    {"id": "3255591", "entry": "urlbar_searchmode", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "urlbar_searchmode"}},
+
+    {"id": "3255561", "entry": "contextmenu", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "contextmenu"}},
+    {"id": "3255573", "entry": "contextmenu", "params": {"engine": "Bing"}, "prefs": [], "expected": {"provider_id": "bing", "source": "contextmenu"}},
+    {"id": "3255585", "entry": "contextmenu", "params": {"engine": "DuckDuckGo"}, "prefs": [], "expected": {"provider_id": "ddg", "source": "contextmenu"}},
+
+    {"id": "3255560", "entry": "contextmenu_visual", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "contextmenu_visual"}}
+  ]
+}

--- a/tests/glean/sap_counts/test_sap_counts.py
+++ b/tests/glean/sap_counts/test_sap_counts.py
@@ -1,0 +1,56 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Glean
+from modules.page_object import AboutPrefs
+from tests.glean.flows import (
+    ENTRY_PREFS,
+    SEARCH_TERM,
+    block_if_bot_challenge,
+    run_entry,
+)
+from tests.glean.utils import load_cases
+
+data = load_cases(__file__)
+METRIC = data["metric"]
+
+
+@pytest.fixture(
+    params=data["cases"],
+    ids=lambda c: f"{c['id']}-{c['params']['engine']}-{c['entry']}",
+)
+def case(request):
+    """Parametrized fixture yielding one test case dict from cases.json."""
+    return request.param
+
+
+@pytest.fixture()
+def test_case(case):
+    """TestRail case ID for the current parametrized case."""
+    return case["id"]
+
+
+@pytest.fixture()
+def add_to_prefs_list(case):
+    """Per-case Firefox prefs to set before driver launch."""
+    prefs = [tuple(p) for p in case.get("prefs", [])]
+    prefs += ENTRY_PREFS.get(case["entry"], [])
+    return prefs
+
+
+def test_sap_counts(driver: Firefox, case: dict):
+    """Verify sap.counts records the access point a search was issued from."""
+    prefs = AboutPrefs(driver, category="search")
+    glean = Glean(driver)
+    params = case["params"]
+
+    prefs.open()
+    prefs.search_engine_dropdown().select_option(params["engine"])
+
+    try:
+        run_entry(driver, case["entry"], SEARCH_TERM, params)
+
+        glean.poll_glean_metric(METRIC, case["expected"])
+    except Exception:
+        block_if_bot_challenge(driver)
+        raise

--- a/tests/glean/sap_counts/test_sap_counts.py
+++ b/tests/glean/sap_counts/test_sap_counts.py
@@ -9,7 +9,7 @@ from tests.glean.flows import (
     block_if_bot_challenge,
     run_entry,
 )
-from tests.glean.utils import load_cases
+from tests.glean.utils import load_cases, skip_if_unstable
 
 data = load_cases(__file__)
 METRIC = data["metric"]
@@ -21,6 +21,7 @@ METRIC = data["metric"]
 )
 def case(request):
     """Parametrized fixture yielding one test case dict from cases.json."""
+    skip_if_unstable(request.param)
     return request.param
 
 

--- a/tests/glean/serp_abandonment/test_serp_abandonment.py
+++ b/tests/glean/serp_abandonment/test_serp_abandonment.py
@@ -11,7 +11,7 @@ from tests.glean.flows import (
     block_if_bot_challenge,
     run_abandonment,
 )
-from tests.glean.utils import load_cases
+from tests.glean.utils import load_cases, skip_if_unstable
 
 data = load_cases(__file__)
 METRIC = data["metric"]
@@ -28,6 +28,7 @@ IMPRESSION_ID_RE = re.compile(
 )
 def case(request):
     """Parametrized fixture yielding one test case dict from cases.json."""
+    skip_if_unstable(request.param)
     return request.param
 
 

--- a/tests/glean/serp_engagement/test_serp_engagement.py
+++ b/tests/glean/serp_engagement/test_serp_engagement.py
@@ -10,7 +10,7 @@ from tests.glean.flows import (
     run_action,
     run_entry,
 )
-from tests.glean.utils import load_cases
+from tests.glean.utils import load_cases, skip_if_unstable
 
 data = load_cases(__file__)
 METRIC = data["metric"]
@@ -22,6 +22,7 @@ METRIC = data["metric"]
 )
 def case(request):
     """Parametrized fixture yielding one test case dict from cases.json."""
+    skip_if_unstable(request.param)
     return request.param
 
 

--- a/tests/glean/serp_impression/test_serp_impression.py
+++ b/tests/glean/serp_impression/test_serp_impression.py
@@ -11,7 +11,7 @@ from tests.glean.flows import (
     run_action,
     run_entry,
 )
-from tests.glean.utils import load_cases
+from tests.glean.utils import load_cases, skip_if_unstable
 
 data = load_cases(__file__)
 METRIC = data["metric"]
@@ -25,6 +25,7 @@ METRIC = data["metric"]
 )
 def case(request):
     """Parametrized fixture yielding one test case dict from cases.json."""
+    skip_if_unstable(request.param)
     return request.param
 
 

--- a/tests/glean/utils.py
+++ b/tests/glean/utils.py
@@ -1,9 +1,23 @@
 import json
 from pathlib import Path
 
+import pytest
+
 
 def load_cases(caller_file: str) -> dict:
     """Load cases.json from the same directory as the calling test file."""
     return json.loads(
         (Path(caller_file).parent / "cases.json").read_text(encoding="utf-8")
     )
+
+
+def skip_if_unstable(case: dict) -> None:
+    """Skip a case carrying an `unstable` reason string in cases.json.
+
+    `key.yaml` can only mark a whole test file, so per-case stability lives in the
+    dataset. Called from the `case` fixture, so this runs before `driver` and reports
+    as Untested, not Blocked.
+    """
+    reason = case.get("unstable")
+    if reason:
+        pytest.skip(f"Unstable case: {reason}")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [17 test cases](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=2032890%2C%202032891%2C%202032892%2C%202032893%2C%202032894%2C%202032897%2C%202032898%2C%202032899%2C%202032900%2C%202032901%2C%202032902%2C%202032905%2C%202032906%2C%202032907%2C%202032908%2C%202032909%2C%202032910&list_id=18098581)
TestRail:  [S70197](https://mozilla.testrail.io/index.php?/suites/view/70197)

### Description of Code / Doc Changes
- The work here is split in two, but shipped in a single PR so CI runs once.
   1. Add second batch for sap_counts:
       - Second batch of sap.counts coverage: Perplexity, Qwant and Ecosia on the search access points, 17 cases. Batch 1 (#1601) covered Google, Bing and DuckDuckGo.
        - Engine availability comes from search-config-v2, the Remote Settings collection that defines the search engines Firefox ships, each engine's identifier, URLs, partner codes and the regions it is offered in. Qwant is limited to BE/CH/ES/FR/IT/NL and Ecosia to AT/BE/CH/DE/ES/IT/NL/SE, so their cases pin browser.search.region to FR and DE to make the engine selectable as default. Perplexity is allRegionsAndLocales, so it needs no pref.
        - Perplexity has no `urlbar_persisted` case: it is absent from the `search-telemetry-v2` collection, so Firefox never recognises its results page as a SERP and persisted search terms don't trigger. No TestRail case or bug exists for it either.

     2. Add a way to flag unstable tests:
         - Adds skip_if_unstable: an optional "unstable": "<reason>" key on any case in any cases.json, checked in the case fixture of all five glean test files. key.yaml only works at file level, so disabling one case through the manifest would take out every case in that file. The skip runs before the driver fixture, so no browser starts and the case is left out of the TestRail run instead of being reported. Nothing uses it in this PR,  the mechanism is inert.
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

-  Correct skip_if_unstable docstring. That wording is wrong and will be corrected with batch 3, to avoid re-running the whole glean job for a comment. 
- Create a Glean documentation

### Workflow Checklist

- [z] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
