### PR TITLE
Akash/ Add test_default_search_engine_dropdown

### DIFF
--- a/manifests/key.yaml
+++ b/manifests/key.yaml
@@ -1341,6 +1341,10 @@ preferences:
       win: unstable
     splits:
     - smoke
+  test_default_search_engine_dropdown:
+    result: pass
+    splits:
+    - functional1
   test_firefox_home_new_tabs:
     comment: https://bugzilla.mozilla.org/show_bug.cgi?id=2052847
     result: unstable

--- a/modules/data/about_prefs.components.json
+++ b/modules/data/about_prefs.components.json
@@ -129,6 +129,17 @@
       "location": "about:preferences#search"
     }
   },
+  "search-shortcuts-enabled-engine": {
+    "selectorData": "#engineList moz-box-item:has(moz-toggle[pressed])",
+    "strategy": "css",
+    "groups": [
+      "doNotCache"
+    ],
+    "comment": {
+      "description": "An enabled engine row in the Search shortcuts list (Settings redesign)",
+      "location": "about:preferences#search"
+    }
+  },
   "find-in-settings": {
     "selectorData": "searchInput",
     "strategy": "id",

--- a/modules/page_object_prefs.py
+++ b/modules/page_object_prefs.py
@@ -134,6 +134,38 @@ class AboutPrefs(BasePage):
         button = self.wait.until(lambda _: self.get_element("select-wrapper-button"))
         return button.text
 
+    def get_default_engine_dropdown_options(self) -> list[str]:
+        """Open the Default search engine dropdown, return option labels, close it.
+
+        In the Settings redesign the dropdown is a moz-select whose options are
+        panel-items inside its shadow root, so they can only be reached through
+        the shadow DOM.
+        """
+        root = self.get_element("search-engine-dropdown-root")
+        root.click()
+        # Get the option list out of the moz-select shadow root.
+        panel = self.wait.until(
+            lambda _: self.driver.execute_script(
+                "return arguments[0].shadowRoot.querySelector('panel-list')", root
+            )
+        )
+        options = [
+            option.get_attribute("textContent").strip()
+            for option in panel.find_elements(By.TAG_NAME, "panel-item")
+            if option.is_displayed()
+        ]
+        self.actions.send_keys(Keys.ESCAPE).perform()
+        return options
+
+    def get_enabled_search_engines(self) -> list[str]:
+        """Return the names of the enabled engines in the Search shortcuts list."""
+        return [
+            engine.get_attribute("label")
+            for engine in self.get_element(
+                "search-shortcuts-enabled-engine", multiple=True
+            )
+        ]
+
     def find_in_settings(self, term: str) -> BasePage:
         """Search via the Find in Settings bar, return self."""
         search_input = self.get_element("find-in-settings-input")

--- a/tests/preferences/test_default_search_engine_dropdown.py
+++ b/tests/preferences/test_default_search_engine_dropdown.py
@@ -29,10 +29,12 @@ def test_default_search_engine_dropdown(
     """
     C4105787 - The Default search engine drop-down works as expected.
     """
+    # Step 1: Open about:preferences#search.
     about_prefs.open()
 
     # Step 2: Every enabled engine from Search shortcuts is offered in the dropdown.
     enabled_engines = about_prefs.get_enabled_search_engines()
+    assert enabled_engines, "No enabled engines found in the Search shortcuts list"
     options = about_prefs.get_default_engine_dropdown_options()
     assert set(enabled_engines) == set(options), (
         f"Dropdown shows {options}, expected the enabled engines {enabled_engines}"

--- a/tests/preferences/test_default_search_engine_dropdown.py
+++ b/tests/preferences/test_default_search_engine_dropdown.py
@@ -1,0 +1,47 @@
+import pytest
+from selenium.webdriver import Firefox
+
+from modules.browser_object import Navigation, TabBar
+from modules.page_object import AboutPrefs
+
+NEW_ENGINE = "DuckDuckGo"
+
+
+@pytest.fixture()
+def about_prefs_category():
+    return "search"
+
+
+@pytest.fixture()
+def test_case():
+    return "4105787"
+
+
+@pytest.fixture()
+def add_to_prefs_list():
+    """Add to list of prefs to set"""
+    return [("browser.settings-redesign.enabled", True)]
+
+
+def test_default_search_engine_dropdown(
+    driver: Firefox, about_prefs: AboutPrefs, nav: Navigation, tabs: TabBar
+):
+    """
+    C4105787 - The Default search engine drop-down works as expected.
+    """
+    about_prefs.open()
+
+    # Step 2: Every enabled engine from Search shortcuts is offered in the dropdown.
+    enabled_engines = about_prefs.get_enabled_search_engines()
+    options = about_prefs.get_default_engine_dropdown_options()
+    assert set(enabled_engines) == set(options), (
+        f"Dropdown shows {options}, expected the enabled engines {enabled_engines}"
+    )
+
+    # Step 3: Pick a different default and confirm the search pane agrees.
+    about_prefs.search_engine_dropdown().select_option(NEW_ENGINE)
+    about_prefs.wait_for_default_search_engine(NEW_ENGINE)
+
+    # The unified search button names the new default in its l10n args.
+    tabs.new_tab_by_button()
+    nav.element_attribute_contains("searchmode-switcher", "data-l10n-args", NEW_ENGINE)


### PR DESCRIPTION
### Relevant Links

Bugzilla: [2046693](https://bugzilla.mozilla.org/show_bug.cgi?id=2046693)
TestRail: [4105787](https://mozilla.testrail.io/index.php?/cases/view/4105787)

### Description of Code / Doc Changes

- Adds `tests/preferences/test_default_search_engine_dropdown.py`, covering C4105787.
- Adds `get_enabled_search_engines()` and `get_default_engine_dropdown_options()` to `AboutPrefs`.
- Adds the `search-shortcuts-enabled-engine` component for the enabled rows in the Search shortcuts list.
- Registers the test in `manifests/key.yaml`.

### Process Changes Required

- [x] Changes or creates a BOM/POM (name the object model): AboutPrefs

### Screenshots or Explanations

Outside of search mode the unified search button shows only an icon, no visible text. The engine name lives in its `data-l10n-args` attribute, so that is what the last step asserts on.

### Comments or Future Work

None

### Workflow Checklist

- [x] Reviewers have been requested.
- [x] Code has been linted and formatted.
- [ ] If this is an unblocker, a message has been posted to #dte-automation in Slack.

Thank you!