### PR TITLE
vs/Add test for copy paste drawings.

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1235,12 +1235,17 @@ pdf_viewer:
     splits:
     - functional2
     - nightly
+  test_pdf_draw_style_properties:
+    result: pass
+    splits:
+    - functional2
+    - nightly
   test_pdf_drawing_area_actions:
     result: pass
     splits:
     - functional2
     - nightly
-  test_pdf_draw_style_properties:
+  test_pdf_drawing_can_be_copied_cut_and_pasted_with_keyboard:
     result: pass
     splits:
     - functional2

--- a/modules/data/generic_pdf.components.json
+++ b/modules/data/generic_pdf.components.json
@@ -272,6 +272,13 @@
       "doNotCache"
     ]
   },
+  "drawing-area": {
+    "selectorData": ".canvasWrapper svg.draw",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ]
+  },
   "added-text": {
     "selectorData": ".freeTextEditor",
     "strategy": "css",

--- a/modules/page_object_generics.py
+++ b/modules/page_object_generics.py
@@ -490,6 +490,11 @@ class GenericPdf(BasePage):
 
         return drawing_area
 
+    def wait_for_drawing_area_count(self, expected_count: int) -> BasePage:
+        """Wait until the expected number of drawing areas exists."""
+        self.expect(lambda _: len(self.get_elements("drawing-area")) == expected_count)
+        return self
+
     def get_drawing_resize_handle(self, drawing_area: WebElement) -> WebElement:
         """
         Return the resize handle for the selected drawing area.

--- a/tests/pdf_viewer/test_pdf_drawing_can_be_copied_cut_and_pasted_with_keyboard.py
+++ b/tests/pdf_viewer/test_pdf_drawing_can_be_copied_cut_and_pasted_with_keyboard.py
@@ -1,0 +1,46 @@
+import pytest
+from selenium.webdriver.common.keys import Keys
+
+from modules.page_object import GenericPdf
+
+PDF_FILE_NAME = "i-9.pdf"
+
+
+@pytest.fixture()
+def test_case():
+    return "1938263"
+
+
+@pytest.fixture()
+def hard_quit():
+    return True
+
+
+@pytest.fixture()
+def file_name():
+    return PDF_FILE_NAME
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    return [("pdfjs.annotationEditorMode", 0)]
+
+
+def test_pdf_drawing_can_be_copied_cut_and_pasted_with_keyboard(
+    pdf_viewer: GenericPdf,
+):
+    """C1938263: Copy, cut, and paste a PDF drawing with keyboard shortcuts."""
+    pdf_viewer.element_visible("toolbar-draw")
+    pdf_viewer.select_editor_tool("toolbar-draw")
+    pdf_viewer.draw_on_pdf_page()
+
+    pdf_viewer.select_drawing_area()
+    pdf_viewer.perform_key_combo(Keys.CONTROL, "c")
+    pdf_viewer.perform_key_combo(Keys.CONTROL, "v")
+    pdf_viewer.wait_for_drawing_area_count(2)
+
+    pdf_viewer.perform_key_combo(Keys.CONTROL, "x")
+    pdf_viewer.wait_for_drawing_area_count(1)
+
+    pdf_viewer.perform_key_combo(Keys.CONTROL, "v")
+    pdf_viewer.wait_for_drawing_area_count(2)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2009710](https://bugzilla.mozilla.org/show_bug.cgi?id=2009710)
TestRail: [1938263](https://mozilla.testrail.io/index.php?/cases/view/1938263)

### Description of Code / Doc Changes

Added PDF drawing copy, cut, and paste keyboard-shortcut coverage.
Added drawing-area count verification.
Added the required PDF selector.

### Process Changes Required

- [ ] Changes or creates a BOM/POM (name the object model): GenericPdf

Thank you!
