### PR TITLE
Akash/ Add test_preferred_language_can_be_added

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1361,6 +1361,10 @@ preferences:
     result: unstable
     splits:
     - functional2
+  test_preferred_language_can_be_added:
+    result: pass
+    splits:
+    - functional1
   test_support_get_help:
     result: pass
     splits:

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -275,6 +275,21 @@ class AboutPrefs(BasePage):
             )
         return self
 
+    def get_installed_browser_languages(self) -> List[str]:
+        """Returns the locale codes already downloaded, in Preferred language order.
+
+        The dropdown lists the installed locales first, then an <hr>, then the
+        locales that are still only available to download.
+        """
+        codes = []
+        for option in self.get_element(
+            "browser-language-preferred-select"
+        ).find_elements(By.CSS_SELECTOR, "option, hr"):
+            if option.tag_name == "hr":
+                break
+            codes.append(option.get_attribute("value"))
+        return codes
+
     def add_website_language(self, lang_code: str) -> BasePage:
         """Adds a language to the Website language card on the Languages pane.
 

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -279,8 +279,15 @@ class AboutPrefs(BasePage):
         """Returns the locale codes already downloaded, in Preferred language order.
 
         The dropdown lists the installed locales first, then an <hr>, then the
-        locales that are still only available to download.
+        locales that are still only available to download. The <hr> is the only
+        marker splitting the two, and the download-only half is fetched
+        asynchronously, so wait for it instead of reading a half-built list.
         """
+        self.wait.until(
+            lambda _: self.get_element(
+                "browser-language-preferred-select"
+            ).find_elements(By.TAG_NAME, "hr")
+        )
         codes = []
         for option in self.get_element(
             "browser-language-preferred-select"

--- a/tests/preferences/test_preferred_language_can_be_added.py
+++ b/tests/preferences/test_preferred_language_can_be_added.py
@@ -1,0 +1,56 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.page_object import AboutPrefs
+
+
+@pytest.fixture()
+def about_prefs_category():
+    # The Preferred language dropdown lives in Settings > Languages.
+    return "languages"
+
+
+@pytest.fixture()
+def test_case():
+    return "3399148"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [
+        ("browser.settings-redesign.enabled", True),
+        ("intl.multilingual.enabled", True),
+        ("intl.multilingual.downloadEnabled", True),
+        ("intl.multilingual.liveReload", True),
+    ]
+
+
+LANGUAGES = ["fr", "de"]
+
+
+def test_preferred_language_can_be_added(driver: Firefox, about_prefs: AboutPrefs):
+    """
+    C3399148 - Language can be added to the 'Preferred language' dropdown.
+    """
+    about_prefs.open()
+    about_prefs.element_visible("browser-language-heading")
+
+    # Only the shipped locale is downloaded when the pane first opens.
+    downloaded = about_prefs.get_installed_browser_languages()
+    for language in LANGUAGES:
+        assert language not in downloaded, f"{language} was already downloaded."
+
+    # Picking a language that isn't downloaded yet installs its language pack.
+    for language in LANGUAGES:
+        about_prefs.set_alternative_language(language)
+        about_prefs.expect(
+            lambda _, lang=language: lang
+            in about_prefs.get_installed_browser_languages()
+        )
+
+    # Reopening the pane still lists every downloaded language.
+    about_prefs.open()
+    downloaded = about_prefs.get_installed_browser_languages()
+    for language in LANGUAGES:
+        assert language in downloaded, f"{language} is missing from the dropdown."


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2047155](https://bugzilla.mozilla.org/show_bug.cgi?id=2047155)
TestRail: [3399148](https://mozilla.testrail.io/index.php?/cases/view/3399148)

### Description of Code / Doc Changes

* Adds `tests/preferences/test_preferred_language_can_be_added.py`, covering C3399148, a language can be added to the Preferred language dropdown in Settings > Languages
* Adds `AboutPrefs.get_installed_browser_languages()`, which returns the locale codes that are already downloaded.
* Registers the test in `manifests/key.yaml` under the `functional1`

### Process Changes Required

- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs

### Screenshots or Explanations

--

### Comments or Future Work

Langpacks come from addons.mozilla.org, which has none for Nightly. `functional1` is not used by nightly runs, so no `exclude_nightly` is needed

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.