### PR TITLE
Akash/ Add test_find_toolbar_persists_after_back_forward

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -575,6 +575,10 @@ find_toolbar:
     splits:
     - smoke
     - ci-extended
+  test_find_toolbar_persists_after_back_forward:
+    result: pass
+    splits:
+    - functional1
   test_find_toolbar_search:
     result: pass
     splits:

--- a/modules/browser_object_navigation.py
+++ b/modules/browser_object_navigation.py
@@ -1385,6 +1385,15 @@ class Navigation(BasePage):
         self.get_element("back-button").click()
 
     @BasePage.context_chrome
+    def click_forward_button(self) -> None:
+        """
+        Click the 'Forward' button.
+        Waits until the button is clickable, it is disabled without forward history.
+        """
+        self.element_clickable("forward-button")
+        self.get_element("forward-button").click()
+
+    @BasePage.context_chrome
     def get_library_recently_closed_urls(self, history_open: bool = False):
         """
         Navigate through Library > History > Recently Closed Tabs and extract URLs. This navigates a chain of nested

--- a/modules/data/navigation.components.json
+++ b/modules/data/navigation.components.json
@@ -1130,6 +1130,13 @@
       "doNotCache"
     ]
   },
+  "forward-button": {
+    "selectorData": "forward-button",
+    "strategy": "id",
+    "groups": [
+      "doNotCache"
+    ]
+  },
   "content-area-menu": {
     "selectorData": "browser[contextmenu='contentAreaContextMenu']",
     "strategy": "css",

--- a/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
+++ b/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
@@ -21,31 +21,17 @@ SECOND_PAGE_URL_PART = "wikipedia.org"
 SEARCH_TERM = "firefox"
 
 
-@pytest.fixture()
-def temp_selectors():
-    return {
-        "forward-button": {
-            "selectorData": "forward-button",
-            "strategy": "id",
-            "groups": ["doNotCache"],
-        },
-    }
-
-
 def test_find_toolbar_persists_after_back_forward(
     driver: Firefox,
     find_toolbar: FindToolbar,
-    temp_selectors: dict,
 ):
     """
     C127261: Verify that navigation back and forward on a page works properly
 
     Arguments:
         find_toolbar: instantiation of FindToolbar BOM.
