### PR TITLE
Akash/ Add Accessibility font settings tests

### DIFF
--- a/data/pages/font_settings_page.html
+++ b/data/pages/font_settings_page.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test Page for Fonts</title>
+    <style>
+      /* The page picks its own font family and size. Pacifico does not need to
+         be installed: the tests check the font family Firefox picks, not the
+         glyphs. The text sits in spans so its width follows the font in use. */
+      .custom-font {
+        font-family: Pacifico;
+        font-size: 28px;
+        color: blue;
+      }
+    </style>
+  </head>
+  <body>
+    <p><span class="custom-font">Custom font + custom size</span></p>
+    <p><span class="reference-font">Reference text</span></p>
+  </body>
+</html>

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1317,6 +1317,14 @@ pocket:
       result: pass
       splits: []
 preferences:
+  test_change_font_family:
+    result: pass
+    splits:
+    - functional1
+  test_change_font_size:
+    result: pass
+    splits:
+    - functional1
   test_check_for_updates:
     result: pass
     splits:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -1636,5 +1636,86 @@
       "description": "The Exceptions dialog \"Save Changes\" button",
       "location": "about:preferences#etp (Manage Exceptions dialog, inside browser-popup iframe)"
     }
+  },
+  "font-family-dropdown": {
+    "selectorData": "defaultFont",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "The Font family moz-select",
+      "location": "about:preferences#accessibility - Fonts section"
+    }
+  },
+  "font-family-select": {
+    "selectorData": "select",
+    "strategy": "css",
+    "shadowParent": "font-family-dropdown",
+    "groups": [],
+    "comment": {
+      "description": "Inner native <select> of the Font family moz-select, option values are font names",
+      "location": "about:preferences#accessibility - Fonts section"
+    }
+  },
+  "font-size-dropdown": {
+    "selectorData": "defaultFontSize",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "The Font size moz-select",
+      "location": "about:preferences#accessibility - Fonts section"
+    }
+  },
+  "font-size-select": {
+    "selectorData": "select",
+    "strategy": "css",
+    "shadowParent": "font-size-dropdown",
+    "groups": [],
+    "comment": {
+      "description": "Inner native <select> of the Font size moz-select, option values are sizes in px",
+      "location": "about:preferences#accessibility - Fonts section"
+    }
+  },
+  "advanced-fonts-button": {
+    "selectorData": "advancedFonts",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "\"Advanced settings\" button in the Fonts section, opens the Fonts dialog",
+      "location": "about:preferences#accessibility - Fonts section"
+    }
+  },
+  "allow-page-fonts-checkbox": {
+    "selectorData": "useDocumentFonts",
+    "strategy": "id",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "The \"Allow pages to choose their own fonts\" checkbox",
+      "location": "about:preferences#accessibility (Fonts dialog, inside browser-popup iframe)"
+    }
+  },
+  "fonts-dialog-shadow-root": {
+    "selectorData": "FontsDialog",
+    "strategy": "id",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "The Fonts dialog root (is a shadow root), hosts the accept/cancel buttons",
+      "location": "about:preferences#accessibility (Fonts dialog, inside browser-popup iframe)"
+    }
+  },
+  "fonts-dialog-accept-button": {
+    "selectorData": "[dlgtype='accept']",
+    "strategy": "css",
+    "shadowParent": "fonts-dialog-shadow-root",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "The Fonts dialog OK button",
+      "location": "about:preferences#accessibility (Fonts dialog, inside browser-popup iframe)"
+    }
   }
 }

