### PR TITLE
Akash/ Update test_add_zip_type for +152

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -472,8 +472,7 @@ downloads:
     splits:
     - functional1
   test_add_zip_type:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2043378
-    result: unstable
+    result: pass
     splits:
     - functional1
   test_change_download_folder:

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -21,7 +21,7 @@ def delete_files_regex_string():
 def temp_selectors():
     return {
         "zip-download-link": {
-            "selectorData": "a[href$='.zip']",
+            "selectorData": "a[href$='Firefox-win32-0.9rc.zip']",
             "strategy": "css",
             "groups": [],
         },

--- a/tests/downloads/test_add_zip_type.py
+++ b/tests/downloads/test_add_zip_type.py
@@ -1,68 +1,57 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.browser_object_navigation import Navigation
-from modules.page_object_generics import GenericPage
-from modules.page_object_prefs import AboutPrefs
+from modules.browser_object import Navigation
+from modules.page_object import AboutPrefs, GenericPage
 
-ZIP_URL = "https://github.com/microsoft/api-guidelines"
+ZIP_URL = "https://ftp.mozilla.org/pub/firefox/releases/0.9rc/"
 
 
 @pytest.fixture()
 def test_case():
-    return "1756743"
+    return "4108460"
 
 
 @pytest.fixture()
 def delete_files_regex_string():
-    return r"api-guidelines-vNext"
+    return r"Firefox-win32-0\.9rc.*\.zip"
 
 
 @pytest.fixture()
 def temp_selectors():
     return {
-        "github-code-button": {
-            "strategy": "xpath",
-            "selectorData": "//button[.//span[normalize-space()='Code']]",
-            "groups": [],
-        },
-        "github-download-button": {
-            "selectorData": 'a[href="/microsoft/api-guidelines/archive/refs/heads/vNext.zip"]',
+        "zip-download-link": {
+            "selectorData": "a[href$='.zip']",
             "strategy": "css",
             "groups": [],
         },
     }
 
 
+@pytest.mark.headed
+@pytest.mark.noxvfb
 def test_add_zip_type(
-    driver: Firefox,
-    sys_platform,
-    home_folder,
-    delete_files,
-    temp_selectors,
-    close_file_manager,
+    driver: Firefox, delete_files, temp_selectors, close_file_manager
 ):
     """
-    C1756743: Verify that the user can add the .zip mime type to Firefox
+    C4108460 - Verify that downloading a .zip file adds the .zip MIME type
+    entry to the Files and Applications list.
     """
+
     # Instantiate objects
-    web_page = GenericPage(driver, url=ZIP_URL)
+    page = GenericPage(driver, url=ZIP_URL)
     nav = Navigation(driver)
+    # The settings redesign (bug 2043378) moved file handlers to this pane
     about_prefs = AboutPrefs(driver, category="downloads")
+    page.elements |= temp_selectors
 
-    # Add temporary selectors for GitHub UI
-    web_page.elements |= temp_selectors
+    # Open the release directory listing and download the zip
+    page.open()
+    page.click_on("zip-download-link")
 
-    # Trigger a ZIP download from GitHub
-    web_page.open()
-    web_page.click_on("github-code-button")
-    web_page.click_on("github-download-button")
-
-    # In the download panel right-click on the download and click "Always Open Similar Files"
+    # Download the file and set 'Always Open Similar Files'
     nav.perform_download_context_action("context-menu-always-open-similar-files")
 
-    # Open about:preferences and verify ZIP mime type is present
+    # Check the zip mime type is listed. Its label and app come from the OS
     about_prefs.open()
-    assert about_prefs.get_app_name_for_mime_type("application/zip"), (
-        "ZIP mime type not found in Applications list"
-    )
+    about_prefs.element_exists("mime-type-item", labels=["application/zip"])


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047091](https://bugzilla.mozilla.org/show_bug.cgi?id=2047091)
TestRail: [4108460](https://mozilla.testrail.io/index.php?/cases/view/4108460)

### Description of Code / Doc Changes

- Rewrote `tests/downloads/test_add_zip_type.py` for C4108460. It downloads a zip from the Firefox 0.9rc release listing, sets Always Open Similar Files from the downloads panel, then checks the application/zip entry in Settings, Downloads, Files and Applications.
- Checks the mime type instead of the handler name, since the name comes from the OS.
- Set `test_add_zip_type` to pass in `manifests/key.yaml` and removed the old bug 2043378 comment.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The test is marked `headed` and `noxvfb` because toggling "Always Open Similar Files" can hand the file to an OS archive handler. `close_file_manager` and `delete_files` clean up after it.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.