### PR TITLE
Bug 2066865 - Upload test artifacts on non-PR runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -280,7 +280,7 @@ jobs:
           exit $env:TEST_EXIT_CODE
 
       - name: Upload artifacts
-        if: ${{ always() && github.event_name == 'pull_request' && inputs.dry_run != true }}
+        if: ${{ always() && inputs.dry_run != true }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
         with:
           name: artifacts-win${{ inputs.test_set == 'glean' && '-glean' || '' }}
@@ -438,7 +438,7 @@ jobs:
           exit $TEST_EXIT_CODE
 
       - name: Upload artifacts
-        if: ${{ always() && github.event_name == 'pull_request' && inputs.dry_run != true }}
+        if: ${{ always() && inputs.dry_run != true }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
         with:
           name: artifacts-mac${{ inputs.test_set == 'glean' && '-glean' || '' }}
@@ -537,6 +537,13 @@ jobs:
           if [[ -n "$XVFB_PID" ]]; then kill -9 "$XVFB_PID"; fi;
           xvfb-run -f "$HOME/.Xauthority" -s "-screen 0 1600x1200x24" uv run pytest --fx-executable="$FX_EXECUTABLE" --geckodriver=geckodriver $(cat selected_tests) || TEST_EXIT_CODE=$?;
           exit $TEST_EXIT_CODE
+
+      - name: Upload artifacts
+        if: ${{ always() && inputs.dry_run != true }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
+        with:
+          name: artifacts-linux${{ inputs.test_set == 'glean' && '-glean' || '' }}
+          path: artifacts
 
   Use-Artifacts:
     if: ${{ github.event_name != 'workflow_dispatch' }}


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2066865](https://bugzilla.mozilla.org/show_bug.cgi?id=2066865) (blocks [2065220](https://bugzilla.mozilla.org/show_bug.cgi?id=2065220) — Finalize Nightly quality gates with STARfox)
Phabricator (mozilla-central counterpart): [D323010](https://phabricator.services.mozilla.com/D323010)

### Description of Code / Doc Changes

The `dte-test` tasks in the Firefox Nightly release graph invoke this workflow via `workflow_dispatch`, but those runs published **no artifacts at all**, so there was nothing for Taskcluster to fetch back into the release graph.

* `Test-Windows` / `Test-MacOS`: dropped the `github.event_name == 'pull_request'` clause from the `Upload artifacts` step, so uploads happen on `workflow_dispatch` (and `schedule`) too, not only on PRs.
* `Smoke-Linux`: added the `Upload artifacts` step, which it never had. Publishes `artifacts-linux` from `artifacts/` (this job doesn't move reports into a per-platform dir the way Windows/macOS do).
* Both keep `always() && inputs.dry_run != true`, so a **failing** run still leaves its reports behind — that's the case the reports are most needed for.

### Process Changes Required

- [x] Changes CI flow

### Screenshots or Explanations

**Heads up for reviewers: a green PR here does not verify this change.** PR runs reach `main.yml` through `ci-dispatch.yml` with `github.event_name == 'pull_request'`, which is the one condition that was already true. The PR path uploaded artifacts before this change and will after. Only a `workflow_dispatch` run exercises what's being fixed.

So it was verified by dispatching this branch directly, covering both conclusions:

| Run | `test_set` | Result | Artifacts |
|---|---|---|---|
| [33661349923](https://github.com/mozilla/fx-desktop-qa-automation/actions/runs/33661349923) | `smoke` | **failure** (62 passed / 3 failed) | `artifacts-linux`, 2.2 MB |
| [33662409153](https://github.com/mozilla/fx-desktop-qa-automation/actions/runs/33662409153) | `ci` | success | `artifacts-linux` |

For comparison, the three real Nightly-triggered runs from 2026-08-31/09-01 (`33452069518`, `33454328050`, `33460070514`) all report `total_count: 0`.

The failing run's artifact contains `report.json`, `report.html`, the headed equivalents, and per-failure screenshots plus chrome/content logs for every retry — which is exactly the debugging material bug 2066865 needs to land in the release graph.

`actionlint` reports the same 12 pre-existing shellcheck findings before and after this change; no new ones.

### Comments or Future Work

* The mozilla-central side ([D323010](https://phabricator.services.mozilla.com/D323010)) downloads these artifacts and republishes them as a `public/starfox` Taskcluster artifact. **This PR should land first** — until it does, that script correctly finds nothing and logs a warning.
* The 3 failures in the `smoke` run above are pre-existing and unrelated. Production currently runs `test_set: ci`, so they don't affect the gate today, but they will once bug 2065220 flips `TEST_SET` to `nightly`.
* `Use-Artifacts` is left alone. It's currently unreachable in every path (it `needs` both `Test-Windows` and `Test-MacOS`, and each caller runs only one of them, so it is always skipped). Worth a separate look, out of scope here.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.

Thank you!