-        temp_selectors: the forward button, next to the URL bar.
     """
     nav = Navigation(driver)
-    nav.elements |= temp_selectors
 
     # Visit two pages in the same tab, so there is history in both directions
     GenericPage(driver, url=FIRST_PAGE).open()

--- a/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
+++ b/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
@@ -54,29 +54,24 @@ def test_find_toolbar_persists_after_back_forward(
     find_toolbar.open_with_key_combo()
     find_toolbar.find(SEARCH_TERM)
 
-    def find_toolbar_persists():
-        """The findbar is still open and still holds the search term"""
+    def shows_search_term(_):
+        """The findbar is torn down and rebuilt while the page loads"""
+        try:
+            find_bar = find_toolbar.get_element("find-toolbar-input")
+            return (
+                find_bar.is_displayed()
+                and find_bar.get_property("value") == SEARCH_TERM
+            )
+        except (NoSuchElementException, StaleElementReferenceException):
+            return False
 
-        def shows_search_term(_):
-            """The findbar is torn down and rebuilt while the page loads"""
-            try:
-                find_bar = find_toolbar.get_element("find-toolbar-input")
-                return (
-                    find_bar.is_displayed()
-                    and find_bar.get_property("value") == SEARCH_TERM
-                )
-            except (NoSuchElementException, StaleElementReferenceException):
-                return False
-
-        find_toolbar.expect(shows_search_term)
-
-    # Back to the previous page
+    # Back to the previous page, the findbar stays open with the term in it
     nav.click_back_button()
     page.url_contains(FIRST_PAGE_URL_PART)
-    find_toolbar_persists()
+    find_toolbar.expect(shows_search_term)
 
     # Forward to the next page
     nav.element_clickable("forward-button")
     nav.click_on("forward-button")
     page.url_contains(SECOND_PAGE_URL_PART)
-    find_toolbar_persists()
+    find_toolbar.expect(shows_search_term)

--- a/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
+++ b/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
@@ -57,7 +57,6 @@ def test_find_toolbar_persists_after_back_forward(
     find_toolbar.expect(shows_search_term)
 
     # Forward to the next page
-    nav.element_clickable("forward-button")
-    nav.click_on("forward-button")
+    nav.click_forward_button()
     nav.url_contains(SECOND_PAGE_URL_PART)
     find_toolbar.expect(shows_search_term)

--- a/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
+++ b/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
@@ -1,0 +1,82 @@
+import pytest
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+)
+from selenium.webdriver import Firefox
+
+from modules.browser_object import FindToolbar, Navigation
+from modules.page_object_generics import GenericPage
+
+
+@pytest.fixture()
+def test_case():
+    return "127261"
+
+
+FIRST_PAGE = "https://www.mozilla.org/en-US/"
+FIRST_PAGE_URL_PART = "mozilla.org"
+SECOND_PAGE = "https://en.wikipedia.org/wiki/Firefox"
+SECOND_PAGE_URL_PART = "wikipedia.org"
+SEARCH_TERM = "firefox"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "forward-button": {
+            "selectorData": "forward-button",
+            "strategy": "id",
+            "groups": ["doNotCache"],
+        },
+    }
+
+
+def test_find_toolbar_persists_after_back_forward(
+    driver: Firefox,
+    find_toolbar: FindToolbar,
+    temp_selectors: dict,
+):
+    """
+    C127261: Verify that navigation back and forward on a page works properly
+
+    Arguments:
+        find_toolbar: instantiation of FindToolbar BOM.
+        temp_selectors: the forward button, next to the URL bar.
+    """
+    nav = Navigation(driver)
+    nav.elements |= temp_selectors
+
+    # Visit two pages in the same tab, so there is history in both directions
+    GenericPage(driver, url=FIRST_PAGE).open()
+    page = GenericPage(driver, url=SECOND_PAGE).open()
+
+    find_toolbar.open_with_key_combo()
+    find_toolbar.find(SEARCH_TERM)
+
+    def find_toolbar_persists():
+        """The findbar is still open and still holds the search term"""
+
+        def shows_search_term(_):
+            """The findbar is torn down and rebuilt while the page loads"""
+            try:
+                find_bar = find_toolbar.get_element("find-toolbar-input")
+                return (
+                    find_bar.is_displayed()
+                    and find_bar.get_property("value") == SEARCH_TERM
+                )
+            except (NoSuchElementException, StaleElementReferenceException):
+                return False
+
+        find_toolbar.expect(shows_search_term)
+
+    # Back to the previous page
+    nav.click_back_button()
+    page.url_contains(FIRST_PAGE_URL_PART)
+    find_toolbar_persists()
+
+    # Forward to the next page
+    nav.element_clickable("forward-button")
+    nav.click_on("forward-button")
+    page.url_contains(SECOND_PAGE_URL_PART)
+    find_toolbar_persists()

--- a/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
+++ b/tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py
@@ -49,7 +49,7 @@ def test_find_toolbar_persists_after_back_forward(
 
     # Visit two pages in the same tab, so there is history in both directions
     GenericPage(driver, url=FIRST_PAGE).open()
-    page = GenericPage(driver, url=SECOND_PAGE).open()
+    GenericPage(driver, url=SECOND_PAGE).open()
 
     find_toolbar.open_with_key_combo()
     find_toolbar.find(SEARCH_TERM)
@@ -67,11 +67,11 @@ def test_find_toolbar_persists_after_back_forward(
 
     # Back to the previous page, the findbar stays open with the term in it
     nav.click_back_button()
-    page.url_contains(FIRST_PAGE_URL_PART)
+    nav.url_contains(FIRST_PAGE_URL_PART)
     find_toolbar.expect(shows_search_term)
 
     # Forward to the next page
     nav.element_clickable("forward-button")
     nav.click_on("forward-button")
-    page.url_contains(SECOND_PAGE_URL_PART)
+    nav.url_contains(SECOND_PAGE_URL_PART)
     find_toolbar.expect(shows_search_term)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2013516](https://bugzilla.mozilla.org/show_bug.cgi?id=2013516)
TestRail: [127261](https://mozilla.testrail.io/index.php?/cases/view/127261)

### Description of Code / Doc Changes

- Adds `tests/find_toolbar/test_find_toolbar_persists_after_back_forward.py`, covering C127261, the Find Toolbar stays open with the search term after navigating back and forward.
- Registers the test in `manifests/key.yaml` under the `functional1` split.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): Navigation (adds the `forward-button` selector and `click_forward_button()`)
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The findbar input drops out of the DOM for a moment while the back / forward navigation finishes, so a single visibility check was flaky. The persistence check polls until the input is displayed with the search term still in it.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!