### PR TITLE
Hani/ Add test tp enable after website removed from exceptions

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1706,6 +1706,10 @@ security_and_privacy:
     result: pass
     splits:
     - smoke
+  test_tp_enabled_after_website_removed_from_exceptions:
+    result: pass
+    splits:
+    - functional3
   test_trackers_counted_correctly_in_panel:
     result: pass
     splits:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -1565,5 +1565,55 @@
       "description": "The \"Firefox Home (Default)\" option inside the New tabs dropdown in About Preferences Home section",
       "location": "About Preferences - Home - Homepage section"
     }
+  },
+  "manage-exceptions-button": {
+    "selectorData": "etpManageExceptionsButton",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "\"Manage Exceptions\" button on the privacy pane; opens the tracking protection exceptions dialog listing sites where ETP is disabled",
+      "location": "about:preferences#privacy"
+    }
+  },
+  "exceptions-dialog-shadow-root": {
+    "selectorData": "dialog[buttons='accept,cancel']",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "The Exceptions for Enhanced Tracking Protection dialog root (is a shadow root); hosts the accept/cancel buttons",
+      "location": "about:preferences#etp (Manage Exceptions dialog, inside browser-popup iframe)"
+    }
+  },
+  "remove-all-websites-button": {
+    "selectorData": "removeAllPermissions",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "\"Remove all websites\" button; clears all ETP exception entries",
+      "location": "about:preferences#etp (Manage Exceptions dialog, inside browser-popup iframe)"
+    }
+  },
+  "remove-website-button": {
+    "selectorData": "removePermission",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "\"Remove Website\" button; removes the currently selected ETP exception entry",
+      "location": "about:preferences#etp (Manage Exceptions dialog, inside browser-popup iframe)"
+    }
+  },
+  "exceptions-save-changes-button": {
+    "selectorData": "[dlgtype='accept']",
+    "strategy": "css",
+    "shadowParent": "exceptions-dialog-shadow-root",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "The Exceptions dialog \"Save Changes\" button",
+      "location": "about:preferences#etp (Manage Exceptions dialog, inside browser-popup iframe)"
+    }
   }
 }

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1696,10 +1696,12 @@ class AboutPrefs(BasePage):
         # Confirm the moz-select actually wrote through to the backing pref —
         # asserting .value alone would be tautological since we just set it.
         self.expect(
-            lambda _: self.driver.execute_script(
-                "return Services.prefs.getStringPref('browser.ai.control.translations', '');"
+            lambda _: (
+                self.driver.execute_script(
+                    "return Services.prefs.getStringPref('browser.ai.control.translations', '');"
+                )
+                == state
             )
-            == state
         )
         return self
 

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1054,14 +1054,24 @@ class AboutPrefs(BasePage):
         self.switch_to_iframe_context(self.get_element("browser-popup"))
         return self
 
+    def _dismiss_open_prefs_dialog(self) -> None:
+        """
+        Close any prefs sub-dialog already showing in the popup iframe.
+
+        The ``browser-popup`` (``.dialogFrame``) element exists even when no
+        dialog is open; a dialog that is actually visible has a positive x
+        offset. This is a fragile heuristic, kept in one place so the
+        popup-dialog helpers don't diverge.
+        """
+        if self.get_iframe().location["x"] > 0:
+            self.click_on("close-dialog")
+
     def press_button_get_popup_dialog_iframe(self, button_label: str) -> WebElement:
         """
         Returns the iframe object for the dialog panel in the popup after pressing some button that
         triggers a popup
         """
-        # hack to know if the current iframe is the default browser one or not
-        if self.get_iframe().location["x"] > 0:
-            self.click_on("close-dialog")
+        self._dismiss_open_prefs_dialog()
         self.click_on("prefs-button", labels=[button_label])
         iframe = self.get_element("browser-popup")
         return iframe
@@ -1534,12 +1544,9 @@ class AboutPrefs(BasePage):
         the dialog's iframe context. Call ``self.switch_to_default_frame()``
         afterward to return to the main page.
         """
-        # hack to know if the current iframe is the default browser one or not
-        if self.get_iframe().location["x"] > 0:
-            self.click_on("close-dialog")
+        self._dismiss_open_prefs_dialog()
         self.js_click_on("manage-exceptions-button")
-        iframe = self.get_element("browser-popup")
-        self.switch_to_iframe_context(iframe)
+        self.switch_to_iframe_context(self.get_element("browser-popup"))
         return self
 
     def remove_all_exceptions_and_save(self) -> BasePage:

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1525,6 +1525,33 @@ class AboutPrefs(BasePage):
         self.js_click_on("homepage-new-tabs-firefox-home-option")
         return self
 
+    def open_manage_exceptions_dialog(self) -> BasePage:
+        """
+        Open the ETP "Manage Exceptions" dialog and switch into its popup iframe.
+
+        Must be called from about:preferences#etp (see ``open_etp_settings``).
+        After calling this method, subsequent element interactions happen within
+        the dialog's iframe context. Call ``self.switch_to_default_frame()``
+        afterward to return to the main page.
+        """
+        # hack to know if the current iframe is the default browser one or not
+        if self.get_iframe().location["x"] > 0:
+            self.click_on("close-dialog")
+        self.js_click_on("manage-exceptions-button")
+        iframe = self.get_element("browser-popup")
+        self.switch_to_iframe_context(iframe)
+        return self
+
+    def remove_all_exceptions_and_save(self) -> BasePage:
+        """
+        From inside the ETP "Manage Exceptions" dialog iframe, remove every
+        exception entry and save the changes. Returns to the default frame.
+        """
+        self.click_on("remove-all-websites-button")
+        self.click_on("exceptions-save-changes-button")
+        self.switch_to_default_frame()
+        return self
+
     # ── AI Controls ──────────────────────────────────────────────────────
 
     def toggle_ai_killswitch_click(self) -> BasePage:

--- a/tests/ai_controls/test_c3298824_block_all_persists.py
+++ b/tests/ai_controls/test_c3298824_block_all_persists.py
@@ -30,10 +30,12 @@ def test_block_all_ai_features_option_persists(about_prefs: AboutPrefs):
         "Services.prefs.setStringPref('browser.ai.control.translations', 'available');"
     )
     about_prefs.expect(
-        lambda _: about_prefs.driver.execute_script(
-            "return Services.prefs.getStringPref('browser.ai.control.translations', '');"
+        lambda _: (
+            about_prefs.driver.execute_script(
+                "return Services.prefs.getStringPref('browser.ai.control.translations', '');"
+            )
+            == "available"
         )
-        == "available"
     )
 
     # Enabling an individual feature must NOT clear the global Block-all toggle.

--- a/tests/security_and_privacy/test_tp_enabled_after_website_removed_from_exceptions.py
+++ b/tests/security_and_privacy/test_tp_enabled_after_website_removed_from_exceptions.py
@@ -1,0 +1,55 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TabBar
+from modules.browser_object_trust_panel import TrustPanel
+from modules.page_object_generics import GenericPage
+from modules.page_object_prefs import AboutPrefs
+
+TEST_WEBSITE = "https://edition.cnn.com/"
+
+
+@pytest.fixture()
+def test_case():
+    return "446435"
+
+
+def test_tp_enabled_after_website_removed_from_exceptions(
+    driver: Firefox,
+    trust_panel: TrustPanel,
+    tabs: TabBar,
+):
+    """
+    C446435 - TP gets enabled if a website is removed from Exceptions
+    """
+
+    # Instantiate objects
+    test_page = GenericPage(driver, url=TEST_WEBSITE)
+    about_prefs = AboutPrefs(driver, category="privacy")
+
+    # Access test website
+    test_page.open()
+
+    # Click on the shield icon and turn off Tracking protection via toggle button
+    trust_panel.open_panel()
+    trust_panel.trustpanel_toggle_on_off()
+
+    # Site reloads; the shield icon reflects the disabled state
+    trust_panel.element_visible("shield-icon-disabled")
+
+    # Visit "about:preferences#privacy" and click on the "Manage Exceptions..." button
+    about_prefs.open()
+    about_prefs.open_etp_settings()
+    about_prefs.open_manage_exceptions_dialog()
+
+    # Click on the "Remove Website" button from the dialog and save changes
+    about_prefs.remove_all_exceptions_and_save()
+
+    # Access again https://edition.cnn.com/ in a new tab
+    tabs.open_and_switch_to_new_tab()
+    test_page.open()
+
+    # The website is accessed and the shield icon has a "✓" in it (ETP re-enabled)
+    trust_panel.open_panel()
+    trust_panel.trustpanel_status("on")
+    trust_panel.element_visible("trustpanel-header-enabled")

--- a/tests/security_and_privacy/test_tp_enabled_after_website_removed_from_exceptions.py
+++ b/tests/security_and_privacy/test_tp_enabled_after_website_removed_from_exceptions.py
@@ -42,7 +42,7 @@ def test_tp_enabled_after_website_removed_from_exceptions(
     about_prefs.open_etp_settings()
     about_prefs.open_manage_exceptions_dialog()
 
-    # Click on the "Remove Website" button from the dialog and save changes
+    # Click on the "Remove all Website" button from the dialog and save changes
     about_prefs.remove_all_exceptions_and_save()
 
     # Access again https://edition.cnn.com/ in a new tab


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2015758](https://bugzilla.mozilla.org/show_bug.cgi?id=2015758)
TestRail: [446435](https://mozilla.testrail.io/index.php?/cases/view/446435)

### Description of Code / Doc Changes

* Add test to verify that TP gets enabled if a website is removed from Exceptions

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
