### PR TITLE
Akash/ Add test_find_on_page_with_rtl_language

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -566,6 +566,10 @@ find_toolbar:
     result: pass
     splits:
     - functional1
+  test_find_on_page_with_rtl_language:
+    result: pass
+    splits:
+    - functional1
   test_find_text_on_buttons:
     result: pass
     splits:

--- a/modules/browser_object_find_toolbar.py
+++ b/modules/browser_object_find_toolbar.py
@@ -48,6 +48,18 @@ class FindToolbar(BasePage):
         return self
 
     @BasePage.context_chrome
+    def type_in_find_bar(self, term: str) -> BasePage:
+        """Type into the find bar without submitting the search"""
+        self.get_element("find-toolbar-input").send_keys(term)
+        return self
+
+    @BasePage.context_chrome
+    def delete_chars_from_find_bar(self, count: int) -> BasePage:
+        """Backspace over the last `count` characters in the find bar"""
+        self.get_element("find-toolbar-input").send_keys(Keys.BACK_SPACE * count)
+        return self
+
+    @BasePage.context_chrome
     def get_match_args(self) -> dict:
         """Return the status of the find session"""
         self.expect(

--- a/tests/find_toolbar/test_find_on_page_with_rtl_language.py
+++ b/tests/find_toolbar/test_find_on_page_with_rtl_language.py
@@ -1,0 +1,74 @@
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+
+from modules.browser_object import FindToolbar
+
+
+@pytest.fixture()
+def test_case():
+    return "127251"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Make sure the site is served in Arabic"""
+    return [("intl.accept_languages", "ar")]
+
+
+TARGET_PAGE = "https://ar.wikipedia.org/wiki/موزيلا_فايرفوكس"
+SEARCH_TERM = "الش"
+EXTRA_CHARS = "ركة"
+MIN_MATCHES = 5  # the page had 13 matches when the test was written
+
+
+def test_find_on_page_with_rtl_language(
+    driver: Firefox, find_toolbar: FindToolbar, current_match: str
+):
+    """
+    C127251: Verify that searching on a page with RTL language works properly
+
+    Arguments:
+        find_toolbar: instantiation of FindToolbar BOM.
+        current_match: script returning info about the currently highlighted match.
+    """
+    driver.get(TARGET_PAGE)
+    find_toolbar.open_with_key_combo()
+
+    # Typing and deleting RTL characters works
+    with driver.context(driver.CONTEXT_CHROME):
+        find_input = find_toolbar.get_element("find-toolbar-input")
+        find_input.send_keys(SEARCH_TERM + EXTRA_CHARS)
+        assert find_input.get_property("value") == SEARCH_TERM + EXTRA_CHARS
+        find_input.send_keys(Keys.BACK_SPACE * len(EXTRA_CHARS))
+        assert find_input.get_property("value") == SEARCH_TERM
+
+    # Every match of the RTL search term is found
+    find_toolbar.find(SEARCH_TERM)
+    total_matches = find_toolbar.match_dict["total"]
+    assert total_matches >= MIN_MATCHES
+
+    # The searched text is the only highlight
+    find_toolbar.rewind_to_first_match()
+    first_match = WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(current_match)
+    )
+    assert first_match[0] == SEARCH_TERM
+    assert first_match[1] == 1
+
+    # F3 moves the highlight forward, SHIFT+F3 moves it back
+    find_toolbar.navigate_matches_by_keys()
+    WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(current_match) not in (None, first_match)
+    )
+    find_toolbar.navigate_matches_by_keys(backwards=True)
+    WebDriverWait(driver, 10).until(
+        lambda d: d.execute_script(current_match) == first_match
+    )
+
+    # Scrolling up and down leaves the search session intact
+    driver.execute_script("window.scrollBy(0, 2000)")
+    driver.execute_script("window.scrollTo(0, 0)")
+    assert driver.execute_script(current_match) == first_match
+    assert find_toolbar.get_match_args()["total"] == total_matches

--- a/tests/find_toolbar/test_find_on_page_with_rtl_language.py
+++ b/tests/find_toolbar/test_find_on_page_with_rtl_language.py
@@ -1,6 +1,5 @@
 import pytest
 from selenium.webdriver import Firefox
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
 from modules.browser_object import FindToolbar
@@ -36,20 +35,27 @@ def test_find_on_page_with_rtl_language(
     driver.get(TARGET_PAGE)
     find_toolbar.open_with_key_combo()
 
-    # Typing and deleting RTL characters works
-    with driver.context(driver.CONTEXT_CHROME):
-        find_input = find_toolbar.get_element("find-toolbar-input")
-        find_input.send_keys(SEARCH_TERM + EXTRA_CHARS)
-        assert find_input.get_property("value") == SEARCH_TERM + EXTRA_CHARS
-        find_input.send_keys(Keys.BACK_SPACE * len(EXTRA_CHARS))
-        assert find_input.get_property("value") == SEARCH_TERM
+    # Typing RTL characters into the find bar works
+    find_toolbar.type_in_find_bar(SEARCH_TERM + EXTRA_CHARS)
+    assert (
+        find_toolbar.get_attribute_value("find-toolbar-input", "value")
+        == SEARCH_TERM + EXTRA_CHARS
+    )
+
+    # Deleting them works too
+    find_toolbar.delete_chars_from_find_bar(len(EXTRA_CHARS))
+    assert (
+        find_toolbar.get_attribute_value("find-toolbar-input", "value") == SEARCH_TERM
+    )
 
     # Every match of the RTL search term is found
     find_toolbar.find(SEARCH_TERM)
     total_matches = find_toolbar.match_dict["total"]
     assert total_matches >= MIN_MATCHES
 
-    # The searched text is the only highlight
+    # The searched text is the only highlight.
+    # Selenium cannot read the find highlight, so current_match runs JS returning the
+    # page selection as [text, range count, text node index, offset].
     find_toolbar.rewind_to_first_match()
     first_match = WebDriverWait(driver, 10).until(
         lambda d: d.execute_script(current_match)
@@ -57,7 +63,8 @@ def test_find_on_page_with_rtl_language(
     assert first_match[0] == SEARCH_TERM
     assert first_match[1] == 1
 
-    # F3 moves the highlight forward, SHIFT+F3 moves it back
+    # F3 moves the highlight forward, SHIFT+F3 moves it back.
+    # Re-running current_match shows which match the selection sits on now.
     find_toolbar.navigate_matches_by_keys()
     WebDriverWait(driver, 10).until(
         lambda d: d.execute_script(current_match) not in (None, first_match)
@@ -67,8 +74,10 @@ def test_find_on_page_with_rtl_language(
         lambda d: d.execute_script(current_match) == first_match
     )
 
-    # Scrolling up and down leaves the search session intact
+    # Scrolling up and down leaves the search session intact.
+    # These scripts scroll the page down 2000px, then back to the top.
     driver.execute_script("window.scrollBy(0, 2000)")
     driver.execute_script("window.scrollTo(0, 0)")
+    # current_match again: the scroll should not have moved the selection
     assert driver.execute_script(current_match) == first_match
     assert find_toolbar.get_match_args()["total"] == total_matches


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2013515](https://bugzilla.mozilla.org/show_bug.cgi?id=2013515)
TestRail: [127251](https://mozilla.testrail.io/index.php?/cases/view/127251)

### Description of Code / Doc Changes

- Adds `tests/find_toolbar/test_find_on_page_with_rtl_language.py` for C127251, searching an Arabic Wikipedia page with the Find Toolbar.
- Registers the test in `manifests/key.yaml` under the `functional1` split.
- Adds `type_in_find_bar` and `delete_chars_from_find_bar` to the `FindToolbar` BOM, both in the chrome context.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): `FindToolbar`
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Same shape as the existing `test_find_word_with_special_characters` tests. Step 4's caret-on-the-left check stays manual as the findbar input exposes no RTL signal to WebDriver.

Didn't reuse `BasePage.fill` as it leaves the chrome context set, which breaks the later page reads.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!