### PR TITLE
Akash/ Fix theme tests for nova UI in Fx157

### DIFF
--- a/modules/data/about_addons.components.json
+++ b/modules/data/about_addons.components.json
@@ -35,7 +35,22 @@
   "find-more-themes-button": {
     "selectorData": "button[data-l10n-id='find-more-themes']",
     "strategy": "css",
-    "groups": []
+    "groups": [],
+    "comment": {
+      "description": "Find more themes footer button. CSS hides it under browser.nova.enabled, the default from Fx157 on",
+      "location": "about:addons Themes view footer"
+    }
+  },
+  "find-more-themes-promo-button": {
+    "selectorData": "moz-button[data-l10n-id='find-more-themes-promo-open-amo-button']",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "Explore themes button, which replaces find-more-themes-button under browser.nova.enabled (Fx157+)",
+      "location": "about:addons Themes view, promo card at the bottom"
+    }
   },
   "install-theme-button": {
     "selectorData": "button[data-l10n-id='install-theme-button']",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -1873,6 +1873,25 @@ class AboutAddons(BasePage):
             else:
                 return background_color
 
+    def click_find_more_themes(self) -> BasePage:
+        """Clicks the control that opens the AMO themes page in a new tab.
+
+        Under browser.nova.enabled, the default from Fx157 on, CSS hides the
+        footer button and the promo card's Explore themes button takes over.
+        Older builds show the footer button, so click whichever one this build
+        actually displays.
+        """
+
+        def displayed_button(_):
+            for name in ("find-more-themes-promo-button", "find-more-themes-button"):
+                for button in self.get_elements(name):
+                    if button.is_displayed():
+                        return button
+            return False
+
+        self.wait.until(displayed_button).click()
+        return self
+
     def is_devedition(self):
         active_theme_el = self.driver.find_element(
             By.CSS_SELECTOR, ".card.addon[active] h3.addon-name"

--- a/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
+++ b/tests/theme_and_toolbar/test_customize_themes_and_redirect.py
@@ -16,6 +16,7 @@ COMPACT_LIGHT = "firefox-compact-light_mozilla_org-heading"
 
 THEMES: dict[str, list[str]] = {
     COMPACT_DARK: [
+        "rgb(23, 21, 25)",  # nova dark, the default from Fx157 on
         "rgb(43, 42, 51)",  # classic darker tone
         "rgb(143, 143, 148)",  # focused dark
         "rgb(120, 119, 126)",  # dark without focus

--- a/tests/theme_and_toolbar/test_installed_theme_enabled.py
+++ b/tests/theme_and_toolbar/test_installed_theme_enabled.py
@@ -21,7 +21,7 @@ def test_find_more_themes(driver: Firefox) -> None:
     """
     about_addons = AboutAddons(driver).open()
     about_addons.choose_sidebar_option("theme")
-    about_addons.get_element("find-more-themes-button").click()
+    about_addons.click_find_more_themes()
 
     driver.switch_to.window(driver.window_handles[-1])
 


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2071215](https://bugzilla.mozilla.org/show_bug.cgi?id=2071215), [2071216](https://bugzilla.mozilla.org/show_bug.cgi?id=2071216)
TestRail: [118173](https://mozilla.testrail.io/index.php?/cases/view/118173), [118174](https://mozilla.testrail.io/index.php?/cases/view/118174)

### Description of Code / Doc Changes

* Accepts nova's dark theme toolbar color `rgb(23, 21, 25)` in `test_customize_themes_and_redirect.py`, alongside the existing values.
* Adds a `find-more-themes-promo-button` selector and `AboutAddons.click_find_more_themes()`, which clicks whichever button the build shows.
* Points `test_find_more_themes` at that method.

### Process Changes Required

- [ ] Adds a dependency (rerun `uv sync`)
- [ ] Modifies a git hook (rerun `./devsetup.sh`)
- [ ] Changes the BasePage
- [x] Changes or creates a BOM/POM (name the object model): AboutAddons
- [ ] Changes CI flow
- [ ] Changes scheduled Beta / DevEdition / RC
- [ ] Changes Autofill L10n harness

### Screenshots or Explanations

Both tests broke because `browser.nova.enabled` defaults to true in 157. Nova changes the dark theme color and hides the old "Find more themes" footer button in favour of the promo card button (Bug 2057200).

Verified on 156.0 and 157.0b1: both pass on both builds.

### Comments or Future Work

Surfaced by #1642, where CI selected these two tests because `AboutAddons` lives in `page_object_prefs.py`. That PR is red on these two failures and should go green once this lands.

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.