### PR TITLE
Akash/ Fix image context menu URL check and save flake

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -787,11 +787,7 @@ menus:
     splits:
     - smoke
   test_image_context_menu_actions:
-    comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2049603
-    result:
-      linux: unstable
-      mac: pass
-      win: unstable
+    result: pass
     splits:
     - functional2
     - nightly

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -25,7 +25,7 @@ LINK_IMAGE_URL = (
 )
 # The thumbnail host varies (upload/thumb) and may have a query string.
 LOADED_IMAGE_URL = (
-    r"https://[\w-]+\.wikimedia\.org/wikipedia/commons/thumb/a/a0/Firefox_logo%2C_2019\.svg/\d+px"
+    r"https://[a-zA-Z0-9-]+\.wikimedia\.org/wikipedia/commons/thumb/a/a0/Firefox_logo%2C_2019\.svg/\d+px"
     r"-Firefox_logo%2C_2019\.svg\.png"
 )
 # Match the saved file by stem; the served format varies (.webp/.png).

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -1,6 +1,5 @@
 import os
 import re
-from time import monotonic, sleep
 
 import pytest
 from selenium.webdriver import Firefox
@@ -24,18 +23,17 @@ def delete_files_regex_string():
 LINK_IMAGE_URL = (
     "https://en.wikipedia.org/wiki/Firefox#/media/File:Firefox_logo,_2019.svg"
 )
+# The thumbnail host varies (upload/thumb) and may have a query string.
 LOADED_IMAGE_URL = (
-    r"https://upload\.wikimedia\.org/wikipedia/commons/thumb/a/a0/Firefox_logo%2C_2019\.svg/\d+px"
+    r"https://[\w-]+\.wikimedia\.org/wikipedia/commons/thumb/a/a0/Firefox_logo%2C_2019\.svg/\d+px"
     r"-Firefox_logo%2C_2019\.svg\.png"
 )
 # Match the saved file by stem; the served format varies (.webp/.png).
 SAVED_IMAGE_STEM = "Firefox_logo,_2019.svg"
 # Mock picker needs a deterministic target path; the extension is the test's
-# choice (we only verify a non-empty file was saved). Native saves are auto-named.
+# choice (we only verify a non-empty file was saved).
 SAVED_IMAGE_FILENAME = f"{SAVED_IMAGE_STEM}.png"
-# Poll for the saved file, re-confirming the native save dialog each tick.
 SAVE_TIMEOUT_SECONDS = 15
-SAVE_POLL_INTERVAL_SECONDS = 1
 
 
 def test_open_image_in_new_tab(driver: Firefox):
@@ -64,13 +62,11 @@ def test_open_image_in_new_tab(driver: Firefox):
     wiki_image_page.verify_opened_image_url("wikimedia", LOADED_IMAGE_URL)
 
 
-@pytest.mark.headed
-def test_save_image_as(driver: Firefox, sys_platform, downloads_folder, delete_files):
+def test_save_image_as(driver: Firefox, downloads_folder, delete_files):
     """
     C2637622.2: save image as
     """
-    wiki_image_page = GenericPage(driver, url=LINK_IMAGE_URL)
-    wiki_image_page.open()
+    wiki_image_page = GenericPage(driver, url=LINK_IMAGE_URL).open()
     image_context_menu = ContextMenu(driver)
 
     # Wait for page to load
