### PR TITLE
add PDF test for drawing and an existing drawing use the selected color,

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1246,6 +1246,7 @@ pdf_viewer:
     result: pass
     splits:
     - functional2
+    - nightly
   test_pdf_dropdown_functionality:
     result: pass
     splits:

--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1242,6 +1242,10 @@ pdf_viewer:
     splits:
     - functional2
     - nightly
+  test_pdf_draw_style_properties:
+    result: pass
+    splits:
+    - functional2
   test_pdf_dropdown_functionality:
     result: pass
     splits:

--- a/modules/data/generic_pdf.components.json
+++ b/modules/data/generic_pdf.components.json
@@ -240,6 +240,26 @@
     "strategy": "id",
     "groups": []
   },
+  "draw-options": {
+    "selectorData": "editorInkParamsToolbar",
+    "strategy": "id",
+    "groups": []
+  },
+  "draw-color": {
+    "selectorData": "editorInkColor",
+    "strategy": "id",
+    "groups": []
+  },
+  "draw-thickness": {
+    "selectorData": "editorInkThickness",
+    "strategy": "id",
+    "groups": []
+  },
+  "draw-opacity": {
+    "selectorData": "editorInkOpacity",
+    "strategy": "id",
+    "groups": []
+  },
   "toolbar-text": {
     "selectorData": "editorFreeTextButton",
     "strategy": "id",

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -366,6 +366,61 @@ class GenericPdf(BasePage):
         self.element_attribute_contains(tool, "class", "toggled")
         return self
 
+    def set_draw_style(self, color: str, thickness: int, opacity: float) -> BasePage:
+        """Set the color, thickness, and opacity used by the PDF Draw tool."""
+        color_control = self.get_element("draw-color")
+        opacity_control = None
+        if color_control.get_attribute("alpha") is not None:
+            color = self.driver.execute_script(
+                """
+                const color = arguments[0];
+                const opacity = arguments[1];
+                const channels = [1, 3, 5].map(
+                    index => parseInt(color.slice(index, index + 2), 16) / 255
+                );
+                return `color(srgb ${channels.join(" ")} / ${opacity})`;
+                """,
+                color,
+                opacity,
+            )
+        else:
+            opacity_control = self.get_element("draw-opacity")
+
+        draw_style = [
+            (color_control, "draw-color", color),
+            (self.get_element("draw-thickness"), "draw-thickness", thickness),
+        ]
+        if opacity_control:
+            draw_style.append((opacity_control, "draw-opacity", opacity))
+
+        for control, control_name, value in draw_style:
+            updated_value, expected_value = self.driver.execute_script(
+                """
+                const control = arguments[0];
+                const expectedControl = control.cloneNode();
+                expectedControl.value = arguments[1];
+                control.value = arguments[1];
+                control.dispatchEvent(new Event("input", { bubbles: true }));
+                return [control.value, expectedControl.value];
+                """,
+                control,
+                str(value),
+            )
+            assert updated_value == expected_value, (
+                f"Expected {control_name} to be {value}, got {updated_value}."
+            )
+
+        return self
+
+    def get_drawing_style(self) -> dict[str, str | None]:
+        """Return the rendered color, thickness, and opacity of the drawing."""
+        drawing_area = self.get_drawing_area()
+        return {
+            "color": drawing_area.get_attribute("stroke"),
+            "thickness": drawing_area.get_attribute("stroke-width"),
+            "opacity": drawing_area.get_attribute("stroke-opacity"),
+        }
+
     def draw_on_pdf_page(self, page_number: str = "1") -> BasePage:
         """Draw a short line on the selected PDF page."""
         page = self.get_element("pdf-page", labels=[page_number])

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -368,6 +368,11 @@ class GenericPdf(BasePage):
 
     def set_draw_style(self, color: str, thickness: int, opacity: float) -> BasePage:
         """Set the color, thickness, and opacity used by the PDF Draw tool."""
+        if thickness <= 0:
+            raise ValueError("Draw thickness must be greater than zero.")
+        if not 0 <= opacity <= 1:
+            raise ValueError("Draw opacity must be between zero and one.")
+
         color_control = self.get_element("draw-color")
         opacity_control = None
         if color_control.get_attribute("alpha") is not None:
@@ -397,14 +402,21 @@ class GenericPdf(BasePage):
             updated_value, expected_value = self.driver.execute_script(
                 """
                 const control = arguments[0];
-                const expectedControl = control.cloneNode();
-                expectedControl.value = arguments[1];
-                control.value = arguments[1];
+                const requestedValue = arguments[1];
+                const normalizeExpectedValue = arguments[2];
+                let expectedValue = requestedValue;
+                if (normalizeExpectedValue) {
+                    const expectedControl = control.cloneNode();
+                    expectedControl.value = requestedValue;
+                    expectedValue = expectedControl.value;
+                }
+                control.value = requestedValue;
                 control.dispatchEvent(new Event("input", { bubbles: true }));
-                return [control.value, expectedControl.value];
+                return [control.value, expectedValue];
                 """,
                 control,
                 str(value),
+                control_name == "draw-color",
             )
             assert updated_value == expected_value, (
                 f"Expected {control_name} to be {value}, got {updated_value}."

--- a/tests/pdf_viewer/test_pdf_draw_style_properties.py
+++ b/tests/pdf_viewer/test_pdf_draw_style_properties.py
@@ -1,0 +1,62 @@
+import pytest
+
+from modules.page_object import GenericPdf
+
+PDF_FILE_NAME = "i-9.pdf"
+INITIAL_COLOR = "#0060df"
+INITIAL_THICKNESS = 5
+INITIAL_OPACITY = 0.5
+UPDATED_COLOR = "#ff0039"
+UPDATED_THICKNESS = 10
+UPDATED_OPACITY = 0.75
+
+
+@pytest.fixture()
+def test_case():
+    return "1938262"
+
+
+@pytest.fixture()
+def hard_quit():
+    return True
+
+
+@pytest.fixture()
+def file_name():
+    return PDF_FILE_NAME
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("pdfjs.annotationEditorMode", 0)]
+
+
+def test_pdf_draw_color_thickness_and_opacity(pdf_viewer: GenericPdf):
+    """
+    C1938262: Verify drawing and an existing drawing use the selected color,
+    thickness, and opacity.
+    """
+    # Step 1: PDF is opened and the Text/Draw toolbar buttons are available.
+    pdf_viewer.element_visible("toolbar-text")
+    pdf_viewer.element_visible("toolbar-draw")
+
+    # Steps 2-5: Select Draw and configure its color, thickness, and opacity.
+    pdf_viewer.select_editor_tool("toolbar-draw")
+    pdf_viewer.element_visible("draw-options")
+    pdf_viewer.set_draw_style(INITIAL_COLOR, INITIAL_THICKNESS, INITIAL_OPACITY)
+
+    # Step 6: Draw an element and verify that it uses the selected style.
+    pdf_viewer.draw_on_pdf_page()
+    initial_style = pdf_viewer.get_drawing_style()
+    assert initial_style["color"] == INITIAL_COLOR
+    assert float(initial_style["opacity"]) == INITIAL_OPACITY
+
+    # Step 7: Select the drawing, change its style, and verify the update.
+    pdf_viewer.select_drawing_area()
+    pdf_viewer.element_visible("draw-options")
+    pdf_viewer.set_draw_style(UPDATED_COLOR, UPDATED_THICKNESS, UPDATED_OPACITY)
+    updated_style = pdf_viewer.get_drawing_style()
+
+    assert updated_style["color"] == UPDATED_COLOR
+    assert updated_style["thickness"] != initial_style["thickness"]
+    assert float(updated_style["opacity"]) == UPDATED_OPACITY

--- a/tests/pdf_viewer/test_pdf_draw_style_properties.py
+++ b/tests/pdf_viewer/test_pdf_draw_style_properties.py
@@ -58,5 +58,7 @@ def test_pdf_draw_color_thickness_and_opacity(pdf_viewer: GenericPdf):
     updated_style = pdf_viewer.get_drawing_style()
 
     assert updated_style["color"] == UPDATED_COLOR
-    assert updated_style["thickness"] != initial_style["thickness"]
+    assert float(updated_style["thickness"]) == pytest.approx(
+        float(initial_style["thickness"]) * UPDATED_THICKNESS / INITIAL_THICKNESS
+    )
     assert float(updated_style["opacity"]) == UPDATED_OPACITY

--- a/tests/pdf_viewer/test_pdf_draw_style_properties.py
+++ b/tests/pdf_viewer/test_pdf_draw_style_properties.py
@@ -49,6 +49,10 @@ def test_pdf_draw_color_thickness_and_opacity(pdf_viewer: GenericPdf):
     pdf_viewer.draw_on_pdf_page()
     initial_style = pdf_viewer.get_drawing_style()
     assert initial_style["color"] == INITIAL_COLOR
+    # The helper verifies the toolbar value. PDF.js scales the rendered SVG stroke,
+    # so establish a positive baseline and verify the proportional change below.
+    initial_thickness = float(initial_style["thickness"])
+    assert initial_thickness > 0
     assert float(initial_style["opacity"]) == INITIAL_OPACITY
 
     # Step 7: Select the drawing, change its style, and verify the update.
@@ -59,6 +63,6 @@ def test_pdf_draw_color_thickness_and_opacity(pdf_viewer: GenericPdf):
 
     assert updated_style["color"] == UPDATED_COLOR
     assert float(updated_style["thickness"]) == pytest.approx(
-        float(initial_style["thickness"]) * UPDATED_THICKNESS / INITIAL_THICKNESS
+        initial_thickness * UPDATED_THICKNESS / INITIAL_THICKNESS
     )
     assert float(updated_style["opacity"]) == UPDATED_OPACITY


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009709](https://bugzilla.mozilla.org/show_bug.cgi?id=2009709)
TestRail: [1938262](https://mozilla.testrail.io/index.php?/cases/view/1938262)

### Description of Code / Doc Changes

- Added PDF Draw color, thickness, and opacity coverage.
- Added reusable Draw style selectors and helpers.

Thank you!
