### PR TITLE
Hani/ Test tcp option carries over PB

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1702,6 +1702,10 @@ security_and_privacy:
     result: pass
     splits:
     - functional3
+  test_tcp_option_carries_over_private_window:
+    result: pass
+    splits:
+    - functional3
   test_third_party_content_blocked_private_browsing:
     result: pass
     splits:

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -473,7 +473,9 @@ class AboutPrefs(BasePage):
         """
         if level not in self.ETP_LEVEL_RADIOS:
             raise ValueError(f"Unknown ETP level: {level!r}")
-        self.click_on(self.ETP_LEVEL_RADIOS[level])
+        # Native click lands on dead space for "custom" and is silently dropped,
+        # leaving the pref unchanged, so click the moz-radio host directly.
+        self.js_click_on(self.ETP_LEVEL_RADIOS[level])
         return self
 
     def select_etp_level(self, level: str) -> BasePage:
@@ -483,6 +485,25 @@ class AboutPrefs(BasePage):
         """
         self.open_etp_settings()
         self.set_etp_level(level)
+        return self
+
+    def verify_etp_level(self, level: str) -> BasePage:
+        """
+        Assert which Enhanced Tracking Protection level is selected on
+        about:preferences#etp. level: standard|strict|custom.
+
+        Must be called from about:preferences#etp (see ``open_etp_settings``).
+        """
+        if level not in self.ETP_LEVEL_RADIOS:
+            raise ValueError(f"Unknown ETP level: {level!r}")
+
+        def _level_is_checked(_):
+            radio = self.get_element(self.ETP_LEVEL_RADIOS[level])
+            return bool(
+                self.driver.execute_script("return !!arguments[0].checked;", radio)
+            )
+
+        self.expect(_level_is_checked)
         return self
 
     def open_etp_customize(self) -> BasePage:

--- a/tests/security_and_privacy/test_tcp_option_carries_over_private_window.py
+++ b/tests/security_and_privacy/test_tcp_option_carries_over_private_window.py
@@ -1,0 +1,54 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import PanelUi
+from modules.page_object import AboutPrefs
+
+
+@pytest.fixture()
+def test_case():
+    return "446319"
+
+
+def test_tcp_option_carries_over_private_window(driver: Firefox, panel_ui: PanelUi):
+    """
+    C446319 - Verify that the selected option carries over to Private window
+    """
+
+    # Instantiate objects
+    about_prefs = AboutPrefs(driver, category="privacy")
+    normal_window = driver.current_window_handle
+
+    # Select "Standard" up front: a fresh profile does not reliably start on it
+    about_prefs.open()
+    about_prefs.select_etp_level("standard")
+
+    # Open a New private window
+    panel_ui.open_and_switch_to_new_window("private")
+    private_window = driver.current_window_handle
+    private_about_prefs = AboutPrefs(driver, category="privacy")
+
+    # Access about:preferences#privacy and observe the "Standard" section
+    private_about_prefs.open()
+    private_about_prefs.open_etp_settings()
+    private_about_prefs.verify_etp_level("standard")
+
+    # Click on the "Strict" option and open about:preferences#privacy in a normal window
+    private_about_prefs.set_etp_level("strict")
+    driver.switch_to.window(normal_window)
+    about_prefs.open()
+
+    # The "Strict" section is displayed
+    about_prefs.open_etp_settings()
+    about_prefs.verify_etp_level("strict")
+
+    # Click on the "Custom" section and open about:preferences#privacy in a private window
+    about_prefs.set_etp_level("custom")
+    driver.switch_to.window(private_window)
+
+    # about:preferences#privacy page is opened in private window
+    private_about_prefs.open()
+
+    # The "Custom" section is checked
+    private_about_prefs.open_etp_settings()
+    private_about_prefs.verify_etp_level("custom")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2015754](https://bugzilla.mozilla.org/show_bug.cgi?id=2015754)
TestRail: [446319](https://mozilla.testrail.io/index.php?/cases/view/446319)

### Description of Code / Doc Changes

* Add test to verify that the selected option carries over to Private window

### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

N/A

### Comments or Future Work

N/A

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