@@ -80,53 +76,22 @@ def test_save_image_as(driver: Firefox, sys_platform, downloads_folder, delete_f
     image_logo = wiki_image_page.get_element("mediawiki-image")
     wiki_image_page.context_click(image_logo)
 
-    # Linux CI can't reliably drive the native "Save As" dialog, so use the mock
-    # file picker, which is the repo convention for downloads. Other platforms
-    # confirm the native dialog.
-    use_mock_picker = sys_platform == "Linux"
-    mock_saved_image_location = os.path.join(downloads_folder, SAVED_IMAGE_FILENAME)
-    if use_mock_picker:
-        wiki_image_page.install_mock_file_picker(mock_saved_image_location)
-
+    # mock the native save dialog, which CI cannot drive reliably
+    saved_image_location = os.path.join(downloads_folder, SAVED_IMAGE_FILENAME)
+    wiki_image_page.install_mock_file_picker(saved_image_location)
     try:
         # Save the image
         image_context_menu.click_and_hide_menu("context-menu-save-image-as")
-
-        if use_mock_picker:
-            wiki_image_page.wait_for_mock_file_picker()
-            wiki_image_page.custom_wait(timeout=SAVE_TIMEOUT_SECONDS).until(
-                lambda _: (
-                    os.path.exists(mock_saved_image_location)
-                    and os.path.getsize(mock_saved_image_location) > 0
-                ),
-                message=f"No non-empty saved image at {mock_saved_image_location}",
-            )
-        else:
-            # Native dialog path: the save dialog opens after a variable delay, so
-            # re-confirm on a poll loop until a non-empty file matching the stem appears.
-            saved_image_location = None
-            end_time = monotonic() + SAVE_TIMEOUT_SECONDS
-            while monotonic() < end_time:
-                wiki_image_page.handle_os_download_confirmation()
-                saved_image_location = next(
-                    (
-                        os.path.join(downloads_folder, name)
-                        for name in os.listdir(downloads_folder)
-                        if name.startswith(SAVED_IMAGE_STEM)
-                        and os.path.getsize(os.path.join(downloads_folder, name)) > 0
-                    ),
-                    None,
-                )
-                if saved_image_location:
-                    break
-                sleep(SAVE_POLL_INTERVAL_SECONDS)
-
-            assert saved_image_location, (
-                f"No saved image matching '{SAVED_IMAGE_STEM}*' found in {downloads_folder}"
-            )
+        wiki_image_page.wait_for_mock_file_picker()
     finally:
-        if use_mock_picker:
-            wiki_image_page.cleanup_mock_file_picker()
+        wiki_image_page.cleanup_mock_file_picker()
+
+    # verify a non-empty file was written
+    wiki_image_page.custom_wait(timeout=SAVE_TIMEOUT_SECONDS).until(
+        lambda _: os.path.exists(saved_image_location)
+        and os.path.getsize(saved_image_location) > 0,
+        message=f"No non-empty saved image at {saved_image_location}",
+    )
 
 
 def test_copy_image_link(driver: Firefox):

--- a/tests/menus/test_image_context_menu_actions.py
+++ b/tests/menus/test_image_context_menu_actions.py
@@ -1,5 +1,5 @@
-import os
 import re
+from pathlib import Path
 
 import pytest
 from selenium.webdriver import Firefox
@@ -36,6 +36,13 @@ SAVED_IMAGE_FILENAME = f"{SAVED_IMAGE_STEM}.png"
 SAVE_TIMEOUT_SECONDS = 15
 
 
+def new_tab_handle(driver: Firefox, original_handles: set[str]) -> str:
+    """Return the handle of the tab opened since original_handles was taken."""
+    new_handles = set(driver.window_handles) - original_handles
+    assert len(new_handles) == 1, f"Expected exactly one new tab, got {new_handles}"
+    return new_handles.pop()
+
+
 def test_open_image_in_new_tab(driver: Firefox):
     """
     C2637622.1: open an image in a new tab
@@ -52,12 +59,15 @@ def test_open_image_in_new_tab(driver: Firefox):
     image_logo = wiki_image_page.get_element("mediawiki-image")
     wiki_image_page.context_click(image_logo)
 
+    # note the open tabs so we can pick out the new one
+    original_handles = set(driver.window_handles)
+
     # open in a new tab
     image_context_menu.click_and_hide_menu("context-menu-open-image-in-new-tab")
 
-    # switch to the second tab and verify the URL
+    # switch to the new tab and verify the URL
     tabs.wait_for_num_tabs(2)
-    driver.switch_to.window(driver.window_handles[1])
+    driver.switch_to.window(new_tab_handle(driver, original_handles))
     wiki_image_page.wait_for_page_to_load()
     wiki_image_page.verify_opened_image_url("wikimedia", LOADED_IMAGE_URL)
 
@@ -77,8 +87,8 @@ def test_save_image_as(driver: Firefox, downloads_folder, delete_files):
     wiki_image_page.context_click(image_logo)
 
     # mock the native save dialog, which CI cannot drive reliably
-    saved_image_location = os.path.join(downloads_folder, SAVED_IMAGE_FILENAME)
-    wiki_image_page.install_mock_file_picker(saved_image_location)
+    saved_image_location = Path(downloads_folder) / SAVED_IMAGE_FILENAME
+    wiki_image_page.install_mock_file_picker(str(saved_image_location))
     try:
         # Save the image
         image_context_menu.click_and_hide_menu("context-menu-save-image-as")
@@ -88,8 +98,8 @@ def test_save_image_as(driver: Firefox, downloads_folder, delete_files):
 
     # verify a non-empty file was written
     wiki_image_page.custom_wait(timeout=SAVE_TIMEOUT_SECONDS).until(
-        lambda _: os.path.exists(saved_image_location)
-        and os.path.getsize(saved_image_location) > 0,
+        lambda _: saved_image_location.exists()
+        and saved_image_location.stat().st_size > 0,
         message=f"No non-empty saved image at {saved_image_location}",
     )
 
@@ -114,10 +124,11 @@ def test_copy_image_link(driver: Firefox):
     # copy the link
     image_context_menu.click_and_hide_menu("context-menu-copy-image-link")
 
-    # open a new tab
+    # open a new tab and switch to it
+    original_handles = set(driver.window_handles)
     tabs.new_tab_by_button()
     tabs.wait_for_num_tabs(2)
-    driver.switch_to.window(driver.window_handles[1])
+    driver.switch_to.window(new_tab_handle(driver, original_handles))
 
     # context click and paste
     search_bar = nav.get_awesome_bar()


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2070538](https://bugzilla.mozilla.org/show_bug.cgi?id=2070538)
TestRail: --

### Description of Code / Doc Changes

* Updated the expected image URL pattern. Wikipedia moved thumbnails to `thumb.wikimedia.org` and added `?utm_*` params, breaking the hardcoded host on every platform.
* `test_save_image_as` now mocks the file picker on all platforms, not just Linux. Driving the real OS save dialog was the cause of the Mac and Windows instability.
* Dropped the `@pytest.mark.headed` marker, since the test no longer needs desktop input.
* * Flipped `manifests/key.yaml` from `unstable` on Linux and Windows to `result: pass`, since the native dialog that caused the instability is gone.

### Process Changes Required
--

### Screenshots or Explanations

The URL check uses `re.match`, which only anchors the start, so the trailing query string does not need to be matched. Only the host needed to become flexible: `[\w-]+\.wikimedia\.org`.

All 3 subtests pass locally on Mac and Windows, headed and headless.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.