### PR TITLE
Smart Window (S70279) test suite

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1892,6 +1892,35 @@ sidebar:
     result: pass
     splits:
     - smoke
+smart_window:
+  test_c3248785_switch_to_smart_window_prompts_signin:
+    result: pass
+    splits:
+    - functional1
+  test_c3248786_switch_to_classic_window:
+    result: pass
+    splits:
+    - functional1
+  test_c3309849_switch_windows_while_visiting_website:
+    result: pass
+    splits:
+    - functional1
+  test_c3309851_smart_window_missing_in_private_browsing:
+    result: pass
+    splits:
+    - functional1
+  test_c3309853_open_private_window_from_smart_window:
+    result: pass
+    splits:
+    - functional1
+  test_c3309854_open_classic_window_from_smart_window:
+    result: pass
+    splits:
+    - functional1
+  test_c3310319_block_smart_window_from_ai_controls:
+    result: pass
+    splits:
+    - functional1
 sync_and_fxa:
   test_existing_fxa:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1938362

--- a/modules/browser_object.py
+++ b/modules/browser_object.py
@@ -10,5 +10,6 @@ from modules.browser_object_panel_ui import *
 from modules.browser_object_print_preview import *
 from modules.browser_object_reader_view import *
 from modules.browser_object_sidebar import *
+from modules.browser_object_smart_window import *
 from modules.browser_object_tabbar import *
 from modules.browser_object_trust_panel import *

