### PR TITLE
Akash/ Update test_set_always_ask_file_type for +152

### DIFF
--- a/tests/downloads/test_set_always_ask_file_type.py
+++ b/tests/downloads/test_set_always_ask_file_type.py
@@ -1,44 +1,36 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object import Navigation
+from modules.browser_object import Navigation, TabBar
 from modules.page_object import AboutPrefs
 
 
 @pytest.fixture()
 def test_case():
-    return "1756752"
+    return "4108462"
 
 
-@pytest.fixture()
-def delete_files_regex_string():
-    return r"pdf-example-bookmarks.pdf"
-
-
-CONTENT_DISPOSITION_ATTACHMENT_URL = (
-    "https://download.novapdf.com/download/samples/pdf-example-bookmarks.pdf"
-)
-
-
-def test_set_always_ask_file_type(driver: Firefox, delete_files):
+def test_set_always_ask_file_type(driver: Firefox, fillable_pdf_url: str):
     """
-    C1756752 - Ensure that the Always ask option in Firefox Applications settings
-    leads to a dialog asking "What should Firefox do with this file?" when the file type
-    is downloaded.
+    C4108462 - Verify that setting PDF handling to "Always ask" makes a PDF
+    download show the "What should Firefox do with this file?" dialog.
     """
 
-    # Initialize page objects
+    # Instantiate objects
     nav = Navigation(driver)
-    # Moved the Applications file-handlers list
-    # from the General pane to about:preferences#downloads.
+    tabs = TabBar(driver)
+    # The settings redesign (bug 2043378) moved file handlers to this pane
     about_prefs = AboutPrefs(driver, category="downloads")
 
     # Set PDF handling to "Always ask"
     about_prefs.open()
     about_prefs.set_pdf_handling_to_always_ask()
 
-    # Navigate to download URL and verify dialog appears
-    nav.search(CONTENT_DISPOSITION_ATTACHMENT_URL)
+    # Download the PDF again from a new tab
+    tabs.new_tab_by_button()
+    tabs.wait_for_num_tabs(2)
+    driver.switch_to.window(driver.window_handles[-1])
+    nav.search(fillable_pdf_url)
 
-    # Wait for and handle the unknown content type dialog
+    # The dialog opens in its own window, Escape cancels out of it
     about_prefs.handle_unknown_content_dialog()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047093](https://bugzilla.mozilla.org/show_bug.cgi?id=2047093)
TestRail: [4108462](https://mozilla.testrail.io/index.php?/cases/view/4108462)

### Description of Code / Doc Changes

- Points the test at C4108462, the 152+ version of the case. The old C1756752 is scoped to pre 152 Settings.
- Downloads the i-9 PDF via the shared `fillable_pdf_url` fixture instead of the third party novapdf sample.
- Adds step 2 of the case: open a new tab, switch to it, then load the PDF from there.
- Drops `delete_files`, since cancelling the dialog never saves a file.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model):
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

`key.yaml` needs no change: same file name, still `result: pass`.

Passed 3/3 local runs on macOS.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!