### PR TITLE
Anca/ Glean add sap count third batch 

### DIFF
--- a/tests/glean/sap_counts/cases.json
+++ b/tests/glean/sap_counts/cases.json
@@ -41,6 +41,26 @@
     {"id": "3255606", "entry": "contextmenu", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"provider_id": "qwant", "source": "contextmenu"}},
     {"id": "3255626", "entry": "contextmenu", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"provider_id": "ecosia", "source": "contextmenu"}},
 
-    {"id": "3255560", "entry": "contextmenu_visual", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "contextmenu_visual"}}
+    {"id": "3255560", "entry": "contextmenu_visual", "params": {"engine": "Google"}, "prefs": [], "expected": {"provider_id": "google", "source": "contextmenu_visual"}},
+
+    {"id": "3255557", "entry": "urlbar", "params": {"engine": "Google"}, "prefs": [["browser.search.region", "DE"]], "expected": {"partner_code": "firefox-b-d", "provider_id": "google", "provider_name": "Google"}},
+    {"id": "3255558", "entry": "urlbar", "params": {"engine": "Google"}, "prefs": [["browser.search.region", "CA"]], "expected": {"partner_code": "firefox-b-d", "provider_id": "google", "provider_name": "Google"}},
+    {"id": "3255559", "entry": "urlbar", "params": {"engine": "Google"}, "prefs": [["browser.search.region", "US"]], "expected": {"partner_code": "firefox-b-1-d", "provider_id": "google", "provider_name": "Google"}},
+
+    {"id": "3255570", "entry": "urlbar", "params": {"engine": "Bing"}, "prefs": [["browser.search.region", "DE"]], "expected": {"partner_code": "MOZI", "provider_id": "bing", "provider_name": "Bing"}},
+    {"id": "3255571", "entry": "urlbar", "params": {"engine": "Bing"}, "prefs": [["browser.search.region", "CA"]], "expected": {"partner_code": "MOZI", "provider_id": "bing", "provider_name": "Bing"}},
+    {"id": "3255572", "entry": "urlbar", "params": {"engine": "Bing"}, "prefs": [["browser.search.region", "US"]], "expected": {"partner_code": "MOZI", "provider_id": "bing", "provider_name": "Bing"}},
+
+    {"id": "3255582", "entry": "urlbar", "params": {"engine": "DuckDuckGo"}, "prefs": [["browser.search.region", "DE"]], "expected": {"partner_code": "ffab", "provider_id": "ddg", "provider_name": "DuckDuckGo"}},
+    {"id": "3255583", "entry": "urlbar", "params": {"engine": "DuckDuckGo"}, "prefs": [["browser.search.region", "CA"]], "expected": {"partner_code": "ffab", "provider_id": "ddg", "provider_name": "DuckDuckGo"}},
+    {"id": "3255584", "entry": "urlbar", "params": {"engine": "DuckDuckGo"}, "prefs": [["browser.search.region", "US"]], "expected": {"partner_code": "ffab", "provider_id": "ddg", "provider_name": "DuckDuckGo"}},
+
+    {"id": "3255594", "entry": "urlbar", "params": {"engine": "Perplexity"}, "prefs": [["browser.search.region", "DE"]], "expected": {"partner_code": "firefox", "provider_id": "perplexity", "provider_name": "Perplexity"}},
+    {"id": "3255595", "entry": "urlbar", "params": {"engine": "Perplexity"}, "prefs": [["browser.search.region", "CA"]], "expected": {"partner_code": "firefox", "provider_id": "perplexity", "provider_name": "Perplexity"}},
+    {"id": "3255596", "entry": "urlbar", "params": {"engine": "Perplexity"}, "prefs": [["browser.search.region", "US"]], "expected": {"partner_code": "firefox", "provider_id": "perplexity", "provider_name": "Perplexity"}},
+
+    {"id": "3255605", "entry": "urlbar", "params": {"engine": "Qwant"}, "prefs": [["browser.search.region", "FR"]], "expected": {"partner_code": "brz-moz", "provider_id": "qwant", "provider_name": "Qwant"}},
+
+    {"id": "3255625", "entry": "urlbar", "params": {"engine": "Ecosia"}, "prefs": [["browser.search.region", "DE"]], "expected": {"partner_code": "mzl", "provider_id": "ecosia", "provider_name": "Ecosia"}}
   ]
 }

--- a/tests/glean/utils.py
+++ b/tests/glean/utils.py
@@ -15,8 +15,9 @@ def skip_if_unstable(case: dict) -> None:
     """Skip a case carrying an `unstable` reason string in cases.json.
 
     `key.yaml` can only mark a whole test file, so per-case stability lives in the
-    dataset. Called from the `case` fixture, so this runs before `driver` and reports
-    as Untested, not Blocked.
+    dataset. Called from the `case` fixture, so this runs before `driver` writes
+    `json_metadata["test_case"]`. Without it the case is not reported to TestRail at
+    all, the same as a test skipped through the manifest.
     """
     reason = case.get("unstable")
     if reason:


### PR DESCRIPTION
### Relevant Links

Bugzilla: [14 test cases ](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=2032850%2C%202032851%2C%202032852%2C%202032861%2C%202032862%2C%202032863%2C%202032871%2C%202032872%2C%202032873%2C%202032887%2C%202032888%2C%202032889%2C%202032896%2C%202032904&list_id=18100735)
TestRail: _

### Description of Code / Doc Changes

- Third batch of sap.counts coverage: 14 cases asserting `partner_code`, `provider_id` and `provider_name`. Batch 1 (#1601) covered Google, Bing and DuckDuckGo on the search access points, batch 2 (#1608) added Perplexity, Qwant and Ecosia.
- No new metric or flow. `sap.counts` already carries these as event extras (`browser/components/search/metrics.yaml`: `source`, `provider_id`, `provider_name`, `partner_code`, `overridden_by_third_party`), so only the `expected` set differs from the existing cases.
- Each engine is covered in DE, CA and US to confirm `partner_code` doesn't vary by region. Google is the exception that makes the check meaningful: `firefox-b-d` in DE and CA, `firefox-b-1-d` in US. Qwant and Ecosia are region-gated, so each has a case only where it is available FR and DE.
- Correct the `skip_if_unstable` docstring from #1608, as promised

### Process Changes Required


_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
