### PR TITLE
Akash/ Add test_whats_new_link

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1358,6 +1358,10 @@ preferences:
     result: unstable
     splits:
     - functional2
+  test_whats_new_link:
+    result: pass
+    splits:
+    - functional1
 printing_ui:
   test_page_number_indicator_print_preview:
     result: pass

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -778,6 +778,27 @@
       "description": "shadow root for update state elements"
     }
   },
+  "update-info-root": {
+    "selectorData": "updateAppInfo",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "shadow root for the update-information element (Firefox Updates > version line)",
+      "location": "about:preferences#about"
+    }
+  },
+  "whats-new-link": {
+    "selectorData": "#releasenotes",
+    "strategy": "css",
+    "shadowParent": "update-info-root",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Firefox Updates > \"What's new\" link, opens the release notes",
+      "location": "about:preferences#about"
+    }
+  },
   "update_available_button": {
     "selectorData": "[data-l10n-id='update-updateButton']",
     "strategy": "css",

--- a/tests/preferences/test_whats_new_link.py
+++ b/tests/preferences/test_whats_new_link.py
@@ -1,0 +1,44 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object_prefs import AboutPrefs
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Firefox Updates card lives in Settings > About Firefox.
+    return "about"
+
+
+@pytest.fixture()
+def test_case():
+    return "3374338"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+def test_whats_new_link(driver: Firefox, about_prefs: AboutPrefs):
+    """
+    C3374338 - The "What's new" link in the Firefox Updates card works correctly.
+    """
+    about_prefs.open()
+
+    # Hovering changes the link color, so compare it before and after.
+    default_color = about_prefs.get_element("whats-new-link").value_of_css_property(
+        "color"
+    )
+    about_prefs.hover("whats-new-link")
+    hover_color = about_prefs.get_element("whats-new-link").value_of_css_property(
+        "color"
+    )
+    assert hover_color != default_color, "The What's new link has no hover effect"
+
+    # The link has target="_blank", so the release notes open in a new tab.
+    about_prefs.click_on("whats-new-link")
+    about_prefs.wait_for_num_tabs(2)
+    about_prefs.switch_to_new_tab()
+    about_prefs.url_contains("releasenotes")

--- a/tests/preferences/test_whats_new_link.py
+++ b/tests/preferences/test_whats_new_link.py
@@ -27,6 +27,9 @@ def test_whats_new_link(driver: Firefox, about_prefs: AboutPrefs):
     """
     about_prefs.open()
 
+    # The link points at the release notes for the build under test.
+    release_notes_url = about_prefs.get_element("whats-new-link").get_attribute("href")
+
     # Hovering changes the link color, so compare it before and after.
     default_color = about_prefs.get_element("whats-new-link").value_of_css_property(
         "color"
@@ -41,4 +44,4 @@ def test_whats_new_link(driver: Firefox, about_prefs: AboutPrefs):
     about_prefs.click_on("whats-new-link")
     about_prefs.wait_for_num_tabs(2)
     about_prefs.switch_to_new_tab()
-    about_prefs.url_contains("releasenotes")
+    about_prefs.url_contains(release_notes_url.split("?")[0])

--- a/tests/preferences/test_whats_new_link.py
+++ b/tests/preferences/test_whats_new_link.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver import Firefox
 
-from modules.page_object_prefs import AboutPrefs
+from modules.page_object import AboutPrefs
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047152](https://bugzilla.mozilla.org/show_bug.cgi?id=2047152)
TestRail: [3374338](https://mozilla.testrail.io/index.php?/cases/view/3374338)

### Description of Code / Doc Changes

- Adds `tests/preferences/test_whats_new_link.py` for C3374338.
- Adds `update-info-root` and `whats-new-link` to `about_prefs.components.json`.
- Registers the test in `manifests/key.yaml` (functional1).

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): `AboutPrefs` (component manifest only, no Python changes)
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The "What's new" link is the `#releasenotes` anchor inside the `update-information` element's shadow DOM on `about:preferences#about`.

Hover is verified by comparing the link's `color` before and after hovering, since the redesign styles hover with `::part(support-link):hover { color: var(--link-color-hover) }`.

The link has `target="_blank"`, so the test waits for a second tab, switches to it, and confirms the URL is the release notes page.

Passes locally on Firefox 156.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!