--- a/modules/browser_object_smart_window.py
+++ b/modules/browser_object_smart_window.py
@@ -1,0 +1,212 @@
+import logging
+
+from selenium.webdriver.common.keys import Keys
+
+from modules.page_base import BasePage
+
+AI_WINDOW_MODULE = "moz-src:///browser/components/aiwindow/ui/modules/AIWindow.sys.mjs"
+
+
+class SmartWindow(BasePage):
+    """
+    Browser Object Model for the Smart Window (AI Window) chrome.
+
+    Covers the Switch Windows button and its Classic/Smart panel, plus the
+    chrome that only exists while a window is in the Smart Window state.
+    """
+
+    URL_TEMPLATE = "about:blank"
+
+    # ── Smart Window state ───────────────────────────────────────────────
+
+    @BasePage.context_chrome
+    def is_smart_window_active(self) -> bool:
+        """
+        Report whether the current window is in the Smart Window state.
+
+        Reads AIWindow.isAIWindowActive rather than the `ai-window` attribute
+        so the check follows the product's own definition of "active".
+        """
+        return self.driver.execute_script(
+            f"""
+            const {{ AIWindow }} = ChromeUtils.importESModule("{AI_WINDOW_MODULE}");
+            return AIWindow.isAIWindowActive(window);
+            """
+        )
+
+    def expect_smart_window_active(self, active: bool = True) -> BasePage:
+        """
+        Wait until the current window is (or is not) a Smart Window.
+        """
+        self.expect(lambda _: self.is_smart_window_active() == active)
+        return self
+
+    @BasePage.context_chrome
+    def activate_smart_window(self) -> BasePage:
+        """
+        Put the current window into the Smart Window state.
+
+        TEST HARNESS ONLY. This calls AIWindow.toggleAIWindow directly, which
+        is the same call the product makes *after* it has authorized the user.
+        Going through the UI instead (the Switch Windows button, the hamburger
+        menu, the AI settings link) routes through
+        AIWindowAccountAuth.ensureAIWindowAccess, which needs a live FxA
+        account and so cannot run in this suite.
+
+        Use this to reach Smart Window surfaces whose *behaviour* is under
+        test. Do not use it in a test whose subject is the entry point itself
+        -- assert the sign-in redirect instead (see C3248785).
+        """
+        logging.info("Activating Smart Window state via AIWindow.toggleAIWindow")
+        self.driver.execute_script(
+            f"""
+            const {{ AIWindow }} = ChromeUtils.importESModule("{AI_WINDOW_MODULE}");
+            AIWindow.toggleAIWindow(window, true, "other");
+            """
+        )
+        self.expect_smart_window_active(True)
+        return self
+
+    # ── Switch Windows button ────────────────────────────────────────────
+
+    def open_window_switcher(self) -> BasePage:
+        """
+        Click the Switch Windows button and wait for its panel to open.
+        """
+        self.click_on("window-switcher-button")
+        self.element_visible("window-switcher-view")
+        return self
+
+    @BasePage.context_chrome
+    def close_window_switcher(self) -> BasePage:
+        """
+        Dismiss the Switch Windows panel with ESC.
+        """
+        self.actions.send_keys(Keys.ESCAPE).perform()
+        self.element_not_visible("window-switcher-view")
+        return self
+
+    def get_switcher_selection(self) -> str:
+        """
+        Return which entry the Switch Windows panel shows as current.
+
+        Returns
+        -------
+        str
+            "smart", "classic", or "none" if neither is checked.
+        """
+        for name, label in (
+            ("switch-to-smart", "smart"),
+            ("switch-to-classic", "classic"),
+        ):
+            # The panel sets state with toggleAttribute, so an unselected entry
+            # has no attribute at all. Reject "false" anyway, so a future
+            # checked="false" would not read as selected.
+            checked = self.get_element(name).get_attribute("checked")
+            if checked and checked != "false":
+                return label
+        return "none"
+
+    def expect_switcher_selection(self, expected: str) -> BasePage:
+        """
+        Wait until the Switch Windows panel marks `expected` as current.
+        """
+        self.expect(lambda _: self.get_switcher_selection() == expected)
+        return self
+
+    def switch_to_classic_window(self) -> BasePage:
+        """
+        Switch the current window to a Classic Window via the Switch Windows
+        button, and wait for the switch to take effect.
+        """
+        self.open_window_switcher()
+        self.click_on("switch-to-classic")
+        self.expect_smart_window_active(False)
+        return self
+
+    def click_switch_to_smart_window(self) -> BasePage:
+        """
+        Click the Smart entry in the Switch Windows panel.
+
+        Does not wait for a Smart Window: while signed out this navigates to
+        the FxA sign-in page instead.
+        """
+        self.open_window_switcher()
+        self.click_on("switch-to-smart")
+        return self
+
+    @BasePage.context_chrome
+    def switcher_button_available(self) -> bool:
+        """
+        Report whether the Switch Windows button is offered in this window.
+
+        Checks visibility, not merely existence. The three ways Smart Window
+        can be unavailable do not look alike in the DOM:
+
+        - Private Browsing window -> the widget is never built (no element)
+        - browser.smartwindow.enabled=false -> element exists with hidden=true
+        - blocked in AI Controls -> the widget is destroyed (no element)
+
+        An existence-only check would call the middle case "available", which
+        would let a test pass with the feature switched off.
+
+        Drops the implicit wait so an absent button returns immediately rather
+        than costing a full timeout.
+        """
+        original = self.driver.timeouts.implicit_wait
+        self.driver.implicitly_wait(0)
+        try:
+            elements = self.get_elements("window-switcher-button")
+            return bool(elements) and elements[0].is_displayed()
+        finally:
+            self.driver.implicitly_wait(original)
+
+    # ── Tabs ─────────────────────────────────────────────────────────────
+
+    @BasePage.context_chrome
+    def get_selected_tab_url(self) -> str:
+        """
+        Return the URL of the selected tab, read from chrome.
+
+        Used instead of driver.current_url where the action under test opens a
+        new tab, since the content-context handle can still point at the old
+        one.
+        """
+        return self.driver.execute_script(
+            "return gBrowser.selectedBrowser.currentURI.spec;"
+        )
+
+    def expect_selected_tab_url_contains(self, fragment: str) -> BasePage:
+        """
+        Wait until the selected tab's URL contains `fragment`.
+        """
+        self.expect(lambda _: fragment in self.get_selected_tab_url())
+        return self
+
+    # ── Windows ──────────────────────────────────────────────────────────
+
+    def wait_for_new_window(self, known_handles: set[str]) -> str:
+        """
+        Wait for a window outside `known_handles` to open, and return its handle.
+
+        Deliberately waits with self.wait rather than self.expect: expect is
+        wrapped in context_of_model, and window_handles is context-sensitive --
+        chrome context lists browser windows, content context lists tabs.
+        Diffing a chrome-context list against a content-context baseline
+        returns a handle for the wrong window, so this stays in whichever
+        context the caller captured `known_handles` in.
+
+        Arguments
+        ---------
+        known_handles: set[str]
+            driver.window_handles captured before the action that opens a window.
+        """
+        opened: set[str] = set()
+
+        def _new_window(driver) -> bool:
+            nonlocal opened
+            opened = set(driver.window_handles) - known_handles
+            return bool(opened)
+
+        self.wait.until(_new_window)
+        return opened.pop()

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -1427,6 +1427,11 @@
     "strategy": "id",
     "groups": []
   },
+  "ai-control-smart-window-select": {
+    "selectorData": "aiControlSmartWindowSelect",
+    "strategy": "id",
+    "groups": []
+  },
   "doh-advanced-button": {
     "selectorData": "dohAdvancedButton",
     "strategy": "id",

--- a/modules/data/panel_ui.components.json
+++ b/modules/data/panel_ui.components.json
@@ -205,6 +205,24 @@
       "location": "Hamburger menu"
     }
   },
+  "panel-ui-new-smart-window": {
+    "selectorData": "appMenu-new-ai-window-button",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "New Smart Window, shown only in a Classic Window",
+      "location": "Hamburger menu"
+    }
+  },
+  "panel-ui-new-classic-window": {
+    "selectorData": "appMenu-new-classic-window-button",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "New Classic Window, shown only in a Smart Window",
+      "location": "Hamburger menu"
+    }
+  },
   "recent-history-content": {
     "selectorData": "#appMenu_historyMenu .toolbarbutton-text",
     "strategy": "css",

--- a/modules/data/smart_window.components.json
+++ b/modules/data/smart_window.components.json
@@ -1,0 +1,67 @@
+{
+  "context": "chrome",
+  "do-not-cache": true,
+  "window-switcher-button": {
+    "selectorData": "ai-window-toggle",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "Switch Windows button, opens the Classic/Smart switcher panel",
+      "location": "Tabs toolbar"
+    }
+  },
+  "window-switcher-view": {
+    "selectorData": "ai-window-toggle-view",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "Panel view holding the Classic and Smart switch buttons",
+      "location": "Switch Windows panel"
+    }
+  },
+  "switch-to-classic": {
+    "selectorData": "ai-window-switch-classic",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "Switches the current window to a Classic Window",
+      "location": "Switch Windows panel"
+    }
+  },
+  "switch-to-smart": {
+    "selectorData": "ai-window-switch-ai",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "Switches the current window to a Smart Window",
+      "location": "Switch Windows panel"
+    }
+  },
+  "smart-window-ask-button": {
+    "selectorData": "smartwindow-ask-button",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "ASK button, toggles the AI chat sidebar. Smart Window only",
+      "location": "Toolbox"
+    }
+  },
+  "smart-window-box": {
+    "selectorData": "ai-window-box",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "Container for the AI chat sidebar. Smart Window only",
+      "location": "Browser window"
+    }
+  },
+  "context-open-link-in-smart-window": {
+    "selectorData": "context-openlinksmartwindow",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "Open Link in Smart Window context menu item",
+      "location": "Link context menu"
+    }
+  }
+}

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1669,6 +1669,47 @@ class AboutPrefs(BasePage):
         )
         return self
 
