### PR TITLE
Akash/ Add website language reorder and delete tests

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1370,6 +1370,14 @@ preferences:
     result: pass
     splits:
     - functional1
+  test_website_language_can_be_deleted:
+    result: pass
+    splits:
+    - functional1
+  test_website_language_can_be_reordered:
+    result: pass
+    splits:
+    - functional1
   test_whats_new_link:
     result: pass
     splits:

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -999,6 +999,28 @@
       "location": "about:preferences#languages Website language section"
     }
   },
+  "website-language-remove-button": {
+    "selectorData": "moz-button[locale='{code}'][action='remove']",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Delete button on one accepted website language row, found by locale code",
+      "location": "about:preferences#languages Website language section"
+    }
+  },
+  "website-language-remove-buttons": {
+    "selectorData": "moz-button[action='remove']",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Every website language row's delete button, in list order (locale attribute holds the code)",
+      "location": "about:preferences#languages Website language section"
+    }
+  },
   "search-suggestion-in-private-windows": {
     "selectorData": "showSearchSuggestionsPrivateWindowsCheckbox",
     "strategy": "id",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -299,6 +299,40 @@ class AboutPrefs(BasePage):
         self.click_on("website-language-add-button")
         return self
 
+    def get_website_language_order(self) -> List[str]:
+        """Returns the locale codes on the Website language card, in list order."""
+        return [
+            button.get_attribute("locale")
+            for button in self.get_elements("website-language-remove-buttons")
+        ]
+
+    def move_website_language(self, lang_code: str, direction: str) -> BasePage:
+        """Moves a language up or down on the Website language card.
+
+        The list is a reorderable moz-box-group: Ctrl+Shift+ArrowUp/ArrowDown is
+        the Move Up / Move Down action, and the row itself has to be focused for
+        the group to pick the keypress up.
+
+        Args:
+            lang_code: The language code to move (e.g. 'fr')
+            direction: 'up' or 'down'
+        """
+        self.click_on("website-language-item", labels=[lang_code])
+        arrow = Keys.ARROW_UP if direction == "up" else Keys.ARROW_DOWN
+        self.actions.key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys(
+            arrow
+        ).key_up(Keys.SHIFT).key_up(Keys.CONTROL).perform()
+        return self
+
+    def remove_website_language(self, lang_code: str) -> BasePage:
+        """Deletes a language from the Website language card.
+
+        Args:
+            lang_code: The language code to delete (e.g. 'fr')
+        """
+        self.click_on("website-language-remove-button", labels=[lang_code])
+        return self
+
     def open_doh_advanced(self) -> BasePage:
         """Open the DoH Advanced settings sub-pane.
 

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -306,7 +306,9 @@ class AboutPrefs(BasePage):
             for button in self.get_elements("website-language-remove-buttons")
         ]
 
-    def move_website_language(self, lang_code: str, direction: str) -> BasePage:
+    def move_website_language(
+        self, lang_code: str, direction: Literal["up", "down"]
+    ) -> BasePage:
         """Moves a language up or down on the Website language card.
 
         The list is a reorderable moz-box-group: Ctrl+Shift+ArrowUp/ArrowDown is

--- a/tests/preferences/test_website_language_can_be_deleted.py
+++ b/tests/preferences/test_website_language_can_be_deleted.py
@@ -1,0 +1,41 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutPrefs
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Website language card lives in Settings > Languages.
+    return "languages"
+
+
+@pytest.fixture()
+def test_case():
+    return "3399159"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+LANGUAGES = ["fr", "es"]
+
+
+def test_website_language_can_be_deleted(driver: Firefox, about_prefs: AboutPrefs):
+    """
+    C3399159 - Languages in the 'Website language' section can be deleted.
+    """
+    about_prefs.open()
+    about_prefs.element_visible("website-language-heading")
+
+    for language in LANGUAGES:
+        about_prefs.add_website_language(language)
+        about_prefs.element_visible("website-language-item", labels=[language])
+
+    # Each Delete button removes only its own row.
+    for language in LANGUAGES:
+        about_prefs.remove_website_language(language)
+        about_prefs.element_not_visible("website-language-item", labels=[language])

--- a/tests/preferences/test_website_language_can_be_deleted.py
+++ b/tests/preferences/test_website_language_can_be_deleted.py
@@ -36,6 +36,8 @@ def test_website_language_can_be_deleted(driver: Firefox, about_prefs: AboutPref
         about_prefs.element_visible("website-language-item", labels=[language])
 
     # Each Delete button removes only its own row.
-    for language in LANGUAGES:
+    for i, language in enumerate(LANGUAGES):
         about_prefs.remove_website_language(language)
         about_prefs.element_not_visible("website-language-item", labels=[language])
+        for remaining in LANGUAGES[i + 1 :]:
+            about_prefs.element_visible("website-language-item", labels=[remaining])

--- a/tests/preferences/test_website_language_can_be_reordered.py
+++ b/tests/preferences/test_website_language_can_be_reordered.py
@@ -1,0 +1,49 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutPrefs
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Website language card lives in Settings > Languages.
+    return "languages"
+
+
+@pytest.fixture()
+def test_case():
+    return "3399158"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+LANGUAGES = ["fr", "es"]
+
+
+def test_website_language_can_be_reordered(driver: Firefox, about_prefs: AboutPrefs):
+    """
+    C3399158 - Languages in the 'Website language' can be reordered.
+    """
+    about_prefs.open()
+    about_prefs.element_visible("website-language-heading")
+
+    # Add each language, newest first, then confirm the starting order.
+    for language in LANGUAGES:
+        about_prefs.add_website_language(language)
+        about_prefs.element_visible("website-language-item", labels=[language])
+    original_order = about_prefs.get_website_language_order()
+
+    # Move Down on the first language swaps it with the one below it.
+    about_prefs.move_website_language(original_order[0], "down")
+    moved_down = [original_order[1], original_order[0], *original_order[2:]]
+    about_prefs.expect(lambda _: about_prefs.get_website_language_order() == moved_down)
+
+    # Move Up puts it back where it started.
+    about_prefs.move_website_language(original_order[0], "up")
+    about_prefs.expect(
+        lambda _: about_prefs.get_website_language_order() == original_order
+    )


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047163](https://bugzilla.mozilla.org/show_bug.cgi?id=2047163), [2047164](https://bugzilla.mozilla.org/show_bug.cgi?id=2047164)
TestRail: [3399158](https://mozilla.testrail.io/index.php?/cases/view/3399158), [3399159](https://mozilla.testrail.io/index.php?/cases/view/3399159)

### Description of Code / Doc Changes

- Adds `test_website_language_can_be_reordered.py` (C3399158) and `test_website_language_can_be_deleted.py` (C3399159) to the `preferences` suite.
- Adds `get_website_language_order`, `move_website_language`, and `remove_website_language` to `AboutPrefs`.
- Adds `website-language-remove-button` and `website-language-remove-buttons` to `about_prefs.components.json`.
- Registers both tests in `manifests/key.yaml` under `functional1`.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

The Website language list is a reorderable `moz-box-group`. It has no 3 dot menu, so the Move Up and Move Down steps in C3399158 are covered by the keyboard shortcut the list actually ships, Ctrl+Shift+ArrowUp / Ctrl+Shift+ArrowDown on the focused row.

### Comments or Future Work

C3399158 also asks for reordering by drag and drop, which is not covered here. The list uses HTML5 drag events, which Selenium mouse actions do not fire reliably in Firefox. The test case steps mention a 3 dot menu with Move to Top and Move to Bottom that does not exist in the build, so the case may need updating.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack