### PR TITLE
Akash/ Wait for find toolbar to open before search

### DIFF
--- a/modules/browser_object_find_toolbar.py
+++ b/modules/browser_object_find_toolbar.py
@@ -23,6 +23,8 @@ class FindToolbar(BasePage):
         self.panel_ui.open_panel_menu()
         self.panel_ui.click_on("find-in-page")
         self.wait_for_page_to_load()
+        # the toolbar is in the DOM before it opens, so wait for it to show
+        self.element_visible("find-toolbar-input")
         return self
 
     @BasePage.context_chrome
@@ -34,6 +36,8 @@ class FindToolbar(BasePage):
             mod_key = Keys.CONTROL
         self.perform_key_combo(mod_key, "f")
         self.wait_for_page_to_load()
+        # the toolbar is in the DOM before it opens, so wait for it to show
+        self.element_visible("find-toolbar-input")
         return self
 
     @BasePage.context_chrome


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2070479](https://bugzilla.mozilla.org/show_bug.cgi?id=2070479)
TestRail: [127276](https://mozilla.testrail.io/index.php?/cases/view/127276)

### Description of Code / Doc Changes

Wait for the find toolbar to be visible, not just present in the DOM, in `FindToolbar.open()` and `FindToolbar.open_with_key_combo()`

### Process Changes Required

- [x] Changes or creates a BOM/POM (name the object model): FindToolbar

### Screenshots or Explanations

`test_find_word_with_special_characters_2` failed on Windows with `ElementNotInteractableException: could not be scrolled into view`.

Firefox adds the `<findbar>` to the DOM before it opens it. `wait_for_page_to_load()` only checks that elements are present, so it returned during that gap and `find()` clicked an input that was still hidden. Waiting for the input to be visible closes the race. Not a Firefox bug, and not specific to the Japanese page or the search term.

Full `tests/find_toolbar` suite green on Windows and macOS, 11 passed each.

### Comments or Future Work

Other BOMs relying on `wait_for_page_to_load()` for lazily built chrome UI may have the same presence-vs-visible gap. Worth a look if similar Windows-only flakes turn up.

### Workflow Checklist

- [ ] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!