+    def get_ai_smart_window_state(self) -> str:
+        """
+        Get the current state of the Smart Window AI feature.
+
+        Returns:
+            str: Current state ("available", "enabled" or "blocked")
+        """
+        return self.get_element("ai-control-smart-window-select").get_attribute("value")
+
+    def set_ai_smart_window(self, state: str) -> BasePage:
+        """
+        Set the Smart Window feature state from AI Controls.
+
+        Uses the same value-assign-plus-events approach as
+        set_ai_translations, because ai-control-smart-window-select is also a
+        `moz-select` custom element rather than a native <select>.
+
+        Arguments:
+            state: "available", "enabled" or "blocked"
+        """
+        select_elem = self.get_element("ai-control-smart-window-select")
+        self.driver.execute_script(
+            """
+            const el = arguments[0];
+            el.value = arguments[1];
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+            """,
+            select_elem,
+            state,
+        )
+        # Confirm the moz-select wrote through to the backing pref rather than
+        # just holding the value we assigned.
+        self.expect(
+            lambda _: self.driver.execute_script(
+                "return Services.prefs.getStringPref('browser.ai.control.smartWindow', '');"
+            )
+            == state
+        )
+        return self
+
     def cancel_ai_killswitch_click(self) -> BasePage:
         """
         Click the AI killswitch toggle and dismiss the confirmation dialog with

--- a/tests/smart_window/conftest.py
+++ b/tests/smart_window/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+
+from modules.browser_object_smart_window import SmartWindow
+
+
+@pytest.fixture()
+def suite_id():
+    return ("S70279", "Smart Window")
+
+
+@pytest.fixture()
+def prefs_list():
+    """
+    Smart Window ships disabled by default; every test in this suite needs the
+    feature available before the window opens.
+    """
+    return [("browser.smartwindow.enabled", True)]
+
+
+@pytest.fixture()
+def smart_window(driver):
+    """Provide the Smart Window BOM for a window still in the Classic state."""
+    return SmartWindow(driver)
+
+
+@pytest.fixture()
+def active_smart_window(driver):
+    """
+    Provide the Smart Window BOM with the window already in the Smart Window
+    state, for tests about behaviour *inside* a Smart Window.
+
+    See SmartWindow.activate_smart_window for why this does not go through the
+    product's own (FxA-gated) entry points.
+    """
+    sw = SmartWindow(driver)
+    sw.activate_smart_window()
+    return sw

--- a/tests/smart_window/test_c3248785_switch_to_smart_window_prompts_signin.py
+++ b/tests/smart_window/test_c3248785_switch_to_smart_window_prompts_signin.py
@@ -1,0 +1,37 @@
+"""
+C3248785 - Switch to Smart Window from the Switch Windows button
+Signed out, choosing Smart in the Switch Windows panel must send the user to
+the FxA sign-in flow rather than switching the window.
+"""
+
+import pytest
+
+from modules.browser_object_smart_window import SmartWindow
+
+FXA_SIGN_IN_HOST = "accounts.firefox.com"
+
+
+@pytest.fixture()
+def test_case():
+    return "3248785"
+
+
+def test_switch_to_smart_window_prompts_signin(smart_window: SmartWindow):
+    """
+    C3248785 - Switch to Smart Window from the Switch Windows button
+    """
+    smart_window.open_window_switcher()
+    smart_window.expect_switcher_selection("classic")
+    smart_window.close_window_switcher()
+
+    smart_window.click_switch_to_smart_window()
+
+    # Sign-in is required first: the FxA flow opens in a new tab, tagged with
+    # the Smart Window entrypoint.
+    smart_window.expect_selected_tab_url_contains(FXA_SIGN_IN_HOST)
+    signin_url = smart_window.get_selected_tab_url()
+    assert "entrypoint=smartwindow" in signin_url, signin_url
+    assert "service=smartwindow" in signin_url, signin_url
+
+    # The window itself stays Classic until sign-in completes.
+    assert not smart_window.is_smart_window_active()

--- a/tests/smart_window/test_c3248786_switch_to_classic_window.py
+++ b/tests/smart_window/test_c3248786_switch_to_classic_window.py
@@ -1,0 +1,35 @@
+"""
+C3248786 - Switch to Classic Window from the Switch Windows button
+Verify a Smart Window can be turned back into a Classic Window from the Switch
+Windows panel, and that the Smart Window chrome is torn down with it.
+"""
+
+import pytest
+
+from modules.browser_object_smart_window import SmartWindow
+
+
+@pytest.fixture()
+def test_case():
+    return "3248786"
+
+
+def test_switch_to_classic_window(active_smart_window: SmartWindow):
+    """
+    C3248786 - Switch to Classic Window from the Switch Windows button
+    """
+    smart_window = active_smart_window
+
+    # The switcher reflects the window it is opened from.
+    smart_window.open_window_switcher()
+    smart_window.expect_switcher_selection("smart")
+    smart_window.close_window_switcher()
+
+    smart_window.element_visible("smart-window-ask-button")
+
+    smart_window.switch_to_classic_window()
+
+    # Smart Window chrome is gone once the window is Classic again.
+    smart_window.element_not_visible("smart-window-ask-button")
+    smart_window.open_window_switcher()
+    smart_window.expect_switcher_selection("classic")

--- a/tests/smart_window/test_c3309849_switch_windows_while_visiting_website.py
+++ b/tests/smart_window/test_c3309849_switch_windows_while_visiting_website.py
@@ -1,0 +1,41 @@
+"""
+C3309849 - Switch windows while visiting a website
+Verify that switching between Smart and Classic keeps the active tab and its
+page loaded.
+"""
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TabBar
+from modules.browser_object_smart_window import SmartWindow
+
+URL = "about:robots"
+
+
+@pytest.fixture()
+def test_case():
+    return "3309849"
+
+
+def test_switch_windows_while_visiting_website(
+    driver: Firefox, smart_window: SmartWindow
+):
+    """
+    C3309849 - Switch windows while visiting a website
+    """
+    tabs = TabBar(driver)
+    driver.get(URL)
+    tabs.expect_title_contains("Gort")
+
+    smart_window.activate_smart_window()
+
+    # The page the user was on survives the switch to Smart.
+    assert driver.current_url == URL
+    tabs.expect_title_contains("Gort")
+
+    smart_window.switch_to_classic_window()
+
+    # ...and the switch back to Classic.
+    assert driver.current_url == URL
+    tabs.expect_title_contains("Gort")

--- a/tests/smart_window/test_c3309851_smart_window_missing_in_private_browsing.py
+++ b/tests/smart_window/test_c3309851_smart_window_missing_in_private_browsing.py
@@ -1,0 +1,41 @@
+"""
+C3309851 - Smart Window option missing in Private Browsing
+Verify that a Private Browsing window offers no way to switch to a Smart
+Window, while the normal window it was opened from still does.
+"""
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import PanelUi
+from modules.browser_object_smart_window import SmartWindow
+
+
+@pytest.fixture()
+def test_case():
+    return "3309851"
+
+
+def test_smart_window_missing_in_private_browsing(
+    driver: Firefox, smart_window: SmartWindow
+):
+    """
+    C3309851 - Smart Window option missing in Private Browsing
+    """
+    # Baseline: the normal window offers the Smart option.
+    assert smart_window.switcher_button_available()
+    smart_window.open_window_switcher()
+    smart_window.element_visible("switch-to-smart")
+    smart_window.close_window_switcher()
+
+    panel_ui = PanelUi(driver)
+    existing_handles = set(driver.window_handles)
+    panel_ui.open_private_window()
+    driver.switch_to.window(smart_window.wait_for_new_window(existing_handles))
+
+    private_window = SmartWindow(driver)
+    private_window.is_private()  # waits and asserts; raises on timeout
+
+    # The Switch Windows button is not built at all in a private window, so
+    # there is no entry point to a Smart Window.
+    assert not private_window.switcher_button_available()

--- a/tests/smart_window/test_c3309853_open_private_window_from_smart_window.py
+++ b/tests/smart_window/test_c3309853_open_private_window_from_smart_window.py
@@ -1,0 +1,48 @@
+"""
+C3309853 - Open a New Private Window from the Smart Window
+Verify a Private Browsing window can be opened from a Smart Window, and that
+it is neither private-plus-smart nor missing its private state.
+"""
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import PanelUi
+from modules.browser_object_smart_window import SmartWindow
+
+
+@pytest.fixture()
+def test_case():
+    return "3309853"
+
+
+def test_open_private_window_from_smart_window(
+    driver: Firefox, active_smart_window: SmartWindow
+):
+    """
+    C3309853 - Open a New Private Window from the Smart Window
+    """
+    panel_ui = PanelUi(driver)
+    smart_handle = driver.current_window_handle
+    existing_handles = set(driver.window_handles)
+
+    panel_ui.open_panel_menu()
+    panel_ui.element_visible("panel-ui-new-private-window")
+    panel_ui.click_on("panel-ui-new-private-window")
+
+    new_handle = active_smart_window.wait_for_new_window(existing_handles)
+    driver.switch_to.window(new_handle)
+
+    private_window = SmartWindow(driver)
+    private_window.is_private()  # waits and asserts; raises on timeout
+
+    # Private Browsing never carries the Smart Window state.
+    private_window.expect_smart_window_active(False)
+    assert not private_window.switcher_button_available()
+
+    # Positive control: the window we opened it from is still a Smart Window,
+    # so the assertions above reflect Private Browsing being exempt rather
+    # than Smart Window being unavailable in this profile.
+    driver.switch_to.window(smart_handle)
+    active_smart_window.expect_smart_window_active(True)
+    assert active_smart_window.switcher_button_available()

--- a/tests/smart_window/test_c3309854_open_classic_window_from_smart_window.py
+++ b/tests/smart_window/test_c3309854_open_classic_window_from_smart_window.py
@@ -1,0 +1,43 @@
+"""
+C3309854 - Open a New Classic Window from the Smart Window
+Verify the hamburger menu in a Smart Window offers "New Classic Window" in
+place of "New Smart Window", and that it opens a Classic Window.
+"""
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import PanelUi
+from modules.browser_object_smart_window import SmartWindow
+
+
+@pytest.fixture()
+def test_case():
+    return "3309854"
+
+
+def test_open_classic_window_from_smart_window(
+    driver: Firefox, active_smart_window: SmartWindow
+):
+    """
+    C3309854 - Open a New Classic Window from the Smart Window
+    """
+    panel_ui = PanelUi(driver)
+    panel_ui.open_panel_menu()
+
+    # A Smart Window swaps the "New Smart Window" entry for "New Classic Window".
+    panel_ui.element_not_visible("panel-ui-new-smart-window")
+    panel_ui.element_visible("panel-ui-new-classic-window")
+
+    existing_handles = set(driver.window_handles)
+    panel_ui.click_on("panel-ui-new-classic-window")
+
+    new_handle = active_smart_window.wait_for_new_window(existing_handles)
+    driver.switch_to.window(new_handle)
+
+    new_window = SmartWindow(driver)
+    new_window.is_not_private()  # waits and asserts; raises on timeout
+
+    # The window is briefly created in the Smart state before being toggled to
+    # Classic, so poll for the settled state rather than reading it once.
+    new_window.expect_smart_window_active(False)

--- a/tests/smart_window/test_c3310319_block_smart_window_from_ai_controls.py
+++ b/tests/smart_window/test_c3310319_block_smart_window_from_ai_controls.py
@@ -1,0 +1,35 @@
+"""
+C3310319 - Enable/Block Smart Window from AI controls
+Verify that blocking Smart Window in AI Controls removes the Switch Windows
+button, and that unblocking it brings the button back.
+"""
+
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object_smart_window import SmartWindow
+from modules.page_object_prefs import AboutPrefs
+
+
+@pytest.fixture()
+def test_case():
+    return "3310319"
+
+
+def test_block_smart_window_from_ai_controls(driver: Firefox):
+    """
+    C3310319 - Enable/Block Smart Window from AI controls
+    """
+    smart_window = SmartWindow(driver)
+    about_prefs = AboutPrefs(driver, category="ai")
+    about_prefs.navigate_to_ai_controls()
+
+    # The feature starts available, so the window switcher is offered.
+    assert about_prefs.get_ai_smart_window_state() == "available"
+    assert smart_window.switcher_button_available()
+
+    about_prefs.set_ai_smart_window("blocked")
+    smart_window.expect(lambda _: not smart_window.switcher_button_available())
+
+    about_prefs.set_ai_smart_window("available")
+    smart_window.expect(lambda _: smart_window.switcher_button_available())


### PR DESCRIPTION
### Relevant Links

Bugzilla: N/A
TestRail: S70279 (AI Smart Window) — C3248785, C3248786, C3309849, C3309851, C3309853, C3309854, C3310319

### Description of Code / Doc Changes

- Adds `tests/smart_window/` — 7 tests, the first slice of Smart Window automation
  - `c3248785` — switching to Smart while signed out routes to the FxA flow (`entrypoint=smartwindow`)
  - `c3248786` — a Smart Window can be switched back to Classic, and Smart-only chrome is torn down
  - `c3309849` — switching windows preserves the active tab and its page
  - `c3309851` — Private Browsing offers no Smart Window entry point
  - `c3309853` — New Private Window from a Smart Window is private, not Smart
  - `c3309854` — New Classic Window from a Smart Window is Classic
  - `c3310319` — blocking Smart Window in AI Controls removes the Switch Windows button
- Adds `modules/browser_object_smart_window.py` + `modules/data/smart_window.components.json`
- Adds `set_ai_smart_window` / `get_ai_smart_window_state` to `AboutPrefs`, plus the
  `ai-control-smart-window-select` entry
- Adds hamburger entries for New Smart Window / New Classic Window to `panel_ui.components.json`
- Registers the suite in `manifests/key.yaml` (`functional1`)

### Process Changes Required

- [x] Changes or creates a BOM/POM (name the object model): **`SmartWindow`** (new), `AboutPrefs` and `PanelUi` (additive only)

### Screenshots or Explanations

**Smart Window does not need a signed-in FxA account to reach.** Setting
`browser.smartwindow.enabled` makes the feature available, and `AIWindow.toggleAIWindow` puts a
window into the Smart state — the same call the product makes *after* it authorizes the user. The
auth gate lives only in `AIWindowAccountAuth.ensureAIWindowAccess`, reached via `launchWindow`.

`SmartWindow.activate_smart_window` wraps that call and documents when **not** to use it: where the
entry point itself is the subject, assert the sign-in redirect instead. `c3248785` does exactly
that — it goes through the real button and asserts the FxA handoff.

**Coverage caveat worth a reviewer's attention:** three tests exercise fully real user paths; four
use the activation fixture, so they verify behaviour inside and out of a Smart Window but **not the
authenticated route into one**. Nothing here covers the real sign-in → Smart Window flow; that
still needs a signed-in profile or manual testing.

**No stubs.** Verified with a negative control — with `browser.smartwindow.enabled` set to `false`,
all 7 fail. That check caught a real bug: `switcher_button_available` was reporting a hidden button
as present. Disabling the pref leaves the element in the DOM with `hidden=true`, while blocking via
AI Controls destroys the widget outright, so the predicate has to test visibility, not existence.

Verified on Custom Firefox **156.0b3** (the build CI uses) and **155.0.1**, 3 consecutive runs plus
combined runs with `tests/ai_controls/` (14/14).

### Comments or Future Work

- **`C3248785` asserts the signed-out gate**, not the switch as TestRail describes it (that case
  assumes a signed-in profile). The case needs annotating or splitting.
- **`C3309858` "Open a link from Smart to Classic Window" does not match the build.** In 155.0.1 and
  156.0b3 the link context menu offers only "Open Link in New Smart Window"
  (`context-openlinksmartwindow`); there is no Classic counterpart. Needs a product answer.
- **Next highest-leverage work is a smart bar input harness**, which unblocks ~12 cases
  (C3248361/2, C3321908, C3322034-36, C3322041, C3977124/6, C3322037/40/42). The smart bar input is
  a ProseMirror contenteditable two shadow roots deep, and Marionette's `shadow_root` API throws on
  it, so `send_keys` never lands.
- Restore Session (C3309859-61, C4065796) is reachable next — SessionStore persists `isAIWindow` and
  restore is gated on `isAIWindowEnabled()`, not re-auth.
- `C3917535` (enterprise policy) needs a `policies.json` harness built from scratch; the kill-switch
  one was removed in #1508.

### Workflow Checklist

- [x] Code has been linted and formatted.