### PR TITLE
Akash/ Add About Firefox support card tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1358,6 +1358,14 @@ preferences:
     result: unstable
     splits:
     - functional2
+  test_support_get_help:
+    result: pass
+    splits:
+    - functional1
+  test_support_share_ideas:
+    result: pass
+    splits:
+    - functional1
   test_whats_new_link:
     result: pass
     splits:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -799,6 +799,52 @@
       "location": "about:preferences#about"
     }
   },
+  "support-get-help": {
+    "selectorData": "supportGetHelp",
+    "strategy": "id",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Firefox support > \"Get help\" link, opens a SUMO article",
+      "location": "about:preferences#about"
+    }
+  },
+  "support-get-help-button": {
+    "selectorData": ".button",
+    "strategy": "css",
+    "shadowParent": "support-get-help",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Hover-styled inner box of \"Get help\", a in Fx155, div in Fx156+",
+      "location": "about:preferences#about"
+    }
+  },
+  "support-share-ideas": {
+    "selectorData": "supportShareIdeas",
+    "strategy": "id",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Firefox support > \"Share ideas and feedback\" link",
+      "location": "about:preferences#about"
+    }
+  },
+  "support-share-ideas-button": {
+    "selectorData": ".button",
+    "strategy": "css",
+    "shadowParent": "support-share-ideas",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Hover-styled inner box of \"Share ideas\", a in Fx155, div in Fx156+",
+      "location": "about:preferences#about"
+    }
+  },
   "update_available_button": {
     "selectorData": "[data-l10n-id='update-updateButton']",
     "strategy": "css",

--- a/tests/preferences/test_support_get_help.py
+++ b/tests/preferences/test_support_get_help.py
@@ -1,0 +1,49 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutPrefs
+
+SUPPORT_PAGE_URL_PART = "support.mozilla.org"
+SUPPORT_PAGE_ARTICLE_PART = "firefox-options-preferences-and-settings"
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Firefox support card lives in Settings > About Firefox.
+    return "about"
+
+
+@pytest.fixture()
+def test_case():
+    return "3374344"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+def test_support_get_help(driver: Firefox, about_prefs: AboutPrefs):
+    """
+    C3374344 - The "Get help" option in the "Firefox support" card works correctly.
+    """
+    about_prefs.open()
+
+    # Hovering changes the background color of the link, so compare it before and after.
+    default_color = about_prefs.get_element(
+        "support-get-help-button"
+    ).value_of_css_property("background-color")
+    about_prefs.hover("support-get-help")
+    hover_color = about_prefs.get_element(
+        "support-get-help-button"
+    ).value_of_css_property("background-color")
+    assert hover_color != default_color, "The Get help option has no hover effect"
+
+    # The link has target="_blank", so the support article opens in a new tab.
+    about_prefs.click_on("support-get-help")
+    about_prefs.wait_for_num_tabs(2)
+    about_prefs.switch_to_new_tab()
+    about_prefs.url_contains(SUPPORT_PAGE_URL_PART)
+    # The in-product link redirects to the settings article on SUMO.
+    about_prefs.url_contains(SUPPORT_PAGE_ARTICLE_PART)

--- a/tests/preferences/test_support_get_help.py
+++ b/tests/preferences/test_support_get_help.py
@@ -30,6 +30,9 @@ def test_support_get_help(driver: Firefox, about_prefs: AboutPrefs):
     """
     about_prefs.open()
 
+    # The card can sit below the fold on shorter viewports.
+    about_prefs.scroll_to_element("support-get-help")
+
     # Hovering changes the background color of the link, so compare it before and after.
     default_color = about_prefs.get_element(
         "support-get-help-button"

--- a/tests/preferences/test_support_share_ideas.py
+++ b/tests/preferences/test_support_share_ideas.py
@@ -1,0 +1,49 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutPrefs
+
+CONNECT_PAGE_URL_PART = "connect.mozilla.org"
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Firefox support card lives in Settings > About Firefox.
+    return "about"
+
+
+@pytest.fixture()
+def test_case():
+    return "3374345"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+def test_support_share_ideas(driver: Firefox, about_prefs: AboutPrefs):
+    """
+    C3374345 - The "Share ideas and feedback" option in the "Firefox support" card
+    works correctly.
+    """
+    about_prefs.open()
+
+    # Hovering changes the background color of the link, so compare it before and after.
+    default_color = about_prefs.get_element(
+        "support-share-ideas-button"
+    ).value_of_css_property("background-color")
+    about_prefs.hover("support-share-ideas")
+    hover_color = about_prefs.get_element(
+        "support-share-ideas-button"
+    ).value_of_css_property("background-color")
+    assert hover_color != default_color, (
+        "The Share ideas and feedback option has no hover effect"
+    )
+
+    # The link has target="_blank", so Mozilla Connect opens in a new tab.
+    about_prefs.click_on("support-share-ideas")
+    about_prefs.wait_for_num_tabs(2)
+    about_prefs.switch_to_new_tab()
+    about_prefs.url_contains(CONNECT_PAGE_URL_PART)

--- a/tests/preferences/test_support_share_ideas.py
+++ b/tests/preferences/test_support_share_ideas.py
@@ -30,6 +30,9 @@ def test_support_share_ideas(driver: Firefox, about_prefs: AboutPrefs):
     """
     about_prefs.open()
 
+    # The card can sit below the fold on shorter viewports.
+    about_prefs.scroll_to_element("support-share-ideas")
+
     # Hovering changes the background color of the link, so compare it before and after.
     default_color = about_prefs.get_element(
         "support-share-ideas-button"


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047153](https://bugzilla.mozilla.org/show_bug.cgi?id=2047153), [2047154](https://bugzilla.mozilla.org/show_bug.cgi?id=2047154)
TestRail: [3374344](https://mozilla.testrail.io/index.php?/cases/view/3374344), [3374345](https://mozilla.testrail.io/index.php?/cases/view/3374345)

### Description of Code / Doc Changes

- Adds `test_support_get_help` (C3374344) and `test_support_share_ideas` (C3374345), covering the two options in the Firefox support card on the redesigned About Firefox page.
- Adds four selectors to `about_prefs.components.json`: the two `moz-box-link` hosts plus their shadow DOM `.button`, which is the element that carries the hover style.
- Registers both tests in `key.yaml` under `preferences` with the `functional1` split.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs element manifest only, no Python changes
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Both tests need `browser.settings-redesign.enabled` set to true.

The hover check reads `background-color` before and after hovering and asserts it changed, matching the approach in `test_whats_new_link`. The hover rule lives on the inner `.button` inside the widget's shadow DOM, so the tests hover the host and read the CSS off that child.

That child is matched by class rather than by tag on purpose. The `moz-box-link` markup changed between versions, `a.button` in 155 and `div.button` in 156+, so a tag-qualified selector only works on one of them. The class is the stable part, and it is what `moz-box-common.css` targets.

Both tests call `scroll_to_element` before hovering. The card sits below the fold on shorter viewports, which failed on Windows in CI with `MoveTargetOutOfBoundsException`. `hover()` does not scroll on its own, unlike `click_on` and `control_click`.

Get help resolves to the SUMO article `firefox-options-preferences-and-settings`, so the test asserts on that slug as well as the domain. Share ideas and feedback goes to `connect.mozilla.org`.

Both tests pass locally on macOS across release 155, Custom 156, and Nightly 157.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!