### PR TITLE
Anca/ Add doh failure falls back to dns

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -839,6 +839,10 @@ networking:
     result: pass
     splits:
     - smoke
+  test_doh_failure_falls_back_to_dns:
+    result: pass
+    splits:
+    - functional1
   test_heuristics_disabled_when_trr_mode_2:
     result: pass
     splits:
@@ -1239,12 +1243,12 @@ pdf_viewer:
     splits:
     - functional2
     - nightly
-  test_pdf_drawing_area_actions:
+  test_pdf_draw_style_properties:
     result: pass
     splits:
     - functional2
     - nightly
-  test_pdf_draw_style_properties:
+  test_pdf_drawing_area_actions:
     result: pass
     splits:
     - functional2

--- a/tests/networking/test_doh_failure_falls_back_to_dns.py
+++ b/tests/networking/test_doh_failure_falls_back_to_dns.py
@@ -6,7 +6,9 @@ from modules.page_object import AboutNetworking
 
 TEST_URL = "https://www.wikipedia.org/"
 TEST_HOST = "www.wikipedia.org"
-UNREACHABLE_DOH_URL = "https://127.0.0.1:1/dns-query"
+# Use a high, non-restricted local port so Firefox attempts the DoH connection
+# instead of rejecting the URL before any network connection is made.
+UNREACHABLE_DOH_URL = "https://127.0.0.1:65535/dns-query"
 
 
 @pytest.fixture()

--- a/tests/networking/test_doh_failure_falls_back_to_dns.py
+++ b/tests/networking/test_doh_failure_falls_back_to_dns.py
@@ -2,7 +2,7 @@ import pytest
 from selenium.webdriver import Firefox
 
 from modules.browser_object import TabBar
-from modules.page_object import AboutNetworking, GenericPage
+from modules.page_object import AboutNetworking
 
 TEST_URL = "https://www.wikipedia.org/"
 TEST_HOST = "www.wikipedia.org"
@@ -28,12 +28,11 @@ def test_doh_failure_falls_back_to_dns(driver: Firefox):
     are successfully handled by the DNS server instead.
     """
     # Instantiate objects
-    test_page = GenericPage(driver, url=TEST_URL)
     networking = AboutNetworking(driver)
     tabs = TabBar(driver)
 
     # Trigger a DNS request while the configured DoH server is unreachable
-    test_page.open()
+    driver.get(TEST_URL)
 
     # Verify that Firefox falls back to the native DNS resolver
     tabs.open_and_switch_to_new_tab()

--- a/tests/networking/test_doh_failure_falls_back_to_dns.py
+++ b/tests/networking/test_doh_failure_falls_back_to_dns.py
@@ -6,7 +6,7 @@ from modules.page_object import AboutNetworking, GenericPage
 
 TEST_URL = "https://www.wikipedia.org/"
 TEST_HOST = "www.wikipedia.org"
-UNREACHABLE_DOH_UR = "https://127.0.0.1:1/dns-query"
+UNREACHABLE_DOH_URL = "https://127.0.0.1:1/dns-query"
 
 
 @pytest.fixture()
@@ -18,7 +18,7 @@ def test_case():
 def add_to_prefs_list():
     return [
         ("network.trr.mode", 2),
-        ("network.trr.uri", UNREACHABLE_DOH_UR),
+        ("network.trr.uri", UNREACHABLE_DOH_URL),
     ]
 
 

--- a/tests/networking/test_doh_failure_falls_back_to_dns.py
+++ b/tests/networking/test_doh_failure_falls_back_to_dns.py
@@ -1,0 +1,43 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import TabBar
+from modules.page_object import AboutNetworking, GenericPage
+
+TEST_URL = "https://www.wikipedia.org/"
+TEST_HOST = "www.wikipedia.org"
+UNREACHABLE_DOH_UR = "https://127.0.0.1:1/dns-query"
+
+
+@pytest.fixture()
+def test_case():
+    return "463507"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [
+        ("network.trr.mode", 2),
+        ("network.trr.uri", UNREACHABLE_DOH_UR),
+    ]
+
+
+def test_doh_failure_falls_back_to_dns(driver: Firefox):
+    """
+    C463507 - Verify that requests which fail to connect to the DoH server
+    are successfully handled by the DNS server instead.
+    """
+    # Instantiate objects
+    test_page = GenericPage(driver, url=TEST_URL)
+    networking = AboutNetworking(driver)
+    tabs = TabBar(driver)
+
+    # Trigger a DNS request while the configured DoH server is unreachable
+    test_page.open()
+
+    # Verify that Firefox falls back to the native DNS resolver
+    tabs.open_and_switch_to_new_tab()
+
+    networking.open()
+    networking.select_network_category("dns")
+    networking.wait_for_dns_entry(TEST_HOST, trr="false")


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2011135](https://bugzilla.mozilla.org/show_bug.cgi?id=2011135)
TestRail: [463507](https://mozilla.testrail.io/index.php?/cases/view/463507)

### Description of Code / Doc Changes

- Add doh failure falls back to dns
- scripts/addtests.py re-sorted key.yaml alphabetically
### Process Changes Required

_Mark the relevant boxes, delete irrelevant lines._

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [ ] Changes or creates a BOM/POM (name the object model): _
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

_If you need to explain your code, do it here._

### Comments or Future Work

_Do we need to start another PR soon to address something you saw while working on this?_

### Workflow Checklist

- [X] Reviewers have been requested.
- [X] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!