--- a/tests/preferences/test_change_font_family.py
+++ b/tests/preferences/test_change_font_family.py
@@ -77,9 +77,8 @@ def test_change_font_family(
 
     about_prefs.open()
     font_select = Select(about_prefs.get_element("font-family-select"))
-    # Skip the default font and the generic names Linux lists as fonts: picking
-    # those would not change how the page looks.
-    default_label = font_select.options[0].get_attribute("label")
+    # Skip the generic names Linux lists as fonts: picking one of those would
+    # not change how the page looks.
     candidates = list(
         islice(
             (
@@ -87,7 +86,6 @@ def test_change_font_family(
                 for option in font_select.options
                 if (value := option.get_attribute("value"))
                 and value not in GENERIC_FONTS
-                and value not in default_label
             ),
             FONTS_TO_TRY,
         )
@@ -106,10 +104,10 @@ def test_change_font_family(
 
     assert chosen_font, f"None of {candidates} redrew the reference text"
     # Pages are still allowed their own fonts, so the page's font is kept.
-    assert (
-        test_page.get_element("custom-font-text").value_of_css_property("font-family")
-        == PAGE_FONT
+    page_font = test_page.get_element("custom-font-text").value_of_css_property(
+        "font-family"
     )
+    assert page_font.startswith(PAGE_FONT), f"The page font is not first in {page_font}"
 
     about_prefs.open()
     about_prefs.click_on("advanced-fonts-button")

--- a/tests/preferences/test_change_font_family.py
+++ b/tests/preferences/test_change_font_family.py
@@ -1,3 +1,4 @@
+from itertools import islice
 from shutil import copyfile
 
 import pytest
@@ -8,6 +9,8 @@ from modules.page_object import AboutPrefs, GenericPage
 
 LOCAL_HTML = "font_settings_page.html"
 PAGE_FONT = "Pacifico"
+GENERIC_FONTS = ("serif", "sans-serif", "monospace", "cursive", "fantasy")
+FONTS_TO_TRY = 3
 
 
 @pytest.fixture()
@@ -74,20 +77,34 @@ def test_change_font_family(
 
     about_prefs.open()
     font_select = Select(about_prefs.get_element("font-family-select"))
-    # The first option is the default font, so pick another one by name.
+    # Skip the default font and the generic names Linux lists as fonts: picking
+    # those would not change how the page looks.
     default_label = font_select.options[0].get_attribute("label")
-    chosen_font = next(
-        value
-        for option in font_select.options
-        if (value := option.get_attribute("value")) and value not in default_label
+    candidates = list(
+        islice(
+            (
+                value
+                for option in font_select.options
+                if (value := option.get_attribute("value"))
+                and value not in GENERIC_FONTS
+                and value not in default_label
+            ),
+            FONTS_TO_TRY,
+        )
     )
-    font_select.select_by_value(chosen_font)
 
-    test_page.open()
-    # The reference text is drawn in the chosen font now.
-    assert _text_width(test_page, "reference-font-text") != reference_width, (
-        f"The reference text was not redrawn in {chosen_font}"
-    )
+    # Two fonts can share their letter widths, so try a few.
+    chosen_font = None
+    for candidate in candidates:
+        about_prefs.open()
+        Select(about_prefs.get_element("font-family-select")).select_by_value(candidate)
+        test_page.open()
+        # The reference text is drawn in the chosen font now.
+        if _text_width(test_page, "reference-font-text") != reference_width:
+            chosen_font = candidate
+            break
+
+    assert chosen_font, f"None of {candidates} redrew the reference text"
     # Pages are still allowed their own fonts, so the page's font is kept.
     assert (
         test_page.get_element("custom-font-text").value_of_css_property("font-family")

--- a/tests/preferences/test_change_font_family.py
+++ b/tests/preferences/test_change_font_family.py
@@ -15,7 +15,7 @@ FONTS_TO_TRY = 3
 
 @pytest.fixture()
 def about_prefs_category():
-    # The Fonts section lives in Settings > Accessibility.
+    # The Fonts section lives in the Accessibility settings.
     return "accessibility"
 
 
@@ -70,15 +70,14 @@ def test_change_font_family(
 
     custom_width = _text_width(test_page, "custom-font-text")
     reference_width = _text_width(test_page, "reference-font-text")
-    # The reference text has no font of its own, so it shows the default font.
+    # The reference text has no font, so it shows the generic default, serif.
     default_font = test_page.get_element("reference-font-text").value_of_css_property(
         "font-family"
     )
 
     about_prefs.open()
     font_select = Select(about_prefs.get_element("font-family-select"))
-    # Skip the generic names Linux lists as fonts: picking one of those would
-    # not change how the page looks.
+    # Skip the generic names Linux lists, they would not change the page.
     candidates = list(
         islice(
             (
@@ -90,20 +89,21 @@ def test_change_font_family(
             FONTS_TO_TRY,
         )
     )
+    assert candidates, "The font family dropdown lists only generic fonts"
 
-    # Two fonts can share their letter widths, so try a few.
+    # Two fonts can share letter widths, so try a few. Settings is open now.
     chosen_font = None
     for candidate in candidates:
-        about_prefs.open()
         Select(about_prefs.get_element("font-family-select")).select_by_value(candidate)
         test_page.open()
         # The reference text is drawn in the chosen font now.
         if _text_width(test_page, "reference-font-text") != reference_width:
             chosen_font = candidate
             break
+        about_prefs.open()
 
     assert chosen_font, f"None of {candidates} redrew the reference text"
-    # Pages are still allowed their own fonts, so the page's font is kept.
+    # Pages can still choose their own fonts, so the page font is kept.
     page_font = test_page.get_element("custom-font-text").value_of_css_property(
         "font-family"
     )

--- a/tests/preferences/test_change_font_family.py
+++ b/tests/preferences/test_change_font_family.py
@@ -1,4 +1,5 @@
 from itertools import islice
+from pathlib import Path
 from shutil import copyfile
 
 import pytest
@@ -31,10 +32,11 @@ def add_to_prefs_list():
 
 
 @pytest.fixture()
-def local_doc_path(tmp_path):
-    loc = tmp_path / LOCAL_HTML
-    copyfile(f"data/pages/{LOCAL_HTML}", loc)
-    return f"file://{loc}"
+def local_doc_path(tmp_path: Path) -> str:
+    source = Path("data/pages") / LOCAL_HTML
+    destination = tmp_path / LOCAL_HTML
+    copyfile(source, destination)
+    return destination.as_uri()
 
 
 @pytest.fixture()

--- a/tests/preferences/test_change_font_family.py
+++ b/tests/preferences/test_change_font_family.py
@@ -1,0 +1,114 @@
+from shutil import copyfile
+
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.support.select import Select
+
+from modules.page_object import AboutPrefs, GenericPage
+
+LOCAL_HTML = "font_settings_page.html"
+PAGE_FONT = "Pacifico"
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Fonts section lives in Settings > Accessibility.
+    return "accessibility"
+
+
+@pytest.fixture()
+def test_case():
+    return "3370446"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+@pytest.fixture()
+def local_doc_path(tmp_path):
+    loc = tmp_path / LOCAL_HTML
+    copyfile(f"data/pages/{LOCAL_HTML}", loc)
+    return f"file://{loc}"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "custom-font-text": {
+            "selectorData": "custom-font",
+            "strategy": "class",
+            "groups": ["doNotCache"],
+        },
+        "reference-font-text": {
+            "selectorData": "reference-font",
+            "strategy": "class",
+            "groups": ["doNotCache"],
+        },
+    }
+
+
+def _text_width(test_page: GenericPage, selector: str) -> float:
+    """Return the width of a line of text, which follows the font in use."""
+    return test_page.get_element(selector).size["width"]
+
+
+def test_change_font_family(
+    driver: Firefox, about_prefs: AboutPrefs, local_doc_path: str, temp_selectors: dict
+):
+    """
+    C3370446 - The font family picked in Settings is used for web page text.
+    """
+    test_page = GenericPage(driver, url=local_doc_path)
+    test_page.elements |= temp_selectors
+    test_page.open()
+
+    custom_width = _text_width(test_page, "custom-font-text")
+    reference_width = _text_width(test_page, "reference-font-text")
+    # The reference text has no font of its own, so it shows the default font.
+    default_font = test_page.get_element("reference-font-text").value_of_css_property(
+        "font-family"
+    )
+
+    about_prefs.open()
+    font_select = Select(about_prefs.get_element("font-family-select"))
+    # The first option is the default font, so pick another one by name.
+    default_label = font_select.options[0].get_attribute("label")
+    chosen_font = next(
+        value
+        for option in font_select.options
+        if (value := option.get_attribute("value")) and value not in default_label
+    )
+    font_select.select_by_value(chosen_font)
+
+    test_page.open()
+    # The reference text is drawn in the chosen font now.
+    assert _text_width(test_page, "reference-font-text") != reference_width, (
+        f"The reference text was not redrawn in {chosen_font}"
+    )
+    # Pages are still allowed their own fonts, so the page's font is kept.
+    assert (
+        test_page.get_element("custom-font-text").value_of_css_property("font-family")
+        == PAGE_FONT
+    )
+
+    about_prefs.open()
+    about_prefs.click_on("advanced-fonts-button")
+    about_prefs.get_and_switch_iframe()
+    about_prefs.click_on("allow-page-fonts-checkbox")
+    about_prefs.click_on("fonts-dialog-accept-button")
+    about_prefs.switch_to_default_frame()
+
+    test_page.open()
+    # Firefox puts its own font first, ahead of the font the page asked for.
+    custom_font = test_page.get_element("custom-font-text").value_of_css_property(
+        "font-family"
+    )
+    assert custom_font.startswith(default_font), (
+        f"The page font is still first in {custom_font}"
+    )
+    assert _text_width(test_page, "custom-font-text") != custom_width, (
+        f"The page text was not redrawn in {chosen_font}"
+    )

--- a/tests/preferences/test_change_font_size.py
+++ b/tests/preferences/test_change_font_size.py
@@ -1,0 +1,93 @@
+from shutil import copyfile
+
+import pytest
+from selenium.webdriver import Firefox
+from selenium.webdriver.support.select import Select
+
+from modules.page_object import AboutPrefs, GenericPage
+
+LOCAL_HTML = "font_settings_page.html"
+NEW_FONT_SIZE = "20"
+PAGE_FONT_SIZE = "28px"
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Fonts section lives in Settings > Accessibility.
+    return "accessibility"
+
+
+@pytest.fixture()
+def test_case():
+    return "3370695"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+@pytest.fixture()
+def local_doc_path(tmp_path):
+    loc = tmp_path / LOCAL_HTML
+    copyfile(f"data/pages/{LOCAL_HTML}", loc)
+    return f"file://{loc}"
+
+
+@pytest.fixture()
+def temp_selectors():
+    return {
+        "custom-font-text": {
+            "selectorData": "custom-font",
+            "strategy": "class",
+            "groups": ["doNotCache"],
+        },
+        "reference-font-text": {
+            "selectorData": "reference-font",
+            "strategy": "class",
+            "groups": ["doNotCache"],
+        },
+    }
+
+
+def _font_sizes(test_page: GenericPage) -> tuple[str, str]:
+    """Return the font sizes of the custom and the reference paragraph."""
+    return (
+        test_page.get_element("custom-font-text").value_of_css_property("font-size"),
+        test_page.get_element("reference-font-text").value_of_css_property("font-size"),
+    )
+
+
+def test_change_font_size(
+    driver: Firefox, about_prefs: AboutPrefs, local_doc_path: str, temp_selectors: dict
+):
+    """
+    C3370695 - The font size chosen in Settings is used for text that does not set
+    its own size.
+    """
+    test_page = GenericPage(driver, url=local_doc_path)
+    test_page.elements |= temp_selectors
+    test_page.open()
+
+    # The page sets its own size, the reference text uses the default one.
+    custom_size, default_size = _font_sizes(test_page)
+    assert custom_size == PAGE_FONT_SIZE
+    assert default_size != f"{NEW_FONT_SIZE}px"
+
+    about_prefs.open()
+    Select(about_prefs.get_element("font-size-select")).select_by_value(NEW_FONT_SIZE)
+
+    test_page.open()
+    assert _font_sizes(test_page) == (PAGE_FONT_SIZE, f"{NEW_FONT_SIZE}px")
+
+    about_prefs.open()
+    about_prefs.click_on("advanced-fonts-button")
+    about_prefs.get_and_switch_iframe()
+    about_prefs.click_on("allow-page-fonts-checkbox")
+    about_prefs.click_on("fonts-dialog-accept-button")
+    about_prefs.switch_to_default_frame()
+
+    # Blocking the page's own fonts changes the font family, not the sizes.
+    test_page.open()
+    assert _font_sizes(test_page) == (PAGE_FONT_SIZE, f"{NEW_FONT_SIZE}px")

--- a/tests/preferences/test_change_font_size.py
+++ b/tests/preferences/test_change_font_size.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from shutil import copyfile
 
 import pytest
@@ -30,10 +31,11 @@ def add_to_prefs_list():
 
 
 @pytest.fixture()
-def local_doc_path(tmp_path):
-    loc = tmp_path / LOCAL_HTML
-    copyfile(f"data/pages/{LOCAL_HTML}", loc)
-    return f"file://{loc}"
+def local_doc_path(tmp_path: Path) -> str:
+    source = Path("data/pages") / LOCAL_HTML
+    destination = tmp_path / LOCAL_HTML
+    copyfile(source, destination)
+    return destination.as_uri()
 
 
 @pytest.fixture()

--- a/tests/preferences/test_change_font_size.py
+++ b/tests/preferences/test_change_font_size.py
@@ -7,6 +7,7 @@ from selenium.webdriver.support.select import Select
 from modules.page_object import AboutPrefs, GenericPage
 
 LOCAL_HTML = "font_settings_page.html"
+# Any size other than the default works here, and the test checks that below.
 NEW_FONT_SIZE = "20"
 PAGE_FONT_SIZE = "28px"
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2048620](https://bugzilla.mozilla.org/show_bug.cgi?id=2048620), [2048621](https://bugzilla.mozilla.org/show_bug.cgi?id=2048621)
TestRail: [3370446](https://mozilla.testrail.io/index.php?/cases/view/3370446), [3370695](https://mozilla.testrail.io/index.php?/cases/view/3370695)

### Description of Code / Doc Changes

- Adds `test_change_font_family` (C3370446): picks a font family in Settings > Accessibility > Fonts, checks the page keeps its own font while it is allowed to, then checks Firefox's font wins once "Allow pages to choose their own fonts" is off.
- Adds `test_change_font_size` (C3370695): picks a font size, checks text without its own size follows the new size while page-defined sizes stay put, before and after blocking page fonts.
- Adds `data/pages/font_settings_page.html`, a local page with one line that sets its own font and size and one reference line that sets neither.
- Adds the Fonts section elements to `modules/data/about_prefs.components.json`, both dropdowns, their inner selects, the Advanced settings button, the allow-own-fonts checkbox and the dialog OK button.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs (element manifest only, no new methods)
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The test cases point at a CodePen pen. That page is behind Cloudflare and starts asking for captcha verification, so the local page copies its shape instead. Pacifico is a Google web font and is not downloaded on the local page, so the tests check which font family Firefox picks plus a text width change proving the text was redrawn, not the Pacifico glyphs.

Firefox never gives the page the chosen font's name. With page fonts blocked the computed font family becomes `serif, Pacifico`, so the assertion is that Firefox's own font is now first.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!