### PR TITLE
Akash/ Add test_website_language_can_be_added

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1366,6 +1366,10 @@ preferences:
     result: pass
     splits:
     - functional1
+  test_website_language_can_be_added:
+    result: pass
+    splits:
+    - functional1
   test_whats_new_link:
     result: pass
     splits:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -949,6 +949,54 @@
       "location": "about:preferences#paneLanguages Browser language section"
     }
   },
+  "website-language-heading": {
+    "selectorData": "moz-fieldset[data-l10n-id='website-language-heading']",
+    "strategy": "css",
+    "groups": [],
+    "comment": {
+      "description": "Website language card heading (Settings redesign)",
+      "location": "about:preferences#languages Website language section"
+    }
+  },
+  "website-language-picker": {
+    "selectorData": "websiteLanguagePicker",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "Add language moz-select on the Website language card",
+      "location": "about:preferences#languages Website language section"
+    }
+  },
+  "website-language-picker-select": {
+    "selectorData": "select",
+    "strategy": "css",
+    "shadowParent": "website-language-picker",
+    "groups": [],
+    "comment": {
+      "description": "Inner native <select> inside the Add language moz-select shadow DOM (shadowParent: website-language-picker)",
+      "location": "about:preferences#languages Website language section"
+    }
+  },
+  "website-language-add-button": {
+    "selectorData": "websiteLanguageAddLanguage",
+    "strategy": "id",
+    "groups": [],
+    "comment": {
+      "description": "Plus button that adds the language picked in the Add language dropdown",
+      "location": "about:preferences#languages Website language section"
+    }
+  },
+  "website-language-item": {
+    "selectorData": "moz-box-item:has(moz-button[locale='{code}'][action='remove'])",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Row for one accepted website language, found by locale code (label reads 'French [fr]')",
+      "location": "about:preferences#languages Website language section"
+    }
+  },
   "search-suggestion-in-private-windows": {
     "selectorData": "showSearchSuggestionsPrivateWindowsCheckbox",
     "strategy": "id",

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -971,7 +971,9 @@
     "selectorData": "select",
     "strategy": "css",
     "shadowParent": "website-language-picker",
-    "groups": [],
+    "groups": [
+      "doNotCache"
+    ],
     "comment": {
       "description": "Inner native <select> inside the Add language moz-select shadow DOM (shadowParent: website-language-picker)",
       "location": "about:preferences#languages Website language section"

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -275,6 +275,30 @@ class AboutPrefs(BasePage):
             )
         return self
 
+    def add_website_language(self, lang_code: str) -> BasePage:
+        """Adds a language to the Website language card on the Languages pane.
+
+        The Add language dropdown fills its options asynchronously, so wait for
+        the target option to show up before selecting it.
+
+        Args:
+            lang_code: The language code to add (e.g. 'fr', 'es')
+        """
+        self.wait.until(
+            lambda _: any(
+                opt.get_attribute("value") == lang_code
+                for opt in self.get_element(
+                    "website-language-picker-select"
+                ).find_elements(By.TAG_NAME, "option")
+            )
+        )
+        Select(self.get_element("website-language-picker-select")).select_by_value(
+            lang_code
+        )
+        self.element_attribute_is("website-language-picker", "value", lang_code)
+        self.click_on("website-language-add-button")
+        return self
+
     def open_doh_advanced(self) -> BasePage:
         """Open the DoH Advanced settings sub-pane.
 

--- a/tests/preferences/test_website_language_can_be_added.py
+++ b/tests/preferences/test_website_language_can_be_added.py
@@ -1,0 +1,41 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutPrefs
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Website language card lives in Settings > Languages.
+    return "languages"
+
+
+@pytest.fixture()
+def test_case():
+    return "3399157"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+LANGUAGES = ["fr", "es"]
+
+
+def test_website_language_can_be_added(driver: Firefox, about_prefs: AboutPrefs):
+    """
+    C3399157 - Languages in the 'Website language' can be added.
+    """
+    about_prefs.open()
+    about_prefs.element_visible("website-language-heading")
+
+    # Pick each language in the Add language dropdown and add it.
+    for language in LANGUAGES:
+        about_prefs.add_website_language(language)
+        about_prefs.element_visible("website-language-item", labels=[language])
+
+    # Both languages stay listed in the Website language section.
+    for language in LANGUAGES:
+        about_prefs.element_visible("website-language-item", labels=[language])


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047162](https://bugzilla.mozilla.org/show_bug.cgi?id=2047162)
TestRail: [3399157](https://mozilla.testrail.io/index.php?/cases/view/3399157)

### Description of Code / Doc Changes

- Adds `tests/preferences/test_website_language_can_be_added.py`, covering C3399157, adding languages to the Website language card in the redesigned Settings.
- Adds elements for the Website language card to `about_prefs.components.json` the card heading, the "Add language" dropdown and its inner select, the add button and a row selector that finds a language by its locale code.
- Adds `add_website_language()` to `AboutPrefs`, which waits for the dropdown to fill in, picks a language and clicks the add button.
- Registers the test in `manifests/key.yaml` as `pass` in the `functional1` split.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The language rows have no IDs, so they are found through the remove button inside each row, which carries the locale code.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.