### PR TITLE
Hani/ Fix test trackers cryptominers fingerprinters

### DIFF
--- a/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
+++ b/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
@@ -4,6 +4,8 @@ from selenium.webdriver import Firefox
 from modules.browser_object import TrustPanel
 from modules.page_object import AboutPrefs, GenericPage
 
+MAX_ATTEMPTS = 3
+
 
 @pytest.fixture()
 def test_case():
@@ -36,4 +38,15 @@ def test_trackers_cryptominers_fingerprinters_blocked(
     trust_panel.trackers_detected("tracking-content")
 
     # The Cross-Site Tracking Cookies, Fingerprinters and Cryptominers are displayed "Blocked"
-    trust_panel.trackers_blocked("tracking-cookies", "cryptominer", "fingerprinter")
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            trust_panel.trackers_blocked(
+                "tracking-cookies", "cryptominer", "fingerprinter"
+            )
+            break
+        except AssertionError:
+            if attempt == MAX_ATTEMPTS:
+                raise
+            tracker_page.open()
+            trust_panel.open_panel()
+            trust_panel.wait_for_trackers(require_count=True)

--- a/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
+++ b/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
@@ -34,12 +34,13 @@ def test_trackers_cryptominers_fingerprinters_blocked(
     trust_panel.open_panel()
     trust_panel.wait_for_trackers(require_count=True)
 
-    # The Tracking Content is NOT blocked
-    trust_panel.trackers_detected("tracking-content")
-
-    # The Cross-Site Tracking Cookies, Fingerprinters and Cryptominers are displayed "Blocked"
     for attempt in range(1, MAX_ATTEMPTS + 1):
         try:
+            # The Tracking Content is NOT blocked
+            trust_panel.trackers_detected("tracking-content")
+
+            # The Cross-Site Tracking Cookies, Fingerprinters and Cryptominers
+            # are displayed "Blocked"
             trust_panel.trackers_blocked(
                 "tracking-cookies", "cryptominer", "fingerprinter"
             )

--- a/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
+++ b/tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py
@@ -35,12 +35,11 @@ def test_trackers_cryptominers_fingerprinters_blocked(
     trust_panel.wait_for_trackers(require_count=True)
 
     for attempt in range(1, MAX_ATTEMPTS + 1):
-        try:
-            # The Tracking Content is NOT blocked
-            trust_panel.trackers_detected("tracking-content")
+        # The Tracking Content is NOT blocked. Not retried: a failure is a regression.
+        trust_panel.trackers_detected("tracking-content")
 
-            # The Cross-Site Tracking Cookies, Fingerprinters and Cryptominers
-            # are displayed "Blocked"
+        # The Cross-Site Tracking Cookies, Fingerprinters and Cryptominers are "Blocked"
+        try:
             trust_panel.trackers_blocked(
                 "tracking-cookies", "cryptominer", "fingerprinter"
             )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2067766](https://bugzilla.mozilla.org/show_bug.cgi?id=2067766)

### Description of Code / Doc Changes

* Fix tests/security_and_privacy/test_trackers_cryptominers_fingerprinters_blocked.py on Windows
* What fails:`trust_panel.trackers_blocked("tracking-cookies", "cryptominer", "fingerprinter")` intermittently raises `AssertionError: Trackers (...) not blocked` in CI.
* trackers_in_category() uses a fixed sleep(0.5) before reading the blocked-items list, which isn't always enough time for Firefox to finish categorizing trackers after wait_for_trackers() confirms a count. A proper fix would poll via wait.until(...) instead, but I think we tried this also before and didn't work as expected 
* Each retry reloads the page and re-runs the detection cycle, giving classification much more time to settle than the original 0.5s window, masking the timing gap rather than fixing it directly.

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
